### PR TITLE
#437 add text & heading component to storybook 

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,26 +1,24 @@
-const path = require('path')
-
-module.exports = {
-  module: {
-    rules: [
+module.exports = ({
+  config
+}) => {
+  config.module.rules.push({
+    test: /\.(ts|tsx)$/,
+    use: [{
+        loader: require.resolve('babel-loader'),
+        options: {
+          presets: [
+            ['react-app', {
+              flow: false,
+              typescript: true
+            }]
+          ],
+        },
+      },
       {
-        test: /\.(ts|tsx)$/,
-        //include: path.resolve(__dirname, '../src'),
-        use: [
-          {
-            loader: require.resolve('babel-loader'),
-            options: {
-              presets: [['react-app', { flow: false, typescript: true }]],
-            },
-          },
-          {
-            loader: require.resolve('react-docgen-typescript-loader'),
-          },
-        ],
+        loader: require.resolve('react-docgen-typescript-loader'),
       },
     ],
-  },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx'],
-  },
-}
+  });
+  config.resolve.extensions.push('.ts', '.tsx', '.js', '.jsx');
+  return config;
+};

--- a/src/components/Heading/heading.stories.tsx
+++ b/src/components/Heading/heading.stories.tsx
@@ -23,16 +23,28 @@ stories.addParameters({
 })
 
 stories.add('default Heading', () => (
+  <Heading>
+    {text(
+      'text',
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit architecto ad inventore animi consequatur deserunt eaque eos excepturi, aliquam iusto placeat quam numquam debitis vel eligendi? A earum voluptates vel!',
+    )}
+  </Heading>
+))
+
+stories.add('playground Heading', () => (
   <Heading
     {...knobsFactory({
-      theme,
       large: true,
       medium: false,
       small: false,
       clipped: false,
       color: 'black',
+      theme,
     })}
   >
-    {text('text', 'Lorem ipsum dolor sit.')}
+    {text(
+      'text',
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Odit architecto ad inventore animi consequatur deserunt eaque eos excepturi, aliquam iusto placeat quam numquam debitis vel eligendi? A earum voluptates vel!',
+    )}
   </Heading>
 ))

--- a/src/components/Heading/heading.stories.tsx
+++ b/src/components/Heading/heading.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, boolean, number, color } from '@storybook/addon-knobs'
+
+import theme from 'src/themes/styled.theme'
+import { knobsFactory } from 'src/utils/knobs'
+
+import Heading from './'
+
+import { withInfo } from '@storybook/addon-info'
+
+const stories = storiesOf('UI/Heading', module)
+
+stories.addDecorator(withKnobs)
+
+stories.addDecorator(withInfo)
+stories.addParameters({
+  info: {
+    inline: true,
+    source: true,
+  },
+})
+
+stories.add('default Heading', () => (
+  <Heading
+    {...knobsFactory({
+      theme,
+      large: true,
+      medium: false,
+      small: false,
+      clipped: false,
+      color: 'black',
+    })}
+  >
+    {text('text', 'Lorem ipsum dolor sit.')}
+  </Heading>
+))

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -5,7 +5,7 @@ import Text, { ITextProps } from 'src/components/Text'
 import { HeadingProps as RebassHeadingProps } from 'rebass'
 
 export const large = (props: ITextProps) =>
-  props.medium ? { fontSize: theme.fontSizes[6] } : null
+  props.large ? { fontSize: theme.fontSizes[6] } : null
 export const medium = (props: ITextProps) =>
   props.medium ? { fontSize: theme.fontSizes[5] } : null
 export const small = (props: ITextProps) =>

--- a/src/components/Text/text.stories.tsx
+++ b/src/components/Text/text.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, boolean, number, color } from '@storybook/addon-knobs'
+
+import { knobsFactory } from 'src/utils/knobs'
+
+import Text from './'
+
+import { withInfo } from '@storybook/addon-info'
+
+const stories = storiesOf('UI/Text', module)
+
+const defaultProps = {
+  uppercase: false,
+  regular: false,
+  txtcenter: false,
+  capitalize: false,
+  bold: false,
+  large: false,
+  medium: false,
+  small: false,
+  superSmall: false,
+  clipped: false,
+  preLine: false,
+  tags: false,
+  auxiliary: false,
+  paragraph: false,
+  fontSize: 4,
+}
+
+const sortedProps = Object.keys(defaultProps)
+  .sort()
+  .reduce((acc, current) => {
+    return { ...acc, [current]: defaultProps[current] }
+  }, {})
+
+stories.addDecorator(withKnobs)
+
+stories.addDecorator(withInfo)
+stories.addParameters({
+  info: {
+    inline: true,
+    source: true,
+  },
+})
+
+stories.add('default Text', () => (
+  <Text {...knobsFactory({})}>{text('text', 'Change me')}</Text>
+))
+
+stories.add('Text as Label', () => (
+  <div>
+    <Text
+      {...knobsFactory({
+        as: 'label',
+      })}
+      htmlFor="awesome_input"
+    >
+      {text('Label', 'Awesome label: ')}
+    </Text>
+    <input type="text" name="awesome_input" id="awesome_input" />
+  </div>
+))
+
+stories.add('playground Text', () => (
+  <Text {...knobsFactory(sortedProps)}>
+    {text('text', 'Lorem ipsum dolor sit.')}
+  </Text>
+))

--- a/src/utils/knobs.ts
+++ b/src/utils/knobs.ts
@@ -1,4 +1,4 @@
-import { withKnobs, text, boolean, number, color } from '@storybook/addon-knobs'
+import { array, text, boolean, number, color } from '@storybook/addon-knobs'
 
 const isColor = (strColor: string): boolean => {
   const style = new Option().style
@@ -8,31 +8,38 @@ const isColor = (strColor: string): boolean => {
   return test1 === true || test2 === true
 }
 
-export const knobsFactory = (element, name = 'props') => {
+export const knobsFactory = (
+  element: any,
+  name: string = 'props',
+  parent: string = '',
+) => {
   if (Array.isArray(element)) {
-    return element
+    return array(name, element, ', ')
   }
 
   if (typeof element === 'string') {
     if (isColor(element)) {
-      return color(name, element)
+      return color(name, element, parent)
     }
-    return text(name, element)
+    return text(name, element, parent)
   }
 
   if (typeof element === 'number') {
-    return number(name, element)
+    return number(name, element, {}, parent)
   }
 
   if (typeof element === 'boolean') {
-    return boolean(name, element)
+    return boolean(name, element, parent)
   }
 
   const keys = Object.keys(element)
 
   if (keys.length > 0) {
     return keys.reduce((accum, current) => {
-      return { ...accum, [current]: knobsFactory(element[current], current) }
+      return {
+        ...accum,
+        [current]: knobsFactory(element[current], current, name),
+      }
     }, {})
   }
 

--- a/src/utils/knobs.ts
+++ b/src/utils/knobs.ts
@@ -1,0 +1,40 @@
+import { withKnobs, text, boolean, number, color } from '@storybook/addon-knobs'
+
+const isColor = (strColor: string): boolean => {
+  const style = new Option().style
+  style.color = strColor
+  const test1 = style.color === strColor
+  const test2 = /^#[0-9A-F]{6}$/i.test(strColor)
+  return test1 === true || test2 === true
+}
+
+export const knobsFactory = (element, name = 'props') => {
+  if (Array.isArray(element)) {
+    return element
+  }
+
+  if (typeof element === 'string') {
+    if (isColor(element)) {
+      return color(name, element)
+    }
+    return text(name, element)
+  }
+
+  if (typeof element === 'number') {
+    return number(name, element)
+  }
+
+  if (typeof element === 'boolean') {
+    return boolean(name, element)
+  }
+
+  const keys = Object.keys(element)
+
+  if (keys.length > 0) {
+    return keys.reduce((accum, current) => {
+      return { ...accum, [current]: knobsFactory(element[current], current) }
+    }, {})
+  }
+
+  return element
+}


### PR DESCRIPTION
## objectives
✅ Add Text component to storybook
✅ Add Heading component to storybook

## Other things

* Was fixed an issue to start storybook, do not necesary upgrade storybook, just adapt the `webpack.config`

* Was fixed something  related with the definition of `fontSize` using a prop (medium, small, large) that I think was a typo in heading component (but I not sure if that was something intentional in any case it can be reversed)

* I made a factory to handle the Knops using a default props objects (let me know if is useful or not)

## Demo

![storybook](https://user-images.githubusercontent.com/5114020/66252217-1139f180-e72f-11e9-81ab-9ae5e8b084aa.gif)

