### PR TITLE
Add useful button tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-select": "^2.4.3",
     "react-slick": "^0.25.2",
     "react-table": "^6.10.3",
+    "react-tooltip": "^4.2.13",
     "react-virtualized": "^9.21.2",
     "rebass": "4.0.6",
     "rxjs": "^6.6.3",

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactTooltip from 'react-tooltip'
+import styled from 'styled-components'
+
+const StyledTooltip = styled(ReactTooltip)`
+  opacity: 1 !important;
+  z-index: 9999 !important;
+`
+
+const Tooltip: React.FC = props => {
+  return (
+    <StyledTooltip
+      event="mouseenter focus"
+      eventOff="mouseleave blur"
+      effect="solid"
+      {...props}
+    />
+  )
+}
+
+export default Tooltip

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -18,8 +18,8 @@ import { isAllowToEditContent, emStringToPx } from 'src/utils/helpers'
 import theme from 'src/themes/styled.theme'
 import ArrowIcon from 'src/assets/icons/icon-arrow-select.svg'
 import { FlagIconHowTos } from 'src/components/Icons/FlagIcon/FlagIcon'
-import ReactTooltip from 'react-tooltip'
-import styled from 'styled-components'
+import Tooltip from 'src/components/Tooltip'
+import { useHistory } from 'react-router'
 
 interface IProps {
   howto: IHowtoDB
@@ -31,10 +31,6 @@ interface IProps {
   onUsefulClick: () => void
 }
 
-const StyledTooltip = styled(ReactTooltip)`
-  opacity: 1 !important;
-`
-
 const UsefulWrapper = ({
   isLoggedIn,
   onClick,
@@ -43,29 +39,25 @@ const UsefulWrapper = ({
   isLoggedIn: boolean
   onClick: () => void
   children: React.ReactChild
-}) => (
-  <>
-    <Button
-      data-tip={
-        isLoggedIn ? undefined : 'You must be logged in to mark as useful.'
-      }
-      variant="subtle"
-      fontSize="14px"
-      onClick={isLoggedIn ? onClick : undefined}
-      ml="8px"
-      backgroundColor="#f5ede2"
-    >
-      {children}
-    </Button>
-    {!isLoggedIn && (
-      <StyledTooltip
-        event="click focus"
-        eventOff="mouseleave blur"
-        effect="solid"
-      />
-    )}
-  </>
-)
+}) => {
+  const history = useHistory()
+
+  return (
+    <>
+      <Button
+        data-tip={isLoggedIn ? undefined : 'log in to use this'}
+        variant="subtle"
+        fontSize="14px"
+        onClick={isLoggedIn ? onClick : () => history.push('/sign-in')}
+        ml="8px"
+        backgroundColor="#f5ede2"
+      >
+        {children}
+      </Button>
+      {!isLoggedIn && <Tooltip />}
+    </>
+  )
+}
 
 export default class HowtoDescription extends React.PureComponent<IProps, any> {
   // eslint-disable-next-line

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -18,6 +18,8 @@ import { isAllowToEditContent, emStringToPx } from 'src/utils/helpers'
 import theme from 'src/themes/styled.theme'
 import ArrowIcon from 'src/assets/icons/icon-arrow-select.svg'
 import { FlagIconHowTos } from 'src/components/Icons/FlagIcon/FlagIcon'
+import ReactTooltip from 'react-tooltip'
+import styled from 'styled-components'
 
 interface IProps {
   howto: IHowtoDB
@@ -29,6 +31,10 @@ interface IProps {
   onUsefulClick: () => void
 }
 
+const StyledTooltip = styled(ReactTooltip)`
+  opacity: 1 !important;
+`
+
 const UsefulWrapper = ({
   isLoggedIn,
   onClick,
@@ -37,31 +43,29 @@ const UsefulWrapper = ({
   isLoggedIn: boolean
   onClick: () => void
   children: React.ReactChild
-}) =>
-  isLoggedIn ? (
+}) => (
+  <>
     <Button
+      data-tip={
+        isLoggedIn ? undefined : 'You must be logged in to mark as useful.'
+      }
       variant="subtle"
       fontSize="14px"
-      onClick={onClick}
+      onClick={isLoggedIn ? onClick : undefined}
       ml="8px"
       backgroundColor="#f5ede2"
     >
       {children}
     </Button>
-  ) : (
-    <Box
-      variant="subtle"
-      p={[15, 10]}
-      sx={{ borderRadius: '5px' }}
-      display="inline-block"
-      fontSize="14px"
-      ml="8px"
-      backgroundColor="#f5ede2"
-      title="You must be logged in to vote"
-    >
-      {children}
-    </Box>
-  )
+    {!isLoggedIn && (
+      <StyledTooltip
+        event="click focus"
+        eventOff="mouseleave blur"
+        effect="solid"
+      />
+    )}
+  </>
+)
 
 export default class HowtoDescription extends React.PureComponent<IProps, any> {
   // eslint-disable-next-line

--- a/yarn.lock
+++ b/yarn.lock
@@ -14666,6 +14666,14 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
+react-tooltip@^4.2.13:
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.13.tgz#908db8a41dc10ae2ae9cc1864746cde939aaab0f"
+  integrity sha512-iAZ02wSxChLWb7Vnu0zeQMyAo/jiGHrwFNILWaR3pCKaFVRjKcv/B6TBI4+Xd66xLXVzLngwJ91Tf5D+mqAqVA==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -17343,6 +17351,11 @@ uuid@^3.0.1, uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)
- [X] - Passes Tests

## Description

_What this PR does_

As discussed on #1096, I am adding a proper tooltip when a not logged in user clicks the `useful` button. I added the [react-tooltip](https://github.com/wwayne/react-tooltip/) library to the project, rather than [react-popper](https://github.com/popperjs/react-popper/), which was suggested by @chrismclarke. The reasoning of the choice is mainly because `react-popper` provides only a usePopper hook that works with the use of the `ref` attribute, which was not clear to me in this case. Apart from that, it has more stars on GitHub and a smoother API for React development overall.

The tooltip is triggered with a `click` or `focus` event, and hidden with a `mouseleave` or `blur` event. Find a demo below.

## Git Issues

_Closes #1096_

## Screenshots/Videos

![tooltip-demo](https://user-images.githubusercontent.com/45438149/106689068-21294600-65ae-11eb-8b46-5cf825b077fd.gif)