### PR TITLE
redirect root page to /academy instead of /how-to

### DIFF
--- a/cypress/integration/common.spec.ts
+++ b/cypress/integration/common.spec.ts
@@ -2,10 +2,10 @@ import { UserMenuItem } from '../support/commands'
 
 describe('[Common]', () => {
   it('[Default Page]', () => {
-    cy.step('The home page is /how-to')
+    cy.step('The home page is /academy')
     cy.visit('/')
       .url()
-      .should('include', '/how-to')
+      .should('include', '/academy')
   })
 
   it('[Not-Found Page]', () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -67,7 +67,7 @@ export class Routes extends React.Component<any, IState> {
               <Route component={NotFoundPage} />
             </Switch>
             <Switch>
-              <Route exact path="/" render={() => <Redirect to="/how-to" />} />
+              <Route exact path="/" render={() => <Redirect to="/academy" />} />
             </Switch>
           </ScrollToTop>
         </BrowserRouter>


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [x] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)
- [ ] - Passes Tests

## Description

Changes landing page from `/how-to` to `/academy`

## Git Issues

Closes #988 