### PR TITLE
557 events filtering by tags

### DIFF
--- a/src/pages/Events/Content/EventsList/EventsList.tsx
+++ b/src/pages/Events/Content/EventsList/EventsList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { IEvent } from 'src/models/events.models'
 import { Button } from 'src/components/Button'
 import { Link } from 'src/components/Links'
-import { Flex, Link as ExternalLink } from 'rebass'
+import { Flex, Link as ExternalLink, Box } from 'rebass'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import Text from 'src/components/Text'
 import styled from 'styled-components'
@@ -10,18 +10,26 @@ import { colors } from 'src/themes/styled.theme'
 import Icon from 'src/components/Icons'
 import { TagDisplay } from 'src/components/Tags/TagDisplay/TagDisplay'
 import Heading from 'src/components/Heading'
+import TagsSelect from 'src/components/Tags/TagsSelect'
+import { inject, observer } from 'mobx-react'
+import { EventStore } from 'src/stores/Events/events.store'
 
-interface IProps {
-  upcomingEvents: IEvent[]
+interface InjectedProps {
+  eventStore?: EventStore
 }
 
 const RowContainer = styled(Flex)`
   border-bottom: 1px solid ${colors.grey4};
 `
-
-export class EventsList extends React.Component<IProps> {
+@inject('eventStore')
+@observer
+export class EventsList extends React.Component<any> {
   constructor(props: any) {
     super(props)
+  }
+
+  get injected() {
+    return this.props as InjectedProps
   }
 
   public getMonth(d: Date) {
@@ -33,83 +41,107 @@ export class EventsList extends React.Component<IProps> {
   }
 
   public render() {
-    const { upcomingEvents } = this.props
-    return (
-      <>
-        <Flex justifyContent={'right'}>
-          <AuthWrapper>
-            <Link to={'/events/create'}>
-              <Button variant="outline" icon={'add'}>
-                create
-              </Button>
-            </Link>
-          </AuthWrapper>
-        </Flex>
-        <React.Fragment>
-          <>
-            {upcomingEvents.length === 0 ? null : ( // *** TODO - indicate whether no upcoming events or data still just loading
-              <Flex
-                bg={'white'}
-                className="list-container"
-                flexWrap={'wrap'}
-                mt={4}
-                px={4}
-              >
-                {upcomingEvents.map((event: IEvent) => (
-                  <RowContainer width={1} py={4} key={event._id}>
-                    <Flex flexWrap={'wrap'} flex={'1'}>
-                      <Text large bold width={1}>
-                        {this.getMonth(new Date(event.date))}
-                      </Text>
-                      <Heading small bold width={1}>
-                        {this.getDay(new Date(event.date))}
-                      </Heading>
-                    </Flex>
-                    <Flex flexWrap={'wrap'} flex={'3'}>
-                      <Text large width={1}>
-                        {event.title}
-                      </Text>
-                      <Text py={2} small width={1}>
-                        by{' '}
-                        <Text inline bold>
-                          {' '}
-                          {event._createdBy}
+    const { filteredEvents } = this.props.eventStore
+    if (filteredEvents) {
+      return (
+        <>
+          <Flex flexWrap={'nowrap'} justifyContent={'space-between'}>
+            <Box width={[1, 1, 0.2]}>
+              <TagsSelect
+                onChange={tags =>
+                  this.props.eventStore.updateSelectedTags(tags)
+                }
+                category="event"
+              />
+            </Box>
+            <AuthWrapper>
+              <Link to={'/events/create'}>
+                <Button variant="outline" icon={'add'}>
+                  create
+                </Button>
+              </Link>
+            </AuthWrapper>
+          </Flex>
+          <React.Fragment>
+            <>
+              {filteredEvents.length === 0 ? null : ( // *** TODO - indicate whether no upcoming events or data still just loading
+                <Flex
+                  bg={'white'}
+                  className="list-container"
+                  flexWrap={'wrap'}
+                  mt={4}
+                  px={4}
+                >
+                  {filteredEvents.map((event: IEvent) => (
+                    <RowContainer width={1} py={4} key={event._id}>
+                      <Flex flexWrap={'wrap'} flex={'1'}>
+                        <Text large bold width={1}>
+                          {this.getMonth(new Date(event.date))}
                         </Text>
-                      </Text>
-                    </Flex>
-                    <Flex flexWrap={'nowrap'} alignItems={'center'} flex={'2'}>
-                      <Icon glyph={'location-on'} />
-                      <Text large width={1} ml={2}>
-                        {event.location.name},{' '}
-                        <Text caps inline>
-                          {event.location.countryCode}
+                        <Heading small bold width={1}>
+                          {this.getDay(new Date(event.date))}
+                        </Heading>
+                      </Flex>
+                      <Flex flexWrap={'wrap'} flex={'3'}>
+                        <Text large width={1}>
+                          {event.title}
                         </Text>
-                      </Text>
-                    </Flex>
-                    <Flex flexWrap={'nowrap'} alignItems={'center'} flex={'2'}>
-                      {event.tags &&
-                        Object.keys(event.tags).map(tag => {
-                          return <TagDisplay key={tag} tagKey={tag} />
-                        })}
-                    </Flex>
-                    <Flex flexWrap={'nowrap'} alignItems={'center'} flex={'1'}>
-                      <ExternalLink
-                        target="_blank"
-                        href={event.url}
-                        color={'black'}
-                        mr={1}
+                        <Text py={2} small width={1}>
+                          by{' '}
+                          <Text inline bold>
+                            {' '}
+                            {event._createdBy}
+                          </Text>
+                        </Text>
+                      </Flex>
+                      <Flex
+                        flexWrap={'nowrap'}
+                        alignItems={'center'}
+                        flex={'2'}
                       >
-                        <Text small>Go to Event Page</Text>
-                      </ExternalLink>
-                      <Icon glyph={'external-link'} />
-                    </Flex>
-                  </RowContainer>
-                ))}
-              </Flex>
-            )}
-          </>
-        </React.Fragment>
-      </>
-    )
+                        <Icon glyph={'location-on'} />
+                        <Text large width={1} ml={2}>
+                          {event.location.name},{' '}
+                          <Text caps inline>
+                            {event.location.countryCode}
+                          </Text>
+                        </Text>
+                      </Flex>
+                      <Flex
+                        flexWrap={'nowrap'}
+                        alignItems={'center'}
+                        flex={'2'}
+                      >
+                        {event.tags &&
+                          Object.keys(event.tags).map(tag => {
+                            return <TagDisplay key={tag} tagKey={tag} />
+                          })}
+                      </Flex>
+                      <Flex
+                        flexWrap={'nowrap'}
+                        alignItems={'center'}
+                        flex={'1'}
+                      >
+                        <ExternalLink
+                          target="_blank"
+                          href={event.url}
+                          color={'black'}
+                          mr={1}
+                        >
+                          <Text small>Go to Event Page</Text>
+                        </ExternalLink>
+                        <Icon glyph={'external-link'} />
+                      </Flex>
+                    </RowContainer>
+                  ))}
+                </Flex>
+              )}
+            </>
+          </React.Fragment>
+        </>
+      )
+    } else {
+      return <div>Events not found</div>
+    }
   }
 }

--- a/src/pages/Events/Events.tsx
+++ b/src/pages/Events/Events.tsx
@@ -20,7 +20,6 @@ class EventsPageClass extends React.Component<IProps, any> {
   }
 
   public render() {
-    const upcomingEvents = this.props.eventStore!.upcomingEvents
     const pastEvents = this.props.eventStore!.pastEvents
     return (
       <div id="EventsPage">
@@ -28,9 +27,7 @@ class EventsPageClass extends React.Component<IProps, any> {
           <Route
             exact
             path="/events"
-            render={props => (
-              <EventsList {...props} upcomingEvents={upcomingEvents} />
-            )}
+            render={props => <EventsList {...props} />}
           />
           <AuthRoute
             path="/events/create"

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -17,7 +17,6 @@ import { Button } from 'src/components/Button'
 import { IHowto } from 'src/models/howto.models'
 import { TagDisplay } from 'src/components/Tags/TagDisplay/TagDisplay'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
-import { ISelectedTags } from 'src/models/tags.model'
 
 interface InjectedProps {
   howtoStore?: HowtoStore

--- a/src/stores/Events/events.store.tsx
+++ b/src/stores/Events/events.store.tsx
@@ -9,7 +9,7 @@ import { RootStore } from '..'
 export class EventStore extends ModuleStore {
   // observables are data variables that can be subscribed to and change over time
   @observable
-  public allEvents: IEvent[]
+  public allEvents: IEvent[] = []
   @observable
   public activeEvent: IEvent | undefined
   @observable

--- a/src/stores/Events/events.store.tsx
+++ b/src/stores/Events/events.store.tsx
@@ -3,6 +3,7 @@ import { IEvent, IEventFormInput } from 'src/models/events.models'
 import { ModuleStore } from '../common/module.store'
 import { Database } from '../database'
 import Filters from 'src/utils/filters'
+import { ISelectedTags } from 'src/models/tags.model'
 import { RootStore } from '..'
 
 export class EventStore extends ModuleStore {
@@ -11,6 +12,8 @@ export class EventStore extends ModuleStore {
   public allEvents: IEvent[]
   @observable
   public activeEvent: IEvent | undefined
+  @observable
+  public selectedTags: ISelectedTags
   @observable
   public eventViewType: 'map' | 'list'
   @computed get upcomingEvents() {
@@ -25,11 +28,19 @@ export class EventStore extends ModuleStore {
     })
   }
 
+  @computed get filteredEvents() {
+    return this.filteredCollectionByTags(this.upcomingEvents, this.selectedTags)
+  }
+
   constructor(rootStore: RootStore) {
     super('v2_events')
     this.allDocs$.subscribe((docs: IEvent[]) => {
       this.allEvents = docs.sort((a, b) => (a.date > b.date ? 1 : -1))
     })
+    this.selectedTags = {}
+  }
+  public updateSelectedTags(tagKey: ISelectedTags) {
+    this.selectedTags = tagKey
   }
 
   public async uploadEvent(values: IEventFormInput, id: string) {

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -54,13 +54,7 @@ export class HowtoStore extends ModuleStore {
   }
 
   @computed get filteredHowtos() {
-    const selectedTagsArr = Object.keys(this.selectedTags)
-    return selectedTagsArr.length > 0
-      ? this.allHowtos.filter(howto => {
-          const tags = howto.tags ? Object.keys(howto.tags) : null
-          return tags ? includesAll(selectedTagsArr, tags) : false
-        })
-      : this.allHowtos
+    return this.filteredCollectionByTags(this.allHowtos, this.selectedTags)
   }
 
   public updateSelectedTags(tagKey: ISelectedTags) {

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -84,7 +84,7 @@ export class ModuleStore {
    * **************************************************************************/
 
   public filteredCollectionByTags(
-    collection: any[],
+    collection: any[] = [],
     selectedTags: ISelectedTags,
   ) {
     const selectedTagsArr = Object.keys(selectedTags)

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -2,8 +2,9 @@ import { BehaviorSubject, Subscription } from 'rxjs'
 import { Database } from '../database'
 import { stripSpecialCharacters } from 'src/utils/helpers'
 import isUrl from 'is-url'
-import { TagCategory } from 'src/models/tags.model'
+import { ISelectedTags } from 'src/models/tags.model'
 import { IDBEndpoint } from 'src/models/common.models'
+import { includesAll } from 'src/utils/filters'
 
 /*  The module store contains common methods used across modules that access specfic
     collections on the database
@@ -77,5 +78,21 @@ export class ModuleStore {
 
   public validateUrl = async (value: any) => {
     return value ? (isUrl(value) ? undefined : 'Invalid url') : 'Required'
+  }
+  /****************************************************************************
+   *            Filtering Methods
+   * **************************************************************************/
+
+  public filteredCollectionByTags(
+    collection: any[],
+    selectedTags: ISelectedTags,
+  ) {
+    const selectedTagsArr = Object.keys(selectedTags)
+    return selectedTagsArr.length > 0
+      ? collection.filter(obj => {
+          const tags = obj.tags ? Object.keys(obj.tags) : null
+          return tags ? includesAll(selectedTagsArr, tags) : false
+        })
+      : collection
   }
 }


### PR DESCRIPTION
#### Allow filtering by tags on event list.
* Rename the method `filteredHowto` in howto.store to `filteredCollectionByTags` and moved to the module.store to allow event.store to access it.
* Add the `SelectTags` component in event list
* Base the event list render() on `filteredEvents` value instead of `upcomingEvents`
Closes #557 