### PR TITLE
Nit/test rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - echo "REACT_APP_BRANCH=$REACT_APP_BRANCH"
 script:
   - yarn test
-  - yarn cy:run
+  - yarn cy:test
   - npm run build
 
 # install firebase cli and set firebase project ci token from environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - echo "REACT_APP_BRANCH=$REACT_APP_BRANCH"
 script:
   - yarn test
-  - yarn cy:test
+  - yarn cy:test:record
   - npm run build
 
 # install firebase cli and set firebase project ci token from environment

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "prod:restore": "cp .env-default .env && rm .env-default",
     "start:ci": "cross-env SITE_VARIANT=test-ci PORT=3456 npm run start",
     "cy:test": "start-test start:ci 3456 cy:run",
-    "cy:test:record": "start-test start:ci 3456 cy:run",
+    "cy:test:record": "start-test start:ci 3456 cy:run:record",
     "cy:run": "cypress run",
     "cy:run:record": "cypress run --record --key 62585f33-d688-47b7-acb3-6d1dca832065",
     "cy:open": "npx cypress open",

--- a/package.json
+++ b/package.json
@@ -125,8 +125,10 @@
     "prod:copy": "cp .env .env-default && cp ./.env-prod ./.env",
     "prod:restore": "cp .env-default .env && rm .env-default",
     "start:ci": "cross-env SITE_VARIANT=test-ci PORT=3456 npm run start",
-    "cy:run": "start-test start:ci 3456 cy:record",
-    "cy:record": "cypress run --record --key 62585f33-d688-47b7-acb3-6d1dca832065",
+    "cy:test": "start-test start:ci 3456 cy:run",
+    "cy:test:record": "start-test start:ci 3456 cy:run",
+    "cy:run": "cypress run",
+    "cy:run:record": "cypress run --record --key 62585f33-d688-47b7-acb3-6d1dca832065",
     "cy:open": "npx cypress open",
     "cy:run:debug": "DEBUG=cypress:* cy:run"
   },


### PR DESCRIPTION
For whatever reason `start-test` doesn't like inline commands on windows, so renamed scripts to be more explicit.

```
    "cy:test": "start-test start:ci 3456 cy:run",
    "cy:test:record": "start-test start:ci 3456 cy:run:record",
    "cy:run": "cypress run",
    "cy:run:record": "cypress run --record --key 62585f33-d688-47b7-acb3-6d1dca832065",
```

`travis.yml` updated to record, as has info in contributing and wiki