### PR TITLE
Adding Google Analytics

### DIFF
--- a/src/components/Analytics/index.tsx
+++ b/src/components/Analytics/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import ReactGA from 'react-ga'
+import { GOOGLE_ANALYTICS_CONFIG } from 'src/config/config'
+import { RouteComponentProps, withRouter } from 'react-router-dom'
+
+class Analytics extends React.Component<RouteComponentProps> {
+  constructor(props: RouteComponentProps) {
+    super(props)
+
+    ReactGA.initialize(GOOGLE_ANALYTICS_CONFIG.trackingCode, { debug: true })
+  }
+
+  componentDidMount() {
+    this.sendPageView(this.props.history.location)
+    this.props.history.listen(this.sendPageView)
+  }
+
+  sendPageView(location: any) {
+    ReactGA.set({ page: location.pathname })
+    ReactGA.pageview(location.pathname)
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default withRouter(Analytics)

--- a/src/components/Analytics/index.tsx
+++ b/src/components/Analytics/index.tsx
@@ -1,18 +1,22 @@
 import React from 'react'
 import ReactGA from 'react-ga'
-import { GOOGLE_ANALYTICS_CONFIG } from 'src/config/config'
+import { SITE, GOOGLE_ANALYTICS_CONFIG } from 'src/config/config'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 
 class Analytics extends React.Component<RouteComponentProps> {
   constructor(props: RouteComponentProps) {
     super(props)
 
-    ReactGA.initialize(GOOGLE_ANALYTICS_CONFIG.trackingCode, { debug: true })
+    if (SITE === 'production' && GOOGLE_ANALYTICS_CONFIG.trackingCode) {
+      ReactGA.initialize(GOOGLE_ANALYTICS_CONFIG.trackingCode, { debug: true })
+    }
   }
 
   componentDidMount() {
-    this.sendPageView(this.props.history.location)
-    this.props.history.listen(this.sendPageView)
+    if (SITE === 'production' && GOOGLE_ANALYTICS_CONFIG.trackingCode) {
+      this.sendPageView(this.props.history.location)
+      this.props.history.listen(this.sendPageView)
+    }
   }
 
   sendPageView(location: any) {

--- a/src/components/GoogleAnalytics/index.tsx
+++ b/src/components/GoogleAnalytics/index.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import ReactGA from 'react-ga'
-import { SITE, GOOGLE_ANALYTICS_CONFIG } from 'src/config/config'
+import { GA_TRACKING_ID } from 'src/config/config'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 
-class Analytics extends React.Component<RouteComponentProps> {
+class GoogleAnalytics extends React.Component<RouteComponentProps> {
   constructor(props: RouteComponentProps) {
     super(props)
 
-    if (SITE === 'production' && GOOGLE_ANALYTICS_CONFIG.trackingCode) {
-      ReactGA.initialize(GOOGLE_ANALYTICS_CONFIG.trackingCode, { debug: true })
+    if (GA_TRACKING_ID) {
+      ReactGA.initialize(GA_TRACKING_ID, { debug: true })
     }
   }
 
   componentDidMount() {
-    if (SITE === 'production' && GOOGLE_ANALYTICS_CONFIG.trackingCode) {
+    if (GA_TRACKING_ID) {
       this.sendPageView(this.props.history.location)
       this.props.history.listen(this.sendPageView)
     }
@@ -29,4 +29,4 @@ class Analytics extends React.Component<RouteComponentProps> {
   }
 }
 
-export default withRouter(Analytics)
+export default withRouter(GoogleAnalytics)

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -124,9 +124,7 @@ export const ALGOLIA_PLACES_CONFIG = algoliaPlacesConfig
 export const SENTRY_CONFIG = sentryConfig
 // tslint:disable no-var-requires
 export const VERSION = require('../../package.json').version
-export const GOOGLE_ANALYTICS_CONFIG = {
-  trackingCode: process.env.REACT_APP_GA_TRACKING_ID,
-}
+export const GA_TRACKING_ID = process.env.REACT_APP_GA_TRACKING_ID
 
 /*********************************************************************************************** /
                                         Interfaces

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -125,7 +125,7 @@ export const SENTRY_CONFIG = sentryConfig
 // tslint:disable no-var-requires
 export const VERSION = require('../../package.json').version
 export const GOOGLE_ANALYTICS_CONFIG = {
-  trackingCode: process.env.GA_ID || 'UA-134522498-4',
+  trackingCode: process.env.GA_TRACKING_ID,
 }
 
 /*********************************************************************************************** /

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -36,8 +36,10 @@ const branch = e.REACT_APP_BRANCH as string
 // as both dev.onearmy.world and onearmy.world are production builds we can't use process.env to distinguish
 // will be set to one of 'localhost', 'staging' or 'production'
 
-function getSiteVariant(gitBranch: string, env: typeof process.env):siteVariants {
-
+function getSiteVariant(
+  gitBranch: string,
+  env: typeof process.env,
+): siteVariants {
   if (env.SITE_VARIANT === 'test-ci') {
     return 'test-ci'
   }
@@ -77,9 +79,8 @@ if (siteVariant === 'production') {
   console.log = () => {}
 }
 
-
-const firebaseConfigs: {[variant in siteVariants]: IFirebaseConfig} = {
-  'localhost': {
+const firebaseConfigs: { [variant in siteVariants]: IFirebaseConfig } = {
+  localhost: {
     apiKey: 'AIzaSyChVNSMiYxCkbGd9C95aChr9GxRJtW6NRA',
     authDomain: 'precious-plastics-v4-dev.firebaseapp.com',
     databaseURL: 'https://precious-plastics-v4-dev.firebaseio.com',
@@ -95,7 +96,7 @@ const firebaseConfigs: {[variant in siteVariants]: IFirebaseConfig} = {
     storageBucket: 'onearmy-test-ci.appspot.com',
     messagingSenderId: '174193431763',
   },
-  'staging': {
+  staging: {
     apiKey: 'AIzaSyChVNSMiYxCkbGd9C95aChr9GxRJtW6NRA',
     authDomain: 'precious-plastics-v4-dev.firebaseapp.com',
     databaseURL: 'https://precious-plastics-v4-dev.firebaseio.com',
@@ -103,7 +104,7 @@ const firebaseConfigs: {[variant in siteVariants]: IFirebaseConfig} = {
     projectId: 'precious-plastics-v4-dev',
     storageBucket: 'precious-plastics-v4-dev.appspot.com',
   },
-  'production': {
+  production: {
     apiKey: e.REACT_APP_FIREBASE_API_KEY as string,
     authDomain: e.REACT_APP_FIREBASE_AUTH_DOMAIN as string,
     databaseURL: e.REACT_APP_FIREBASE_DATABASE_URL as string,
@@ -123,6 +124,9 @@ export const ALGOLIA_PLACES_CONFIG = algoliaPlacesConfig
 export const SENTRY_CONFIG = sentryConfig
 // tslint:disable no-var-requires
 export const VERSION = require('../../package.json').version
+export const GOOGLE_ANALYTICS_CONFIG = {
+  trackingCode: process.env.GA_ID || 'UA-134522498-4',
+}
 
 /*********************************************************************************************** /
                                         Interfaces
@@ -143,4 +147,3 @@ interface IAlgoliaConfig {
   applicationID: string
 }
 type siteVariants = 'localhost' | 'test-ci' | 'staging' | 'production'
-

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -125,7 +125,7 @@ export const SENTRY_CONFIG = sentryConfig
 // tslint:disable no-var-requires
 export const VERSION = require('../../package.json').version
 export const GOOGLE_ANALYTICS_CONFIG = {
-  trackingCode: process.env.GA_TRACKING_ID,
+  trackingCode: process.env.REACT_APP_GA_TRACKING_ID,
 }
 
 /*********************************************************************************************** /

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 /* tslint:disable:no-eval */
 import * as React from 'react'
 import { Switch, Route, BrowserRouter, Redirect } from 'react-router-dom'
-import Analytics from 'src/components/Analytics'
+import GoogleAnalytics from 'src/components/GoogleAnalytics'
 import { NotFoundPage } from './NotFound/NotFound'
 import ScrollToTop from './../components/ScrollToTop/ScrollToTop'
 import Header from './common/Header/Header'
@@ -42,7 +42,7 @@ export class Routes extends React.Component<any, IState> {
       <div>
         {/* <DevHelpers /> */}
         <BrowserRouter>
-          <Analytics />
+          <GoogleAnalytics />
           {/* on page change scroll to top */}
           <ScrollToTop>
             <Switch>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 /* tslint:disable:no-eval */
 import * as React from 'react'
 import { Switch, Route, BrowserRouter, Redirect } from 'react-router-dom'
+import Analytics from 'src/components/Analytics'
 import { NotFoundPage } from './NotFound/NotFound'
 import ScrollToTop from './../components/ScrollToTop/ScrollToTop'
 import Header from './common/Header/Header'
@@ -41,6 +42,7 @@ export class Routes extends React.Component<any, IState> {
       <div>
         {/* <DevHelpers /> */}
         <BrowserRouter>
+          <Analytics />
           {/* on page change scroll to top */}
           <ScrollToTop>
             <Switch>


### PR DESCRIPTION
I decided to make a component to do all the analytics instead of using the Analytics store. It still uses `react-ga`. But I found the store to coupled to the frontend and backend and was confusing. So keep it simple and let the frontend and the `<Analytics />` component take care of the FE. 
