### PR TITLE
delete generated how-tos at end of test

### DIFF
--- a/cypress/integration/how_to.spec.ts
+++ b/cypress/integration/how_to.spec.ts
@@ -1,14 +1,11 @@
 describe('[How To]', () => {
   const SKIP_TIMEOUT = { timeout: 300 }
 
-  before(() => {
-    cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
-  })
-
   describe('[List how-tos]', () => {
     const howtoUrl = '/how-to/make-glasslike-beams'
     const coverFileRegex = /howto-beams-glass-0-3.jpg/
     beforeEach(() => {
+      cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
       cy.visit('/how-to')
       cy.logout()
     })
@@ -55,6 +52,7 @@ describe('[How To]', () => {
 
   describe('[Filter with Tag]', () => {
     beforeEach(() => {
+      cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
       cy.visit('/how-to')
       cy.logout()
     })
@@ -250,6 +248,8 @@ describe('[How To]', () => {
     }
 
     it('[By Authenticated]', () => {
+      cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
+
       cy.login('howto_creator@test.com', 'test1234')
       cy.step('Access the create-how-to page with its url')
       cy.visit('/how-to/create')
@@ -306,15 +306,5 @@ describe('[How To]', () => {
       cy.visit('/how-to/create')
       cy.get('div').contains('Please login to access this page')
     })
-  })
-
-  describe('[Delete a how-to]', () => {
-    // TODO - CC 2019-10-14
-    // Currently no method in app to delete how-to, but expect one to be created
-  })
-
-  // Housekeeping - clear up previously created how-to
-  after(() => {
-    cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
   })
 })

--- a/cypress/integration/how_to.spec.ts
+++ b/cypress/integration/how_to.spec.ts
@@ -30,12 +30,13 @@ describe('[How To]', () => {
 
       cy.step('How-to cards has basic info')
       cy.get(`[data-cy=card] > a[href="${howtoUrl}"]`).within(() => {
-          cy.contains('Make glass-like beams').should('be.exist')
-          cy.contains('By howto_creator').should('be.exist')
-          cy.get('img').should('have.attr', 'src').and('match', coverFileRegex)
-          cy.contains('extrusion').should('be.exist')
-        }
-      )
+        cy.contains('Make glass-like beams').should('be.exist')
+        cy.contains('By howto_creator').should('be.exist')
+        cy.get('img')
+          .should('have.attr', 'src')
+          .and('match', coverFileRegex)
+        cy.contains('extrusion').should('be.exist')
+      })
 
       cy.step(`Open how-to details when click on a how-to ${howtoUrl}`)
       cy.get(`[data-cy=card] > a[href="${howtoUrl}"]`, SKIP_TIMEOUT).click()
@@ -305,5 +306,15 @@ describe('[How To]', () => {
       cy.visit('/how-to/create')
       cy.get('div').contains('Please login to access this page')
     })
+  })
+
+  describe('[Delete a how-to]', () => {
+    // TODO - CC 2019-10-14
+    // Currently no method in app to delete how-to, but expect one to be created
+  })
+
+  // Housekeeping - clear up previously created how-to
+  after(() => {
+    cy.deleteDocuments('v2_howtos', 'title', '==', 'Create a how-to test')
   })
 })


### PR DESCRIPTION
Simply call same delete method at end of how-to test to avoid some of the current race condition issues
(note - could also be put directly after creation)