### PR TITLE
Avoid notification when user edits pin or howto and it was previuosly accepted. #1008

### DIFF
--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -15,7 +15,10 @@ export const notifyPinAccepted = functions.firestore
     const beenAccepted =
       prevInfo !== null ? prevInfo.moderation === 'accepted' : null
     if (info === null || info.moderation !== 'accepted' || beenAccepted) {
-      return
+      return null
+    }
+    if (info.previouslyAccepted) { // Skip after edition of previously accepted
+      return null
     }
     const { _id, type } = info
     await axios
@@ -34,7 +37,10 @@ export const notifyHowToAccepted = functions.firestore
     const beenAccepted =
       prevInfo !== null ? prevInfo.moderation === 'accepted' : null
     if (info === null || info.moderation !== 'accepted' || beenAccepted) {
-      return
+      return null
+    }
+    if (info.previouslyAccepted) { // Skip after edition of previously accepted
+      return null
     }
     const { _createdBy, title, slug } = info
     await axios
@@ -51,7 +57,7 @@ export const notifyEventAccepted = functions.firestore
   .onWrite(async (change, context) => {
     const info = change.after.exists ? change.after.data() : null
     if (info === null || info.moderation !== 'accepted') {
-      return
+      return null
     }
     const user = info._createdBy
     const url = info.url

--- a/functions/src/Integrations/firebase-slack.ts
+++ b/functions/src/Integrations/firebase-slack.ts
@@ -13,11 +13,16 @@ export const notifyNewPin = functions.firestore
     const info = change.after.exists ? change.after.data() : null
     const prevInfo = change.before.exists ? change.before.data() : null
     const prevModeration = (prevInfo !== null) ? prevInfo.moderation : null;
-    if (info === null || info.moderation !== 'awaiting-moderation' || prevModeration === 'awaiting-moderation') {
-      return
+    if (prevModeration === info.moderation){ // Avoid infinite loop
+      return null
     }
-    if (prevModeration === 'accepted' && info.moderation !== 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
-      return change.after.ref.parent.child('moderation').set('accepted');
+    if (prevModeration === 'accepted' && info.moderation === 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
+      return change.after.ref.set({
+        moderation: 'accepted'
+      }, {merge: true});
+    }
+    if (info === null || info.moderation !== 'awaiting-moderation' || prevModeration === 'awaiting-moderation') {
+      return null
     }
 
     const id = info._id
@@ -47,11 +52,16 @@ export const notifyNewHowTo = functions.firestore
     const info = change.after.exists ? change.after.data() : null
     const prevInfo = change.before.exists ? change.before.data() : null
     const prevModeration = (prevInfo !== null) ? prevInfo.moderation : null;
-    if (info === null || info.moderation !== 'awaiting-moderation') {
-      return
+    if (prevModeration === info.moderation){ // Avoid infinite loop
+      return null
     }
-    if (prevModeration === 'accepted' && info.moderation !== 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
-      return change.after.ref.parent.child('moderation').set('accepted');
+    if (prevModeration === 'accepted' && info.moderation === 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
+      return change.after.ref.set({
+        moderation: 'accepted'
+      }, {merge: true});
+    }
+    if (info === null || info.moderation !== 'awaiting-moderation') {
+      return null
     }
 
     const user = info._createdBy
@@ -81,7 +91,7 @@ export const notifyNewEvent = functions.firestore
   .onWrite((change, context) => {
     const info = change.after.exists ? change.after.data() : null
     if (info === null || info.moderation !== 'awaiting-moderation') {
-      return
+      return null
     }
 
     const user = info._createdBy

--- a/functions/src/Integrations/firebase-slack.ts
+++ b/functions/src/Integrations/firebase-slack.ts
@@ -18,6 +18,7 @@ export const notifyNewPin = functions.firestore
     }
     if (prevModeration === 'accepted' && info.moderation === 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
       return change.after.ref.set({
+        previouslyAccepted: true,
         moderation: 'accepted'
       }, {merge: true});
     }
@@ -57,6 +58,7 @@ export const notifyNewHowTo = functions.firestore
     }
     if (prevModeration === 'accepted' && info.moderation === 'awaiting-moderation'){ // If edited after being accepted keep it accepted and avoid message #1008
       return change.after.ref.set({
+        previouslyAccepted: true,
         moderation: 'accepted'
       }, {merge: true});
     }


### PR DESCRIPTION
There was a mistake in 252df324af4ff4fb40ccbc119f6084887f9cbb4b, firebase syntax was used instead of firestore.

Avoid notification when user edits pin or howto and it was previuosly accepted.

Notification will be triggered if user reverts to draft and then try to publish after being accepted.

Note: will trigger disscord message, maybe we could add field in DB to know it has been accepted before.... Would it brake frontend??

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [ ] - Passes Tests

## Description

_What this PR does_

## Git Issues

_Closes #1008

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
