### PR TITLE
add notice for non precise location search value

### DIFF
--- a/src/pages/Settings/content/formSections/MapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MapPin.section.tsx
@@ -4,7 +4,7 @@ import Heading from 'src/components/Heading'
 import { Field } from 'react-final-form'
 import Text from 'src/components/Text'
 import { TextAreaField } from 'src/components/Form/Fields'
-import { Box, Flex } from 'rebass'
+import { Box, Flex, Link } from 'rebass'
 import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
 import { Map, TileLayer, Marker, Popup, ZoomControl } from 'react-leaflet'
 import L from 'leaflet'
@@ -147,6 +147,26 @@ export class UserMapPinSection extends React.Component<IProps, IState> {
               </Button>
             </Box>
           )}
+          <Box
+            bg={theme.colors.softblue}
+            mt={2}
+            p={2}
+            sx={{ borderRadius: '3px' }}
+          >
+            <Text small>
+              We are aware that location search may result in an inaccurate
+              position of your pin. If it happend, choose the closest location
+              to you. Pro tip : you can write your precise address in your
+              profile description & help find a fix{' '}
+              <Link
+                href="https://github.com/ONEARMY/community-platform/issues/739"
+                target="_blank"
+                sx={{ color: 'black', textDecoration: 'underline' }}
+              >
+                here.
+              </Link>
+            </Text>
+          </Box>
         </Box>
       </FlexSectionContainer>
     )


### PR DESCRIPTION
Temporary fix to #739.
Display the following notice under the pin location selector in user settings :
`We are aware that location search may result in an inaccurate
              position of your pin. If it happend, choose the closest location
              to you. Pro tip : you can write your precise address in your
              profile description & help find a fix here`