### PR TITLE
Fix/807 idb incognito browsers

### DIFF
--- a/src/stores/databaseV2/clients/firestore.tsx
+++ b/src/stores/databaseV2/clients/firestore.tsx
@@ -19,7 +19,6 @@ export class FirestoreClient implements AbstractDBClient {
   }
 
   async setDoc(endpoint: IDBEndpoint, doc: DBDoc) {
-    console.log('setting doc', endpoint, doc._id)
     return db.doc(`${endpoint}/${doc._id}`).set(doc)
   }
 
@@ -69,12 +68,14 @@ export class FirestoreClient implements AbstractDBClient {
   private _generateQueryRef(endpoint: IDBEndpoint, queryOpts: DBQueryOptions) {
     const query = { ...DB_QUERY_DEFAULTS, ...queryOpts }
     const { limit, orderBy, order, where } = query
-    const { field, operator, value } = where!
     const baseRef = db.collection(endpoint)
     const limitRef = limit ? baseRef.limit(limit) : baseRef
-    // if using where query ignore orderBy parameters to avoid need for composite indexes?
-    return where
-      ? limitRef.where(field, operator, value)
-      : limitRef.orderBy(field ? field : orderBy!, order!)
+    // if using where query ignore orderBy parameters to avoid need for composite indexes
+    if (where) {
+      const { field, operator, value } = where
+      return limitRef.where(field, operator, value)
+    } else {
+      return limitRef.orderBy(orderBy!, order!)
+    }
   }
 }

--- a/src/stores/databaseV2/index.tsx
+++ b/src/stores/databaseV2/index.tsx
@@ -28,10 +28,19 @@ export class DatabaseV2 implements AbstractDatabase {
     return new CollectionReference<T>(endpoint, this._clients)
   }
 
+  /**
+   * By default 3 databases are provided (cache, server, server-cache)
+   * Additionally, a 'no-idb' search param can be provided to disable
+   * cache-db entirely (triggered from dexie if not supported)
+   */
   private _getDefaultClients = (): DBClients => {
+    const serverDB = new FirestoreClient()
+    const cacheDB = location.search.includes('no-cache')
+      ? serverDB
+      : new DexieClient()
     return {
-      cacheDB: new DexieClient(),
-      serverDB: new FirestoreClient(),
+      cacheDB,
+      serverDB,
       serverCacheDB: new RealtimeDBClient(),
     }
   }
@@ -136,7 +145,7 @@ class CollectionReference<T> {
       order: 'desc',
       limit: 1,
     })
-    return latest.length > 0 ? latest[0]._modified : ''
+    return latest && latest.length > 0 ? latest[0]._modified : ''
   }
 }
 


### PR DESCRIPTION
closes #807 

I've added a new search string that can be used to disable use of dexie, just add `?no-cache` to the url when first navigating. 

I've also improved the dexie error handler to identify when it's failing to load, and automatically refresh the page in no-cache mode. 

In addition I've fixed a minor bug from the firestore methods that showed up once in no-cache mode.

Tested and working with firefox incognito mode. 