### PR TITLE
Fix rotation of arrow icon for HowTo descriptions

### DIFF
--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -71,7 +71,11 @@ export default class HowtoDescription extends React.PureComponent<IProps, any> {
               <Button variant="subtle" fontSize="14px" data-cy="go-back">
                 <Flex>
                   <Image
-                    sx={{ width: '10px', marginRight: '4px', rotate: '90deg' }}
+                    sx={{
+                      width: '10px',
+                      marginRight: '4px',
+                      transform: 'rotate(90deg)',
+                    }}
                     src={ArrowIcon}
                   />
                   <Text>Back</Text>


### PR DESCRIPTION
PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [x] - Passes Tests

## Description

Replace the CSS rotate with transform: rotate(...) to support every browser.

## Git Issues

Closes #1042