### PR TITLE
Fix/caching

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -557,8 +557,34 @@ module.exports = function(webpackEnv) {
       // the HTML & assets that are part of the Webpack build.
       isEnvProduction &&
         new WorkboxWebpackPlugin.GenerateSW({
+          cacheId: 'oa',
           clientsClaim: true,
           skipWaiting: true,
+          // NOTE 2020-01-14 CC - Add support to cache firebase storage and map tiles
+          runtimeCaching: [
+            {
+              urlPattern: /.*\.(?:png|gif|jpg|jpeg|webp|svg).*/gi,
+              handler: 'cacheFirst',
+              options: {
+                cacheName: 'oa-images',
+                fetchOptions: {
+                  credentials: 'same-origin',
+                  mode: 'cors',
+                },
+                backgroundSync: {
+                  name: 'oa-images-background',
+                  options: {
+                    maxRetentionTime: 60 * 24,
+                  },
+                },
+                expiration: {
+                  maxAgeSeconds: 60 * 24 * 7 * 30,
+                  maxEntries: 1000,
+                },
+              },
+            },
+          ],
+          // end update 2020-01-14
           exclude: [/\.map$/, /asset-manifest\.json$/],
           importWorkboxFrom: 'cdn',
           navigateFallback: publicUrl + '/index.html',

--- a/functions/src/config/cors.md
+++ b/functions/src/config/cors.md
@@ -1,4 +1,8 @@
 Setting cors on storage bucket:
 https://cloud.google.com/storage/docs/configuring-cors
 
+`gcloud init`
+
+`gsutil ls`
+
 `gsutil cors set src/config/cors.json gs://[project-name].appspot.com`

--- a/src/stores/databaseV2/clients/dexie.tsx
+++ b/src/stores/databaseV2/clients/dexie.tsx
@@ -51,7 +51,7 @@ export class DexieClient implements AbstractDBClient {
     endpoint: IDBEndpoint,
     queryOpts: DBQueryOptions,
   ) {
-    const query = { ...DB_QUERY_DEFAULTS, queryOpts }
+    const query = { ...DB_QUERY_DEFAULTS, ...queryOpts }
     const { limit, orderBy, order, where } = query
     // all queries sent with a common list of conditions
     const table = db.table<T>(endpoint)

--- a/src/stores/databaseV2/index.tsx
+++ b/src/stores/databaseV2/index.tsx
@@ -135,10 +135,16 @@ class CollectionReference<T> {
     operator: DBQueryWhereOperator,
     value: DBQueryWhereValue,
   ) {
-    const { serverDB } = this.clients
-    const docs = await serverDB.queryCollection<T>(this.endpoint, {
+    const { serverDB, cacheDB } = this.clients
+    let docs = await serverDB.queryCollection<T>(this.endpoint, {
       where: { field, operator, value },
     })
+    // if not found on live try find on cached (might be offline)
+    if (docs.length === 0) {
+      docs = await cacheDB.queryCollection<T>(this.endpoint, {
+        where: { field, operator, value },
+      })
+    }
     return docs
   }
 


### PR DESCRIPTION
Fixes a couple issues with caching

## Done
- Fix dexie query issue that prevented fetching only latest docs
- Add runtime caching support for the service worker to cache images downloaded for the map and howtos (or any other image extensions)
- Add a fallback for database queries which are otherwise server-first

## Todo
- Document how the main cache system works (for reference/interest of others) #873 
- Decide if any additional strategies are required for specific resource types (e.g. https://developers.google.com/web/tools/workbox/modules/workbox-strategies)

## Notes
There were various issues with CORS on image downloads, although I think they should now be handled with the service worker webpack config. It might be worth adding a note on the wiki to explain how to enable cors on firebase storage (as this is required).

Another weird quirk, only half of the images fully cache on load (possibly a limit of firebase request intervals or similar). They do cache eventually and from what I could see the images that don't are typically the smallest (<500B). Unlikely to be able to find a simple fix for this without refactoring our own image display components to execute fetch requests before passing (unless https://developers.google.com/web/tools/workbox/guides/advanced-recipes#warm_the_runtime_cache fixes it?) 
