### PR TITLE
Fix links validations

### DIFF
--- a/src/pages/Settings/content/formSections/Fields/Link.field.tsx
+++ b/src/pages/Settings/content/formSections/Fields/Link.field.tsx
@@ -48,8 +48,6 @@ export class ProfileLinkField extends Component<IProps, IState> {
   // e.g. only a username is given for a bazar link
   public formatLink(link: string) {
     switch (this.state.linkType) {
-      case 'discord':
-        return ensureExternalUrl(link)
       case 'forum':
         return ensureExternalUrl(link)
       case 'website':


### PR DESCRIPTION
PR Type

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)
- [ ] - Passes Tests

## Description
- remove link validation for discord IDs
- As described in #970 thread, still one little bug to fix :
> I've spotted a weird behavior in the link validation while doing a last check. See a screencast [here](http://recordit.co/Pphy7TNBU4)
It happend in the case you have an invalid url first, then the validation removes the last char of the input. But I don't get it because we are not striping any character, we are just adding from the existing value 🤔
