### PR TITLE
feat: close button for submitStatus modal

### DIFF
--- a/src/pages/Howto/Content/Common/SubmitStatus.tsx
+++ b/src/pages/Howto/Content/Common/SubmitStatus.tsx
@@ -32,10 +32,18 @@ export class HowToSubmitStatus extends React.Component<IProps> {
     const uploadStatus = this.injected.howtoStore.uploadStatus
     return uploadStatus.Start ? (
       <Modal>
-        <Heading medium textAlign="center">
-          Uploading How To
-        </Heading>
-        <Box margin="auto" p={0}>
+        <Flex justifyContent="space-between">
+          <Heading small textAlign="center">
+            Uploading How To
+          </Heading>
+          <Icon
+            glyph={'close'}
+            onClick={() => {
+              this.props.onClose()
+            }}
+          />
+        </Flex>
+        <Box margin="15px 0" p={0}>
           {Object.keys(uploadStatus).map(key => (
             <Flex p={0} alignItems="center" key={key}>
               <Icon
@@ -48,7 +56,6 @@ export class HowToSubmitStatus extends React.Component<IProps> {
         </Box>
         <Button
           data-cy={uploadStatus.Complete ? 'view-howto' : ''}
-          mt={3}
           disabled={!uploadStatus.Complete}
           variant={!uploadStatus.Complete ? 'disabled' : 'outline'}
           icon="arrow-forward"


### PR DESCRIPTION
PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [x] - Passes Tests

## Description

Adding a close button to the submit how-to modal. It prevent the user to have to reload the page on how-to upload fail, and thus loose all his how-to writing.

## Git Issues

Partial fix for #781 