### PR TITLE
add catch to cachDB fallback, defer admin store init

### DIFF
--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -8,8 +8,22 @@ import { Link } from 'react-router-dom'
 import Text from 'src/components/Text'
 import Flex from 'src/components/Flex'
 import { Box } from 'rebass'
+import { inject, observer } from 'mobx-react'
+import { AdminStore } from 'src/stores/Admin/admin.store'
 
-class AdminPageClass extends React.Component<null, null> {
+interface IProps {}
+interface IInjectedProps extends IProps {
+  adminStore: AdminStore
+}
+@inject('adminStore')
+@observer
+class AdminPageClass extends React.Component<IProps, any> {
+  componentDidMount() {
+    this.injected.adminStore.init()
+  }
+  get injected() {
+    return this.props as IInjectedProps
+  }
   public render() {
     return (
       <div id="AdminPage">

--- a/src/stores/Admin/admin.store.ts
+++ b/src/stores/Admin/admin.store.ts
@@ -18,18 +18,16 @@ export class AdminStore extends ModuleStore {
   public tags: ITag[] = []
   constructor(rootStore: RootStore) {
     super(rootStore)
-    this._init()
-  }
-
-  @action
-  private async _init() {
-    this.admins = await this._getUsersByRole('admin')
-    this.superAdmins = await this._getUsersByRole('admin')
   }
 
   /*********************************************************************************
    *  User Admin
    *********************************************************************************/
+  @action
+  public async init() {
+    this.admins = await this._getUsersByRole('admin')
+    this.superAdmins = await this._getUsersByRole('admin')
+  }
   public async addUserRole(username: string, role: UserRole) {
     const userRef = this.db.collection<IUser>('v3_users').doc(username)
     const user = await userRef.get('server')
@@ -40,7 +38,7 @@ export class AdminStore extends ModuleStore {
     if (!userRoles.includes(role)) {
       userRoles.push(role)
       await userRef.set({ ...user, userRoles })
-      this._init()
+      this.init()
     }
   }
 
@@ -54,7 +52,7 @@ export class AdminStore extends ModuleStore {
     if (userRoles.includes(role)) {
       userRoles.splice(userRoles.indexOf(role), 1)
       await userRef.set({ ...user, userRoles })
-      this._init()
+      this.init()
     }
   }
 

--- a/src/stores/databaseV2/index.tsx
+++ b/src/stores/databaseV2/index.tsx
@@ -147,6 +147,7 @@ class CollectionReference<T> {
           where: { field, operator, value },
         })
       } catch (error) {
+        console.error(error)
         // at least we can say we tried...
       }
     }

--- a/src/stores/databaseV2/index.tsx
+++ b/src/stores/databaseV2/index.tsx
@@ -140,10 +140,15 @@ class CollectionReference<T> {
       where: { field, operator, value },
     })
     // if not found on live try find on cached (might be offline)
+    // use catch as not all endpoints are cached or some might not be indexed
     if (docs.length === 0) {
-      docs = await cacheDB.queryCollection<T>(this.endpoint, {
-        where: { field, operator, value },
-      })
+      try {
+        docs = await cacheDB.queryCollection<T>(this.endpoint, {
+          where: { field, operator, value },
+        })
+      } catch (error) {
+        // at least we can say we tried...
+      }
     }
     return docs
   }


### PR DESCRIPTION
The added cache fallback methods from PR #872 produced errors when queries were executed on the cache that either:

a) Didn't have a corresponding operation. Basic queries have been created for things like `>`, `==`, `<`, however the firebase custom `array-contains` query has not been created and was throwing an error. This message has been made more clear, and a better catch used to avoid.

b) Didn't have indexes on the fields required to query. By default any searches on dexie can only be performed on fields that are specified in the schema, which didn't include things like `userRoles` or `_authID`. This again is now handled more gracefully.

Additionally, both errors were being thrown on launch from the admin store. As the admin store isn't required for most users I've changed the init function to only fire on admin page load.

Hopefully this should pass the tests, and if so a new PR might need to be made to production (or can try merge and see if it builds)