### PR TITLE
Fix pr920 - clear indexDB local cache before automated test

### DIFF
--- a/cypress/support/hooks.ts
+++ b/cypress/support/hooks.ts
@@ -9,6 +9,8 @@ import { Firestore } from './db/firebase'
  */
 
 before(() => {
+  indexedDB.deleteDatabase('OneArmyCache')
+  cy.clearLocalStorage()
   cy.wrap('Initialising Database').then({ timeout: 60000 }, doc => {
     // large initial timeout in case server slow to respond
     return new Cypress.Promise(async resolve => {

--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -12,7 +12,8 @@ export const notifyPinAccepted = functions.firestore
   .onWrite(async (change, context) => {
     const info = change.after.exists ? change.after.data() : null
     const prevInfo = change.before.exists ? change.before.data() : null
-    const beenAccepted = (prevInfo !== null) ? prevInfo.hasBeenAccepted : null;
+    const beenAccepted =
+      prevInfo !== null ? prevInfo.moderation === 'accepted' : null
     if (info === null || info.moderation !== 'accepted' || beenAccepted) {
       return
     }

--- a/src/models/common.models.tsx
+++ b/src/models/common.models.tsx
@@ -27,7 +27,6 @@ export type IModerationStatus =
 
 export interface IModerable {
   moderation: IModerationStatus
-  hasBeenAccepted?: boolean
   _createdBy?: string
   _id?: string
 }

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -163,9 +163,6 @@ export class MapsStore extends ModuleStore {
     if (!hasAdminRights(this.activeUser)) {
       return false
     }
-    if (pin.moderation === 'accepted') {
-      pin.hasBeenAccepted = true
-    }
     this.setPin(pin)
   }
   public needsModeration(pin: IMapPin) {


### PR DESCRIPTION
Since merge of #920 automated testings build were mysteriously failing, with various errors, always different.
That was linked to the [change of the IModerable interface](https://github.com/ONEARMY/community-platform/pull/920/files) in #920 and the fact that the IndexDB database interfaces cached in the automated browser used by cypress (in my case chromium) was different than the new ones.

In this PR I removed the need of modifiying the interface. We should modify interfaces only in major update cases because it will cause all our user to redownload the datas from db. With approximately 10 000 monthly visitors that will cost a lot of bandwith and more hosting cost too.
In this situation (update a webhook for internal use only), it doesn't appear worth to remove all caching.

Also I added an instruction to clear local indexDB cache at the beggining of the tests.