### PR TITLE
extend timeout and add base route to all tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
   "defaultCommandTimeout_comment": "Increase to 15s to make sure a page is completely loaded.",
-  "defaultCommandTimeout": 15000,
+  "defaultCommandTimeout": 30000,
   "watchForFileChanges": true,
   "chromeWebSecurity": false,
   "video_comment": "Disable video records to improve test execution as it's not worth",

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -68,3 +68,7 @@ const attachCustomCommands = (
 }
 
 attachCustomCommands(Cypress, firebase)
+// ensure the platform is loaded before starting any tests
+beforeEach(() => {
+  cy.visit('/', { timeout: 300000 })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -68,7 +68,3 @@ const attachCustomCommands = (
 }
 
 attachCustomCommands(Cypress, firebase)
-// ensure the platform is loaded before starting any tests
-beforeEach(() => {
-  cy.visit('/', { timeout: 300000 })
-})


### PR DESCRIPTION
Should hopefully fix issue of first test fail. On local machine all tests now appear to pass when localhost is slow to load the platform.