### PR TITLE
only run scripts on PRs targetting master and production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
 dist: trusty
 sudo: false
 cache: yarn
+branches:
+  only:
+    - master
+    - production
 addons:
   chrome: stable
 


### PR DESCRIPTION
I think this should make things work better.

By including branches we can still run build on both PRs and branch push, but only when either the branch is master/production, or the PR targets master/production (I hope...)