### PR TITLE
Fix anchoring for custom markers on Settings page

### DIFF
--- a/src/pages/Settings/content/formSections/MapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MapPin.section.tsx
@@ -34,7 +34,7 @@ interface IState {
 const customMarker = L.icon({
   iconUrl: require('src/assets/icons/map-marker.png'),
   iconSize: [20, 28],
-  iconAnchor: [20, 56],
+  iconAnchor: [10, 28],
 })
 
 // const DEFAULT_PIN_TYPE: string = 'member'


### PR DESCRIPTION
**Previous Behaviour**

The custom icons float around when the zoom level changes, since the anchoring wasn't correct. 

**Fix**

Changed the anchoring to be in the bottom-centre of the icon so they visually stick to the proper place.

**Side note**

Interestingly, it turns out that Algolia's places search returns incorrect lat-lng coordinates for some addresses. E.g. `401 West Georgia Street, Vancouver` is off by quite a bit. This looks like an issue on Algolia's side. E.g. looking up `401 West Georgia Street, Vancouver` [returns wrong coordinates on the actual Algolia page](https://community.algolia.com/places/), which is strange because they're supposed to be pulling from Open Street Maps, which [actually returns the right coordinates](https://www.openstreetmap.org/search?query=401%20west%20georgia%20street%2C%20vancouver). 🤔