### PR TITLE
Virtual scroll code tidying

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "@types/react-select": "^2.0.17",
     "@types/react-slick": "0.23.2",
     "@types/react-table": "^6.8.5",
+    "@types/react-virtualized": "^9.21.10",
     "@types/rebass": "4",
     "@types/storybook__addon-actions": "^3.4.2",
     "@types/storybook__addon-info": "^4.1.0",

--- a/src/components/VirtualizedFlex/VirtualizedFlex.tsx
+++ b/src/components/VirtualizedFlex/VirtualizedFlex.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react'
+import { Flex, Box } from 'rebass'
+import themes from 'src/themes/styled.theme'
+import {
+  List,
+  WindowScroller,
+  CellMeasurerCache,
+  CellMeasurer,
+  ListRowProps,
+} from 'react-virtualized'
+
+interface IProps {
+  data: any[]
+  renderItem: (data: any) => JSX.Element
+  widthBreakpoints: number[]
+}
+interface IState {
+  totalColumns?: number
+  dataRows?: any[][]
+}
+
+// User a measurement cache to dynamically calculate dynamic row heights based on content
+const cache = new CellMeasurerCache({
+  fixedWidth: true,
+  //  only use a single key for all rows (assumes all rows the same height)
+  keyMapper: () => 0,
+})
+/**
+ * Display a list of flex items as a virtualized list (only render what is shown),
+ * automatically calculating the number of rows to be displayed via breakpoints.
+ * Note, does not use react masonry/grid layouts to allow use with page scroller
+ */
+export class VirtualizedFlex extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props)
+    this.state = {}
+  }
+  componentDidMount() {
+    this.generateRowData()
+  }
+
+  /**
+   * Split data into rows and columns depending on breakpoints
+   * Only re-render if the total number of columns has changed
+   */
+  generateRowData() {
+    const previousColumns = this.state.totalColumns
+    const { data, widthBreakpoints } = this.props
+    const currentWidth = window.innerWidth
+    const totalColumns = this._calcTotalColumns(currentWidth, widthBreakpoints)
+    if (previousColumns !== totalColumns) {
+      const dataRows = this._dataToRows(data, totalColumns)
+      this.setState({ totalColumns, dataRows })
+    }
+  }
+
+  /**
+   * When rendering a row call the measurer to check the rendered
+   * content and update the row height to ensure fit
+   */
+  rowRenderer(rowProps: ListRowProps) {
+    const { index, key, style, parent } = rowProps
+    const { renderItem } = this.props
+    const row = this.state.dataRows![index]
+    return (
+      <CellMeasurer
+        cache={cache}
+        key={key}
+        parent={parent}
+        // simply measure first cell as all will be the same
+        columnIndex={0}
+        rowIndex={0}
+      >
+        <Flex key={key} style={style}>
+          {row.map((rowData: any[], i: number) => (
+            <Box style={{ flex: 1 }} key={key + i}>
+              {renderItem(rowData)}
+            </Box>
+          ))}
+        </Flex>
+      </CellMeasurer>
+    )
+  }
+  /**
+   * Takes an array and subdivides into row/column array
+   * of arrays for a specified number of columns
+   */
+  private _dataToRows(data: any[], columns: number) {
+    const totalRows = Math.ceil(data.length / columns)
+    const rows: (typeof data)[] = []
+    for (let i = 0; i < totalRows; i++) {
+      rows.push(data.slice(columns * i, columns * (i + 1)))
+    }
+    return rows
+  }
+  /**
+   * Use theme breakpoints to decide how many columns
+   */
+  private _calcTotalColumns(containerWidth: number, breakpoints: number[]) {
+    return Math.min(
+      [0, ...breakpoints, Infinity].findIndex(width => containerWidth < width),
+      breakpoints.length,
+    )
+  }
+
+  render() {
+    const { dataRows } = this.state
+    return dataRows ? (
+      <WindowScroller onResize={() => this.generateRowData()}>
+        {({ onChildScroll, isScrolling, height, width, scrollTop }) => (
+          <List
+            autoHeight
+            height={height}
+            width={width}
+            isScrolling={isScrolling}
+            onScroll={onChildScroll}
+            scrollTop={scrollTop}
+            rowCount={dataRows.length}
+            overscanRowCount={2}
+            rowRenderer={rowProps => this.rowRenderer(rowProps)}
+            deferredMeasurementCache={cache}
+            rowHeight={cache.rowHeight}
+          />
+        )}
+      </WindowScroller>
+    ) : null
+  }
+
+  static defaultProps: IProps = {
+    widthBreakpoints: themes.breakpoints.map(
+      // Convert theme em string to px number
+      width => Number(width.replace('em', '')) * 16,
+    ),
+    data: [],
+    renderItem: data => <div>RenderItem {data}</div>,
+  }
+}

--- a/src/components/VirtualizedFlex/VirtualizedFlex.tsx
+++ b/src/components/VirtualizedFlex/VirtualizedFlex.tsx
@@ -72,8 +72,8 @@ export class VirtualizedFlex extends React.Component<IProps, IState> {
         rowIndex={0}
       >
         <Flex key={key} style={style}>
-          {row.map((rowData: any[], i: number) => (
-            <Box style={{ flex: 1 }} key={key + i}>
+          {row.map((rowData: any, i: number) => (
+            <Box key={key + i} width={[1, 1 / 2, 1 / 3]}>
               {renderItem(rowData)}
             </Box>
           ))}

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -1,20 +1,16 @@
 import * as React from 'react'
-import { Flex } from 'rebass'
-import { List, WindowScroller } from 'react-virtualized'
-// TODO add loader (and remove this material-ui dep)
+import { Flex, Box } from 'rebass'
 import { Link } from 'src/components/Links'
 import TagsSelect from 'src/components/Tags/TagsSelect'
-
 import { inject, observer } from 'mobx-react'
 import { HowtoStore } from 'src/stores/Howto/howto.store'
 import { Button } from 'src/components/Button'
-import { IHowtoDB } from 'src/models/howto.models'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import MoreContainer from 'src/components/MoreContainer/MoreContainer'
 import HowToCard from 'src/components/HowToCard/HowToCard'
 import Heading from 'src/components/Heading'
 import { Loader } from 'src/components/Loader'
-import themes from 'src/themes/styled.theme'
+import { VirtualizedFlex } from 'src/components/VirtualizedFlex/VirtualizedFlex'
 
 interface InjectedProps {
   howtoStore?: HowtoStore
@@ -22,12 +18,8 @@ interface InjectedProps {
 
 interface IState {
   isLoading: boolean
+  // totalHowtoColumns: number
 }
-
-const breakpointsInPX = themes.breakpoints.map(
-  // From em string to px number
-  breakpoint => Number(breakpoint.replace('em', '')) * 16,
-)
 
 // First we use the @inject decorator to bind to the howtoStore state
 @inject('howtoStore')
@@ -46,39 +38,8 @@ export class HowtoList extends React.Component<any, IState> {
     return this.props as InjectedProps
   }
 
-  /**
-   * Divide howtos into rows and columns for display
-   * (required for virtualized list)
-   */
-  getFilteredHowtoRows(howtos: IHowtoDB[]): IHowtoDB[][] {
-    const { innerWidth } = window
-    const totalColumns = [0, ...breakpointsInPX, Infinity].findIndex(
-      width => innerWidth < width,
-    )
-    const totalRows = Math.ceil(howtos.length / totalColumns)
-    const rows: IHowtoDB[][] = []
-    for (let i = 0; i < totalRows; i++) {
-      rows.push(howtos.slice(totalColumns * i, totalColumns * (i + 1)))
-    }
-    return rows
-  }
-
-  rowRenderer(row: IHowtoDB[][], { index, key, style }) {
-    const howtos: IHowtoDB[] = row[index]
-    return (
-      <Flex key={key} style={style}>
-        {howtos.map((howto: IHowtoDB) => (
-          <Flex key={howto._id} px={4} py={4} width={[1, 1 / 2, 1 / 3]}>
-            <HowToCard howto={howto} />
-          </Flex>
-        ))}
-      </Flex>
-    )
-  }
-
   public render() {
     const { filteredHowtos, selectedTags } = this.props.howtoStore
-    const filteredHowtoRows = this.getFilteredHowtoRows(filteredHowtos)
     return (
       <>
         <Flex py={26}>
@@ -127,22 +88,15 @@ export class HowtoList extends React.Component<any, IState> {
               </Heading>
             </Flex>
           ) : (
-            <Flex flexWrap="wrap" mx={-4}>
-              <WindowScroller>
-                {({ ...props }) => (
-                  <List
-                    autoHeight
-                    width={window.innerWidth}
-                    rowCount={filteredHowtoRows.length}
-                    rowHeight={410}
-                    overscanRowCount={2}
-                    rowRenderer={data =>
-                      this.rowRenderer(filteredHowtoRows, data)
-                    }
-                    {...props}
-                  />
+            <Flex justifyContent={'center'} mx={-4}>
+              <VirtualizedFlex
+                data={filteredHowtos}
+                renderItem={data => (
+                  <Box px={4} py={4}>
+                    <HowToCard howto={data} />
+                  </Box>
                 )}
-              </WindowScroller>
+              />
             </Flex>
           )}
           <Flex justifyContent={'center'} mt={20}>

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -50,7 +50,7 @@ export class HowtoList extends React.Component<any, IState> {
    * Divide howtos into rows and columns for display
    * (required for virtualized list)
    */
-  filterHowtoRows(howtos: IHowtoDB[]): IHowtoDB[][] {
+  getFilteredHowtoRows(howtos: IHowtoDB[]): IHowtoDB[][] {
     const { innerWidth } = window
     const totalColumns = [0, ...breakpointsInPX, Infinity].findIndex(
       width => innerWidth < width,
@@ -79,7 +79,7 @@ export class HowtoList extends React.Component<any, IState> {
 
   public render() {
     const { filteredHowtos, selectedTags } = this.props.howtoStore
-    const filteredHowtoRows = this.filterHowtoRows(filteredHowtos)
+    const filteredHowtoRows = this.getFilteredHowtoRows(filteredHowtos)
     return (
       <>
         <Flex py={26}>

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -64,7 +64,6 @@ export class HowtoList extends React.Component<any, IState> {
   }
 
   rowRenderer(row: IHowtoDB[][], { index, key, style }) {
-    console.log('render row', index)
     const howtos: IHowtoDB[] = row[index]
     return (
       <Flex key={key} style={style}>
@@ -136,7 +135,7 @@ export class HowtoList extends React.Component<any, IState> {
                     width={window.innerWidth}
                     rowCount={filteredHowtoRows.length}
                     rowHeight={410}
-                    overscanRowCount={3}
+                    overscanRowCount={2}
                     rowRenderer={data =>
                       this.rowRenderer(filteredHowtoRows, data)
                     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "declaration": true,
     "outDir": "./lib"
   },
-  "include": ["src", "types"],
+  "include": ["src/**/*", "types"],
   "exclude": [
     "node_modules",
     "build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,6 +3821,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-virtualized@^9.21.10":
+  version "9.21.10"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.10.tgz#cd072dc9c889291ace2c4c9de8e8c050da8738b7"
+  integrity sha512-f5Ti3A7gGdLkPPFNHTrvKblpsPNBiQoSorOEOD+JPx72g/Ng2lOt4MYfhvQFQNgyIrAro+Z643jbcKafsMW2ag==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.8.4":
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"


### PR DESCRIPTION
PR Type

- Code Tidying

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [x] - Passes Tests

## Description
Following #962 (thanks @tudi2d!), some minor code tidying
- swap getter function with regular (as it's used in multiple places it runs the code multiple times)
- simplify row/column calculation methods
- add overscanrowcount property (change default lookahead from 10 rows to 2)

## Screenshots/Videos
Probably deserves one as really neat how images now only load in as they scrolled past!
