### PR TITLE
add profile delete methods and ui

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components'
 
 interface IProps {
   // provide onDidDismiss function to enable backdrop click dismiss
-  onDidDismiss?: () => void
+  onDidDismiss: (data?: any) => void
+  height?: number
 }
 interface IState {
   isOpen: boolean
@@ -27,7 +28,6 @@ const ModalContent = styled.div`
   justify-content: space-between;
   width: 300px;
   max-width: 100%;
-  height: 200px;
   max-height: 100%;
   position: fixed;
   z-index: 10;
@@ -51,13 +51,19 @@ export class Modal extends React.Component<IProps, IState> {
 
   render() {
     const isOpen = this.state
+    const { height, children } = this.props
     return (
       isOpen && (
         <Portal id="portal">
           <ModalBackdrop id="ModalBackdrop" onClick={() => this.dismiss()} />
-          <ModalContent id="ModalContent">{this.props.children}</ModalContent>
+          <ModalContent id="ModalContent" style={height ? { height } : {}}>
+            {children}
+          </ModalContent>
         </Portal>
       )
     )
+  }
+  static defaultProps: IProps = {
+    onDidDismiss: () => null,
   }
 }

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { Flex } from 'rebass'
 import { Avatar } from 'src/components/Avatar'
 import Text from 'src/components/Text'
 import { UserMapPinEdit } from './content/UserMapPinEdit'
+import { ProfileDelete } from './content/ProfileDelete'
 
 interface IProps {
   user: IUser
@@ -23,6 +24,7 @@ interface IState {
   editMode: boolean
   user: IUser
   showNotification: boolean
+  showDeleteDialog?: boolean
 }
 export class UserSettings extends React.Component<IProps, IState> {
   constructor(props: IProps) {
@@ -32,6 +34,10 @@ export class UserSettings extends React.Component<IProps, IState> {
 
   public showSaveNotification() {
     this.setState({ showNotification: true })
+  }
+
+  public deleteProfile(reauthPw: string) {
+    this.props.userStore.deleteUser(reauthPw)
   }
 
   public render() {
@@ -93,6 +99,9 @@ export class UserSettings extends React.Component<IProps, IState> {
             />
           </div>
         </BoxContainer>
+        <ProfileDelete
+          onConfirmation={reauthPw => this.deleteProfile(reauthPw)}
+        />
       </FlexContainer>
     )
   }

--- a/src/pages/Settings/content/ProfileDelete.tsx
+++ b/src/pages/Settings/content/ProfileDelete.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import { Modal } from 'src/components/Modal/Modal'
+import { Button } from 'src/components/Button'
+import Text from 'src/components/Text'
+import { FlexContainer } from 'src/components/Layout/FlexContainer'
+import { Form, Field } from 'react-final-form'
+import { InputField } from 'src/components/Form/Fields'
+
+interface IState {
+  showDeleteDialog: boolean
+}
+interface IProps {
+  onConfirmation: (reauthPw: string) => void
+}
+export class ProfileDelete extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props)
+    this.state = {
+      showDeleteDialog: false,
+    }
+  }
+  onModalDismiss(values: any) {
+    const reauthPw = values.password
+    this.setState({ showDeleteDialog: false })
+    if (reauthPw) {
+      this.props.onConfirmation(reauthPw)
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <Button
+          icon="delete"
+          variant="light"
+          mt={3}
+          onClick={() => this.setState({ showDeleteDialog: true })}
+        >
+          Delete Profile
+        </Button>
+        {this.state.showDeleteDialog && (
+          <Modal onDidDismiss={confirm => this.onModalDismiss(confirm)}>
+            <Text>Confirm your password to delete your account</Text>
+            <Form
+              onSubmit={values => this.onModalDismiss(values)}
+              render={({ values, handleSubmit }) => {
+                return (
+                  <form onSubmit={handleSubmit}>
+                    <Field
+                      name="password"
+                      component={InputField}
+                      type="password"
+                    />
+                    <FlexContainer p={0}>
+                      <Button
+                        style={{ marginLeft: 'auto' }}
+                        onClick={() => this.onModalDismiss({})}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="submit"
+                        variant={values.password ? 'light' : 'disabled'}
+                        disabled={values.password ? false : true}
+                      >
+                        Delete
+                      </Button>
+                    </FlexContainer>
+                  </form>
+                )
+              }}
+            />
+          </Modal>
+        )}
+      </>
+    )
+  }
+
+  static defaultProps: IProps = {
+    onConfirmation: () => null,
+  }
+}

--- a/src/pages/common/Login/SignUp.form.tsx
+++ b/src/pages/common/Login/SignUp.form.tsx
@@ -70,7 +70,7 @@ export class SignUpForm extends React.Component<IProps, IState> {
 
   public async checkUserNameUnique(userName: string) {
     const user = await this.props.userStore.getUserProfile(userName)
-    return user ? false : true
+    return user && !user._deleted ? false : true
   }
 
   public render = () => {

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -131,6 +131,26 @@ export class UserStore {
     return auth.signOut()
   }
 
+  public async deleteUser(reauthPw: string) {
+    // as delete operation is sensitive requires user to revalidate credentials first
+    const authUser = auth.currentUser as firebase.User
+    const credential = EmailAuthProvider.credential(
+      authUser.email as string,
+      reauthPw,
+    )
+    try {
+      await authUser.reauthenticateAndRetrieveDataWithCredential(credential)
+      const user = this.user as IUser
+      await Database.deleteDoc(`v2_users/${user.userName}`)
+      await authUser.delete()
+      // TODO - delete user avatar
+      // TODO - show deleted notification
+    } catch (error) {
+      // TODO show notification if invalid credential
+      throw error
+    }
+  }
+
   private async _createUserProfile(userName: string) {
     const authUser = auth.currentUser as firebase.User
     const user: IUser = {
@@ -139,7 +159,7 @@ export class UserStore {
       userName,
       verified: false,
     }
-    await Database.setDoc(`v2_users${userName}`, user)
+    await Database.setDoc(`v2_users/${userName}`, user)
     this.updateUser(user)
   }
 


### PR DESCRIPTION
**Overview**
Create a button on the user profile page that allows a user to delete their profile
![image](https://user-images.githubusercontent.com/10515065/64687049-a96eee80-d481-11e9-9867-bb3a71fb96c8.png)

Includes a prompt for user to confirm their password before delete
![image](https://user-images.githubusercontent.com/10515065/64687067-b68bdd80-d481-11e9-8aab-c866982248e2.png)
This is mainly because firebase requires reauth for sensitive actions, however probably a good safeguard to ensure a user can't easily be deleted if using a shared computer and forgetting to log out

On click the user is removed from the auth database and profile marked as deleted in the database (with all personal information removed)

**Todo**
- delete user avatar if uploaded
- decide how to handle content attributed to them (e.g. how-tos). Currently all content remains, which is probably preferable
- show notification on successful delete (some sort of toast most likely)
- show notification on error (e.g. incorrect pw provided for revalidation
- handle display of a user profile page that has been deleted (user profile still exists, but only with fields `_deleted:true`