### PR TITLE
Fixed howto submit after deleting step image

### DIFF
--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -126,10 +126,9 @@ export class HowtoStore extends ModuleStore {
     const stepsWithImgMeta: IHowtoStep[] = []
     for (const step of steps) {
       // determine any new images to upload
-      const stepImages = step.images as IConvertedFileMeta[]
-      if (!stepImages[0]) {
-        stepImages.shift()
-      }
+      const stepImages = (step.images as IConvertedFileMeta[]).filter(
+        img => !!img,
+      )
       const imgMeta = await this.uploadCollectionBatch(
         stepImages,
         COLLECTION_NAME,

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -127,6 +127,9 @@ export class HowtoStore extends ModuleStore {
     for (const step of steps) {
       // determine any new images to upload
       const stepImages = step.images as IConvertedFileMeta[]
+      if (!stepImages[0]) {
+        stepImages.shift()
+      }
       const imgMeta = await this.uploadCollectionBatch(
         stepImages,
         COLLECTION_NAME,


### PR DESCRIPTION
Fix for #756 I found the problem. In howto.store.tsx, line 129, when an image is deleted, the object in the stepImages variable is set to null, then that array gets iterated on in uploadCollectionBatch() and the function tries to access properties on null. I added a filter to remove falsey values from the stepImages array. As I’m not very familiar with the codebase yet, I am open to suggestions as to solve this differently if there is a better way.