### PR TITLE
Avoid notification when user edits pin or howto

### DIFF
--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -30,7 +30,10 @@ export const notifyHowToAccepted = functions.firestore
   .document('v3_howtos/{id}')
   .onWrite(async (change, context) => {
     const info = change.after.exists ? change.after.data() : null
-    if (info === null || info.moderation !== 'accepted') {
+    const prevInfo = change.before.exists ? change.before.data() : null
+    const beenAccepted =
+      prevInfo !== null ? prevInfo.moderation === 'accepted' : null
+    if (info === null || info.moderation !== 'accepted' || beenAccepted) {
       return
     }
     const { _createdBy, title, slug } = info

--- a/functions/src/Integrations/firebase-slack.ts
+++ b/functions/src/Integrations/firebase-slack.ts
@@ -16,6 +16,9 @@ export const notifyNewPin = functions.firestore
     if (info === null || info.moderation !== 'awaiting-moderation' || prevModeration === 'awaiting-moderation') {
       return
     }
+    if (prevModeration === 'accepted' && info.moderation !== 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
+      return change.after.ref.parent.child('moderation').set('accepted');
+    }
 
     const id = info._id
     const type = info.type
@@ -42,8 +45,13 @@ export const notifyNewHowTo = functions.firestore
   .document('v3_howtos/{id}')
   .onWrite((change, context) => {
     const info = change.after.exists ? change.after.data() : null
+    const prevInfo = change.before.exists ? change.before.data() : null
+    const prevModeration = (prevInfo !== null) ? prevInfo.moderation : null;
     if (info === null || info.moderation !== 'awaiting-moderation') {
       return
+    }
+    if (prevModeration === 'accepted' && info.moderation !== 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
+      return change.after.ref.parent.child('moderation').set('accepted');
     }
 
     const user = info._createdBy


### PR DESCRIPTION
Fixes #1008

Notification will be triggered if user reverts to draft and then try to publish after being accepted.

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Keeps accepted status after edit avoiding messages to disscord

## Git Issues

Closes #1008
