### PR TITLE
Add PR template and release drafter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -9,6 +9,7 @@ _Select relevant_
 ## Checklist
 
 - [ ] - Latest `master` branch merged
+- [ ] - PR title descriptive (can be used in release notes)
 - [ ] - Passes Tests
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,12 +1,10 @@
-## Type
-
-_Select relevant_
+PR Type
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
-## Checklist
+PR Checklist
 
 - [ ] - Latest `master` branch merged
 - [ ] - PR title descriptive (can be used in release notes)

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,24 @@
+## Type
+
+_Select relevant_
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist
+
+- [ ] - Latest `master` branch merged
+- [ ] - Passes Tests
+
+## Description
+
+_What this PR does_
+
+## Git Issues
+
+_Closes #_
+
+## Screenshots/Videos
+
+_If useful, provide screenshot or capture to highlight main changes_

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'v$NEXT_PATCH_VERSION 🌈'
+name-template: 'v$NEXT_PATCH_VERSION - {Give it a name}'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist
- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [x] - Passes Tests

## Description
Will likely need some fine-tuning, but the idea is to tidy up how PRs and releases are organised. I've added a PR template (used for this PR) to encourage people to be more clear on what they are merging (particularly to remember to close any linked issues, and make sure branch up to date).

Additionally I've included a github workflow action to automatically prepare a draft release from all PRs merged into master. It's setup to automatically list PR titles in the notes, and additionally could  categorise if we choose to tag PRs in a particular way. I still expect the releases will still need to be mostly written by a person, but hopefully this will speed up the process and help make sure nothing is left out

## Git Issues

_Closes #_

## Screenshots/Videos
Example Release Drafter:
https://github.com/release-drafter/release-drafter#readme
![image](https://user-images.githubusercontent.com/10515065/79908745-a30a0300-83d0-11ea-997b-89454079bde4.png)