### PR TITLE
Set link size to fit content

### DIFF
--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { availableGlyphs } from '../Icons'
 import { bytesToSize } from '../ImageInput/ImageInput'
+import { Link } from 'src/components/Links'
 import { IUploadedFileMeta } from 'src/stores/storage'
 import { FileDetails } from './FileDetails'
 
@@ -46,9 +47,14 @@ export class FileInfo extends React.Component<IProps, IState> {
     return (
       <>
         {allowDownload && meta.downloadUrl ? (
-          <a href={meta.downloadUrl} target="_blank" download={file.name}>
+          <Link
+            href={meta.downloadUrl}
+            target="_blank"
+            download={file.name}
+            sx={{ width: '300px' }}
+          >
             <FileDetails file={file} glyph={glyph} size={size} />
-          </a>
+          </Link>
         ) : (
           <FileDetails file={file} glyph={glyph} size={size} />
         )}

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -48,7 +48,7 @@ export class FileInfo extends React.Component<IProps, IState> {
       <>
         {allowDownload && meta.downloadUrl ? (
           <Link
-            href={meta.downloadUrl}
+            to={meta.downloadUrl}
             target="_blank"
             download={file.name}
             sx={{ width: '300px' }}

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { availableGlyphs } from '../Icons'
 import { bytesToSize } from '../ImageInput/ImageInput'
-import { Link } from 'src/components/Links'
 import { IUploadedFileMeta } from 'src/stores/storage'
 import { FileDetails } from './FileDetails'
 
@@ -47,14 +46,14 @@ export class FileInfo extends React.Component<IProps, IState> {
     return (
       <>
         {allowDownload && meta.downloadUrl ? (
-          <Link
-            to={meta.downloadUrl}
+          <a
+            href={meta.downloadUrl}
             target="_blank"
             download={file.name}
-            sx={{ width: '300px' }}
+            style={{ width: '300px' }}
           >
             <FileDetails file={file} glyph={glyph} size={size} />
-          </Link>
+          </a>
         ) : (
           <FileDetails file={file} glyph={glyph} size={size} />
         )}


### PR DESCRIPTION
Closes #779 I set the Link's width to 300px to match the FileDetails component (which is already set to 300px).