### PR TITLE
Show platform version on logo hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precious-plastic-community-platform",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "start": "node scripts/start.js",

--- a/src/pages/common/Header/Menu/Logo/Logo.tsx
+++ b/src/pages/common/Header/Menu/Logo/Logo.tsx
@@ -47,6 +47,7 @@ export class Logo extends React.Component<IProps> {
                 width={[50, 50, 100]}
                 height={[50, 50, 100]}
                 alt={'PP Logo v' + VERSION}
+                title={'PP Logo v' + VERSION}
               />
             </Flex>
             <Text


### PR DESCRIPTION
## Description

Minor fix just to properly display the version number on logo hover (tried before using an `alt tag` but should have been a name tag. Also bumped minor version for future release, and updated PR template to show correctly

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/10515065/80117869-8c80ba80-853c-11ea-8117-fb5671a8a1cc.png)

