### PR TITLE
Fix flexbox cross-browser issue for step images

### DIFF
--- a/src/pages/Howto/Content/Howto/Step/Step.tsx
+++ b/src/pages/Howto/Content/Howto/Step/Step.tsx
@@ -65,9 +65,10 @@ export default class Step extends React.PureComponent<IProps> {
                 </Text>
               </Box>
             </Flex>
-            <Flex width={[1, 1, 5 / 9]}>
+            <Box width={[1, 1, 5 / 9]}>
               {step.videoUrl ? (
                 <ReactPlayer
+                  width="auto"
                   data-cy="video-embed"
                   controls
                   url={step.videoUrl}
@@ -75,7 +76,7 @@ export default class Step extends React.PureComponent<IProps> {
               ) : (
                 <ImageGallery images={step.images as IUploadedFileMeta[]} />
               )}
-            </Flex>
+            </Box>
           </Flex>
         </Flex>
       </>


### PR DESCRIPTION
PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)
- [x] - Passes Tests

## Description

This replaces an unnecessary Flex Wrapper with a normal Box component. This way there is no different behavior cross browsers for the width of the flex items.

## Git Issues

Closes #1054
