### PR TITLE
v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-army-world",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "dependencies": {
     "@babel/core": "7.2.2",

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -7,6 +7,7 @@ import { distanceInWords } from 'date-fns'
 import { IMapPin, IMapPinDetail } from 'src/models/maps.models'
 
 import './popup.css'
+import { Link } from 'src/components/Links'
 
 interface IProps {
   pinDetail?: IMapPin | IMapPinDetail
@@ -118,7 +119,9 @@ export class Popup extends React.Component<IProps> {
         <HeroImage src={heroImageUrl} />
         <ProfileImage src={profilePicUrl} />
         <ContentWrapper>
-          <ComradeName>{name}</ComradeName>
+          <Link to={'u/' + name}>
+            <ComradeName>{name}</ComradeName>
+          </Link>
           <PinTypeWrapper>
             <PinTypeDot type={pinType.grouping}>{pinType.icon}</PinTypeDot>
             <PinTypeName>{pinType.displayName}</PinTypeName>

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -8,6 +8,7 @@ import { IMapPin, IMapPinDetail } from 'src/models/maps.models'
 
 import './popup.css'
 import { Link } from 'src/components/Links'
+import Text from 'src/components/Text'
 
 interface IProps {
   pinDetail?: IMapPin | IMapPinDetail
@@ -17,10 +18,11 @@ interface IProps {
 const HeroImage = styled.img`
   width: 285px;
   height: 175px;
+  object-fit: cover;
 `
 
 const ProfileImage = styled.img`
-  width 50px;
+  width: 50px;
   height: 50px;
   border-radius: 50%;
   margin-top: -25px;
@@ -126,7 +128,7 @@ export class Popup extends React.Component<IProps> {
             <PinTypeDot type={pinType.grouping}>{pinType.icon}</PinTypeDot>
             <PinTypeName>{pinType.displayName}</PinTypeName>
           </PinTypeWrapper>
-          <Description>{shortDescription}</Description>
+          <Text clipped>{shortDescription}</Text>
           <LastOnline>
             last active {distanceInWords(lastActive, new Date())} ago
           </LastOnline>

--- a/src/pages/PageList.tsx
+++ b/src/pages/PageList.tsx
@@ -70,7 +70,7 @@ const admin = {
 
 // community pages (various pages hidden on production build)
 const devCommunityPages = [howTo, events, maps]
-const prodCommunityPages = [howTo, events]
+const prodCommunityPages = [howTo, events, maps]
 const communityPages =
   SITE === 'production' ? prodCommunityPages : devCommunityPages
 // community 'more' dropdown pages (various pages hidden on production build)


### PR DESCRIPTION
Small improvements of map user popup display:
* fix cover image height
* clip the user description
* add `Link` from user popup to user profile page `/u/<username>`

Display map in menu in production.