### PR TITLE
Add how-to client side searching

### DIFF
--- a/cypress/integration/howto/read.spec.ts
+++ b/cypress/integration/howto/read.spec.ts
@@ -42,9 +42,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=create]')
         .click()
         .url()
-        
     })
-   
   })
 
   describe('[Filter with Tag]', () => {
@@ -68,6 +66,7 @@ describe('[How To]', () => {
       cy.step('Type and select a tag')
       cy.get('.data-cy__input')
         .get('input')
+        .first()
         .type('injec')
       cy.get('.data-cy__menu')
         .contains('injection')

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "final-form-arrays": "^3.0.1",
     "final-form-calculate": "^1.3.1",
     "firebase": "^8.2.0",
+    "fuse.js": "^6.4.6",
     "is-url": "^1.2.4",
     "leaflet": "^1.5.1",
     "leaflet.markercluster": "^1.4.1",

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -6,7 +6,7 @@ export const logToSentry = {
   event: Sentry.captureEvent,
   exception: Sentry.captureException,
 }
-const Level = Sentry.Severity
+
 export const initErrorHandler = () => {
   const { location } = window
   if (

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Input } from '../Form/elements'
+
+interface IProps {
+  placeholder: string
+  onChange: (value: string) => void
+}
+
+const style = {
+  background: 'white',
+  fontFamily: 'Varela Round',
+  fontSize: '14px',
+  border: '2px solid black',
+  height: '44px',
+  display: 'flex',
+  marginBottom: 0,
+}
+
+const SearchInput: React.FC<IProps> = ({ placeholder, onChange, ...props }) => {
+  return (
+    <Input
+      placeholder={placeholder}
+      onChange={e => onChange(e.target.value)}
+      style={style}
+      {...props}
+    />
+  )
+}
+
+export default SearchInput

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { Provider, MobXProviderContext } from 'mobx-react'
+import { Provider } from 'mobx-react'
 
 import { ThemeProvider } from 'styled-components'
 import styledTheme from 'src/themes/styled.theme'

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -12,6 +12,7 @@ import HowToCard from 'src/components/HowToCard/HowToCard'
 import Heading from 'src/components/Heading'
 import { Loader } from 'src/components/Loader'
 import { VirtualizedFlex } from 'src/components/VirtualizedFlex/VirtualizedFlex'
+import SearchInput from 'src/components/SearchInput'
 
 interface InjectedProps {
   howtoStore?: HowtoStore
@@ -42,6 +43,7 @@ export class HowtoList extends React.Component<any, IState> {
 
   public render() {
     const { filteredHowtos, selectedTags } = this.props.howtoStore
+
     return (
       <>
         <Flex py={26}>
@@ -61,6 +63,12 @@ export class HowtoList extends React.Component<any, IState> {
               styleVariant="filter"
               placeholder="Filter by tags"
               relevantTagsItems={filteredHowtos}
+            />
+          </Flex>
+          <Flex ml={[0, 0, '8px']} mr={[0, 0, 'auto']} mb={['10px', '10px', 0]}>
+            <SearchInput
+              placeholder="Search for a how-to"
+              onChange={value => this.props.howtoStore.updateSearchValue(value)}
             />
           </Flex>
           <Flex justifyContent={['flex-end', 'flex-end', 'auto']}>

--- a/src/pages/Research/Content/ResearchItemDetail.tsx
+++ b/src/pages/Research/Content/ResearchItemDetail.tsx
@@ -11,7 +11,7 @@ export const ResearchItemDetail = (props: IProps) => {
   React.useEffect(() => {
     const { slug } = props
     store.setActiveResearchItem(slug)
-  }, [])
+  }, [props, store])
   const item = store.activeResearchItem
   return item ? (
     <>

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -20,8 +20,9 @@ import { hasAdminRights, needsModeration } from 'src/utils/helpers'
 const COLLECTION_NAME = 'howtos'
 const HOWTO_SEARCH_WEIGHTS = [
   { name: 'title', weight: 0.5 },
-  { name: 'description', weight: 0.3 },
-  { name: 'steps.title', weight: 0.15 },
+  { name: 'description', weight: 0.2 },
+  { name: '_createdBy', weight: 0.15 },
+  { name: 'steps.title', weight: 0.1 },
   { name: 'steps.text', weight: 0.05 },
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8387,6 +8387,11 @@ fuse.js@^3.4.6:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
   integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 fuzzy-match-utils@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/fuzzy-match-utils/-/fuzzy-match-utils-1.3.0.tgz#7debe2d6dab1dfde3d9526402c3e6b03fc1684f0"


### PR DESCRIPTION
PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)
- [X] - Passes Tests

## Description

As suggested on #1088, adding client-side searching for how-tos using [Fuse](https://github.com/krisk/Fuse/). I added a `SearchInput` component that only renders the search field, and I did the searching logic on the howto store. After filtering the howtos by tags, if there is something typed in the search field the function will perform a Fuse search and return the search-sorted howtos.

On the first commit I also removed some warnings React was throwing for no apparent reason, screenshot below.

Also, I updated an integration test which was selecting the how-to tag selector by the input tag. It now selects the first input, as there are now two.

Note on Fuse - the current weights for the how-to search are:
```
0.5 - Title
0.3 - Description
0.15 - Steps titles
0.05 - Steps descriptions
```
although it looks pretty fast, adding the steps to the search significantly increased the search time, I think it is worth trying a few options and maybe consider not using the steps for now.

## Git Issues

_Closes #1088_

## Screenshots/Videos

![demo](https://user-images.githubusercontent.com/45438149/107069467-c6b40380-67c0-11eb-8e34-c0bb64d73f54.gif)
Demo

<img width="712" alt="react-warnings" src="https://user-images.githubusercontent.com/45438149/107069618-f82ccf00-67c0-11eb-85c8-f0ad1a3249b5.png">
Warnings
