### PR TITLE
add dexie cache-busting methods

### DIFF
--- a/src/stores/databaseV2/utils/db.utils.ts
+++ b/src/stores/databaseV2/utils/db.utils.ts
@@ -1,8 +1,5 @@
 import { DBQueryOptions } from '../types'
 
-//  note, if changing endpoints
-export const DB_API_VERSION = 2
-
 /**
  * For mapping queries it is easiest to provide a common subset of defaults
  * which are designed to prevent accidental alter to the desired data structure


### PR DESCRIPTION
@BenGamma 

This should fix issues with caching data that has been deleted. 

**Done**
- Add methods to allow clearing of cached db. This is currently implemented within an error handler due to the complex nature of updating cached databases. All cached dbs have a version number, when adding a new version you are supposed to also keep the old version alongside notes to tell dexie how to upgrade. Whilst this is very useful to allow incremental upgrades and changes to database structures, it can quickly get messy if you have made numerous changes to the database over time and can't be sure what version everybody currently has in their web browsers. 

The error handler implemented catches the case when a newly versioned database is created but explicit guidance hasn't been set for how to upgrade any/all previous versions. It tells dexie to just delete the old database and start completely fresh with the new one (i.e. pull data cleanly from the server).

- Make explicit variable to set a `version` number for the database, written in date format _yyyymmdd_. Updating this number will force a purge of the cache next time the platform is loaded, pulling all new data from the database.

**Todo**
- Add better support for incremental updates. Whilst the above default behaviour is pretty reasonable (we tend not to update the cache version very often), it might be nice in the future to include optional support for incremental updates - such as a new version where only howTos are removed from the cache. This has been written as a TODO item in the `dexie.tsx` file, although I'm reluctant to create a full issue for it unless it comes up as something in the future if we need to update again.