### PR TITLE
hotfix - tsconfig minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ functions/backup.json
 
 # production
 /build
+/lib
 
 # misc
 .DS_Store

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
-    "build": "tsc",
+    "build": "tsc -b",
     "watch": "./node_modules/.bin/tsc --watch",
     "copyDevConfig": "firebase functions:config:get > .runtimeconfig.json",
     "copyDevConfigWin": "firebase functions:config:get | ac .runtimeconfig.json",
@@ -39,7 +39,7 @@
     "@types/sharp": "^0.22.1",
     "concurrently": "^4.1.1",
     "tslint": "^5.12.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.7.4"
   },
   "engines": {
     "node": "10"

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -7,12 +7,15 @@
     "sourceMap": true,
     "target": "es6",
     "jsx": "react",
-    "typeRoots": ["node_modules/@types"],
-    "baseUrl": "./",
+    "typeRoots": ["./node_modules/@types"],
+    "baseUrl": ".",
     "paths": {
-      "@OAModels/*": ["../src/models/*"]
+      "@OAModels/*": ["../src/models/*"],
+      "src/*": ["../src/*"],
+      "functions/*": ["./*"]
     },
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "spec/**/*.ts"]
+  "references": [{ "path": "../src" }],
+  "include": ["src/**/*"]
 }

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -2806,10 +2806,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.2:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.4:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 unique-string@^2.0.0:
   version "2.0.0"

--- a/src/models/common.models.tsx
+++ b/src/models/common.models.tsx
@@ -1,4 +1,4 @@
-import { DBDoc as DBDocImport } from '../stores/databaseV2/types'
+import { DBDoc as DBDocImport } from 'src/stores/databaseV2/types'
 
 // re-export the database dbDoc to make it easier to import elsewhere
 export type DBDoc = DBDocImport

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,14 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "preserve",
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "experimentalDecorators": true,
-    "typeRoots": ["./node_modules/@types", "./types"]
+    "typeRoots": ["./node_modules/@types", "./types"],
+    "composite": true,
+    "declaration": true,
+    "outDir": "./lib"
   },
   "include": ["src", "types"],
   "exclude": [


### PR DESCRIPTION
Latest build on master failing due to config errors with how `functions` shares some type definitions with the main `src`. Not really sure why this has happened now, but it's always been a bit of a fragile system so not hugely surprised.

This attempts fix by:
- update typescript version in functions to match src
- add project references tsconfig support
- add typing build script for project

In the future we can hopefully achieve a better/more-permanent fix via `lerna` and/or `yarn workspaces`