### PR TITLE
Add query params updating on search howtos

### DIFF
--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -4,6 +4,7 @@ import { Input } from '../Form/elements'
 interface IProps {
   placeholder: string
   onChange: (value: string) => void
+  value?: string
 }
 
 const style = {
@@ -16,10 +17,16 @@ const style = {
   marginBottom: 0,
 }
 
-const SearchInput: React.FC<IProps> = ({ placeholder, onChange, ...props }) => {
+const SearchInput: React.FC<IProps> = ({
+  placeholder,
+  onChange,
+  value,
+  ...props
+}) => {
   return (
     <Input
       placeholder={placeholder}
+      value={value}
       onChange={e => onChange(e.target.value)}
       style={style}
       {...props}

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -74,7 +74,7 @@ export class HowtoList extends React.Component<any, IState> {
   }
 
   public render() {
-    const { filteredHowtos, selectedTags } = this.props.howtoStore
+    const { filteredHowtos, selectedTags, searchValue } = this.props.howtoStore
 
     return (
       <>
@@ -107,7 +107,7 @@ export class HowtoList extends React.Component<any, IState> {
           </Flex>
           <Flex ml={[0, 0, '8px']} mr={[0, 0, 'auto']} mb={['10px', '10px', 0]}>
             <SearchInput
-              value={this.props.howtoStore.searchValue}
+              value={searchValue}
               placeholder="Search for a how-to"
               onChange={value => {
                 updateQueryParams(window.location.href, 'search', value)
@@ -136,7 +136,8 @@ export class HowtoList extends React.Component<any, IState> {
           {filteredHowtos.length === 0 ? (
             <Flex>
               <Heading auxiliary txtcenter width={1}>
-                {Object.keys(selectedTags).length === 0 ? (
+                {Object.keys(selectedTags).length === 0 &&
+                searchValue.length === 0 ? (
                   <Loader />
                 ) : (
                   'No how-tos to show'

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -49,6 +49,7 @@ export class HowtoStore extends ModuleStore {
       this.allHowtos = docs.sort((a, b) => (a._created < b._created ? 1 : -1))
     })
     this.selectedTags = {}
+    this.searchValue = ''
   }
 
   @action


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)
- [X] - Passes Tests

## Description

As discussed in #1100, adding the feature to update the URL query string when the search field is altered. I also implemented the same logic for tags selecting. Everything was done using the JavaScript URL API, so mapping spaces and special characters to encoded values is already working by default. 

Note: as tags are identified by the unique ID, the URL gets a little noisy with the params. If you guys think this is not desirable, I can revert this part.

## Git Issues

_Closes #1100_

## Screenshots/Videos

![1100-search-url](https://user-images.githubusercontent.com/45438149/107441480-0dcd2c00-6b14-11eb-825c-97aed8b7bb63.gif)
(Demo is a bit slow cuz of my machine)
