### PR TITLE
Fixes #678: close dropdown on click away in events

### DIFF
--- a/src/components/LocationSearch/LocationSearch.tsx
+++ b/src/components/LocationSearch/LocationSearch.tsx
@@ -112,6 +112,12 @@ export class LocationSearch extends React.Component<IProps, IState> {
     this.props.onChange(_resultToLocation(selected))
   }
 
+  resetInputAndPanel() {
+    this.userInputRef.current.value = ''
+    this.handleInputChange('')
+    this.places.close()
+  }
+
   render() {
     const { styleVariant } = this.props
     return (
@@ -121,6 +127,7 @@ export class LocationSearch extends React.Component<IProps, IState> {
           placeholder={this.props.placeholder}
           style={styleVariant === 'filter' ? FilterStyle : SelectorStyle}
           ref={this.userInputRef}
+          onBlur={() => this.resetInputAndPanel()}
         />
         {/* the second input takes debounced value from the first input and binds to algolia search  */}
         <AlgoliaResults

--- a/src/components/LocationSearch/LocationSearch.tsx
+++ b/src/components/LocationSearch/LocationSearch.tsx
@@ -112,12 +112,6 @@ export class LocationSearch extends React.Component<IProps, IState> {
     this.props.onChange(_resultToLocation(selected))
   }
 
-  resetInputAndPanel() {
-    this.userInputRef.current.value = ''
-    this.handleInputChange('')
-    this.places.close()
-  }
-
   render() {
     const { styleVariant } = this.props
     return (
@@ -127,7 +121,7 @@ export class LocationSearch extends React.Component<IProps, IState> {
           placeholder={this.props.placeholder}
           style={styleVariant === 'filter' ? FilterStyle : SelectorStyle}
           ref={this.userInputRef}
-          onBlur={() => this.resetInputAndPanel()}
+          onBlur={() => this.places.close()}
         />
         {/* the second input takes debounced value from the first input and binds to algolia search  */}
         <AlgoliaResults


### PR DESCRIPTION
The dropdown closes when clicking away from the field now. I wonder about implementing the second requirement from the issue though -- 'ESC' as a way of closing the dropdown. Is it still necessary to add even though clicking away works?