### PR TITLE
Limit description length for map pins to 70 characters

### DIFF
--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -89,7 +89,11 @@ export class Popup extends React.Component<IProps> {
         ? g.subType === pin.subType && g.type === pin.type
         : g.type === pin.type
     })
-    const { lastActive, heroImageUrl, shortDescription, name } = pin.detail
+    let { lastActive, heroImageUrl, shortDescription, name } = pin.detail
+    const description =
+      shortDescription.length > 70
+        ? shortDescription.substr(0, 70) + '...'
+        : shortDescription
     const lastActiveText = lastActive
       ? distanceInWords(lastActive, new Date())
       : 'a long time'
@@ -116,8 +120,8 @@ export class Popup extends React.Component<IProps> {
               {name}
             </Text>
           </Link>
-          <Text auxiliary small clipped mb={2}>
-            {shortDescription}
+          <Text small mb={2}>
+            {description}
           </Text>
           <LastOnline>last active {lastActiveText} ago</LastOnline>
           {pin.moderation !== 'accepted' && (

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -89,7 +89,7 @@ export class Popup extends React.Component<IProps> {
         ? g.subType === pin.subType && g.type === pin.type
         : g.type === pin.type
     })
-    let { lastActive, heroImageUrl, shortDescription, name } = pin.detail
+    const { lastActive, heroImageUrl, shortDescription, name } = pin.detail
     const description =
       shortDescription.length > 70
         ? shortDescription.substr(0, 70) + '...'
@@ -120,7 +120,7 @@ export class Popup extends React.Component<IProps> {
               {name}
             </Text>
           </Link>
-          <Text small mb={2}>
+          <Text small mb={2} style={{ wordBreak: 'break-word' }}>
             {description}
           </Text>
           <LastOnline>last active {lastActiveText} ago</LastOnline>

--- a/src/pages/Settings/content/formSections/MapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MapPin.section.tsx
@@ -78,12 +78,15 @@ export class UserMapPinSection extends React.Component<IProps, IState> {
         </Flex>
         <Box sx={{ display: isOpen ? 'block' : 'none' }}>
           <Text mb={2} mt={4} medium>
-            Short description of your pin *
+            Short description of your pin (max. 70 characters) *
           </Text>
           <Field
             data-cy="pin-description"
             name="mapPinDescription"
             component={TextAreaField}
+            maxLength="70"
+            style={{ height: 'inherit' }}
+            rows="1"
             placeholder="We are shredding plastic in Plymouth, UK."
             validate={required}
           />

--- a/src/pages/Settings/content/formSections/MapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MapPin.section.tsx
@@ -78,7 +78,7 @@ export class UserMapPinSection extends React.Component<IProps, IState> {
         </Flex>
         <Box sx={{ display: isOpen ? 'block' : 'none' }}>
           <Text mb={2} mt={4} medium>
-            Short description of your pin (max. 70 characters) *
+            Short description of your pin*
           </Text>
           <Field
             data-cy="pin-description"
@@ -87,7 +87,7 @@ export class UserMapPinSection extends React.Component<IProps, IState> {
             maxLength="70"
             style={{ height: 'inherit' }}
             rows="1"
-            placeholder="We are shredding plastic in Plymouth, UK."
+            placeholder="Short description of your pin (max 70 characters)"
             validate={required}
           />
           {!initialFormValues.location || editAddress ? (


### PR DESCRIPTION
- This only sets a limit of characters for people using the endpoint through this frontend

Closes #900 