### PR TITLE
Map/cc edits

### DIFF
--- a/src/mocks/maps.mock.tsx
+++ b/src/mocks/maps.mock.tsx
@@ -23,6 +23,7 @@ export const generatePins = (count: number): Array<IMapPin> => {
 }
 
 export const generatePinDetails = (pin: IMapPin): IMapPinDetail => {
+  console.log('generating details', pin)
   const randomDate = new Date()
   randomDate.setSeconds(randomDate.getSeconds() - Math.random() * 10000)
   const lastActive = randomDate.toISOString()
@@ -36,6 +37,6 @@ export const generatePinDetails = (pin: IMapPin): IMapPinDetail => {
     lastActive,
     profilePicUrl: 'https://picsum.photos/50/50',
     profileUrl: '/testing',
-    heroImageUrl: 'https://picsum.photos/285/175',
+    heroImageUrl: `https://picsum.photos/seed/${lastActive}/285/175`,
   }
 }

--- a/src/mocks/maps.mock.tsx
+++ b/src/mocks/maps.mock.tsx
@@ -23,7 +23,6 @@ export const generatePins = (count: number): Array<IMapPin> => {
 }
 
 export const generatePinDetails = (pin: IMapPin): IMapPinDetail => {
-  console.log('generating details', pin)
   const randomDate = new Date()
   randomDate.setSeconds(randomDate.getSeconds() - Math.random() * 10000)
   const lastActive = randomDate.toISOString()

--- a/src/pages/Maps/Content/Controls/index.tsx
+++ b/src/pages/Maps/Content/Controls/index.tsx
@@ -12,12 +12,17 @@ import { HashLink } from 'react-router-hash-link'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import { Map } from 'react-leaflet'
 import { ILocation } from 'src/models/common.models'
+import { inject } from 'mobx-react'
+import { MapsStore } from 'src/stores/Maps/maps.store'
 
 interface IProps {
   mapRef: React.RefObject<Map>
   availableFilters: Array<IPinType>
   onFilterChange: (grouping: IPinGrouping, filters: Array<IPinType>) => void
   onLocationChange: (selectedLocation: ILocation) => void
+}
+interface IInjectedProps extends IProps {
+  mapsStore: MapsStore
 }
 
 const SearchWrapper = styled.div`
@@ -30,7 +35,7 @@ const MapFlexBar = styled(Flex)`
   position: absolute;
   top: 25px;
   width: 100%;
-  z-index: 99999;
+  z-index: 3;
   left: 50%;
   transform: translateX(-50%);
 `
@@ -38,10 +43,13 @@ const MapFlexBar = styled(Flex)`
 const FlexSpacer = styled.div`
   flex: 1;
 `
-
+@inject('mapsStore')
 class Controls extends React.Component<IProps> {
   constructor(props) {
     super(props)
+  }
+  get injected() {
+    return this.props as IInjectedProps
   }
 
   public render() {
@@ -60,10 +68,12 @@ class Controls extends React.Component<IProps> {
 
     return (
       <MapFlexBar
-        px={[2, 3, 4]}
+        data-cy="map-controls"
+        ml="50px"
         py={1}
         onClick={() => {
-          // this.props.map.current.leafletElement.closePopup()
+          // close any active popup on click
+          this.injected.mapsStore.setActivePin(undefined)
         }}
       >
         <SearchWrapper>
@@ -80,7 +90,6 @@ class Controls extends React.Component<IProps> {
             items={groupedFilters[grouping]}
             onChange={options => {
               this.props.onFilterChange(grouping as IPinGrouping, options)
-              this.props.mapRef.current!.leafletElement.closePopup()
             }}
           />
         ))}

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -103,7 +103,6 @@ export class Popup extends React.Component<IProps> {
 
   public render() {
     const { activePin } = this.props
-    console.log('render', { ...activePin })
     const content = (activePin as IMapPinDetail).name
       ? this.renderContent(activePin as IMapPinDetail)
       : this.renderLoading()

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -103,6 +103,7 @@ export class Popup extends React.Component<IProps> {
 
   public render() {
     const { activePin } = this.props
+    console.log('render', { ...activePin })
     const content = (activePin as IMapPinDetail).name
       ? this.renderContent(activePin as IMapPinDetail)
       : this.renderLoading()

--- a/src/pages/Maps/Content/View/index.tsx
+++ b/src/pages/Maps/Content/View/index.tsx
@@ -72,9 +72,8 @@ class MapView extends React.Component<IProps> {
         center={[center.lat, center.lng]}
         zoom={zoom}
         maxZoom={18}
-        style={{ height: '100%' }}
+        style={{ height: '100%', zIndex: 0 }}
         onmove={this.handleMove}
-        onresize={() => console.log('resize called')}
       >
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -15,10 +15,10 @@ import { Subscription } from 'rxjs'
 import { ModuleStore } from '../common/module.store'
 import { getUserAvatar } from '../User/user.store'
 import { MAP_GROUPINGS } from './maps.groupings'
-import { generatePins } from 'src/mocks/maps.mock'
+import { generatePins, generatePinDetails } from 'src/mocks/maps.mock'
 
 // TODO - remove mock pins from store once integration complete
-// const MOCK_PINS = generatePins(250)
+const IS_MOCK = true
 
 export class MapsStore extends ModuleStore {
   mapEndpoint: IDBEndpoint = 'v2_mappins'
@@ -55,7 +55,11 @@ export class MapsStore extends ModuleStore {
     )
 
     // TODO - remove mock pins when integrated
-    // pins = [...MOCK_PINS, ...pins]
+    if (IS_MOCK) {
+      {
+        pins = [...generatePins(250), ...pins]
+      }
+    }
 
     this.mapPins = pins.map(
       ({ _id, location, pinType, profileType, workspaceType }) => ({
@@ -66,7 +70,6 @@ export class MapsStore extends ModuleStore {
         workspaceType,
       }),
     )
-
     this.filteredPins = this.mapPins
   }
 
@@ -127,7 +130,11 @@ export class MapsStore extends ModuleStore {
   public async setActivePin(pin?: IMapPin) {
     this.activePin = pin
     if (pin) {
-      const pinDetail = await this.getUserProfilePin(pin._id)
+      const pinDetail = IS_MOCK
+        ? generatePinDetails(pin)
+        : await this.getUserProfilePin(pin._id)
+      console.log('active pin', pin)
+      console.log('pin detail', pinDetail)
       this.activePin = { ...pin, ...pinDetail }
     }
   }

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -18,7 +18,7 @@ import { MAP_GROUPINGS } from './maps.groupings'
 import { generatePins } from 'src/mocks/maps.mock'
 
 // TODO - remove mock pins from store once integration complete
-const MOCK_PINS = generatePins(250)
+// const MOCK_PINS = generatePins(250)
 
 export class MapsStore extends ModuleStore {
   mapEndpoint: IDBEndpoint = 'v2_mappins'
@@ -55,7 +55,7 @@ export class MapsStore extends ModuleStore {
     )
 
     // TODO - remove mock pins when integrated
-    pins = [...MOCK_PINS, ...pins]
+    // pins = [...MOCK_PINS, ...pins]
 
     this.mapPins = pins.map(
       ({ _id, location, pinType, profileType, workspaceType }) => ({

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -133,8 +133,6 @@ export class MapsStore extends ModuleStore {
       const pinDetail = IS_MOCK
         ? generatePinDetails(pin)
         : await this.getUserProfilePin(pin._id)
-      console.log('active pin', pin)
-      console.log('pin detail', pinDetail)
       this.activePin = { ...pin, ...pinDetail }
     }
   }
@@ -151,7 +149,6 @@ export class MapsStore extends ModuleStore {
   // add new pin or update existing
   public async setPin(pin: IMapPin) {
     // generate standard doc meta
-    console.debug('setting pin', pin)
     return this.db
       .collection('v2_mappins')
       .doc(pin._id)


### PR DESCRIPTION
Few extra changes, notably:
- few small styling fixes (stop map search blocking zoom button, feedback button etc.)
- fix mock data display (description/images)
- fix popup appear on filter change (closes #698)

Todo
- test with live profile info (once working)
- remove mocks (can be done by setting `IS_MOCK` to `false` in store)
- mobile display
- logged in display (leaves gap underneath filter boxes, possibly fixed with work on new header)