### PR TITLE
Fix user last active updating

### DIFF
--- a/functions/src/userUpdates/backupUser.ts
+++ b/functions/src/userUpdates/backupUser.ts
@@ -1,4 +1,21 @@
-import { DBDoc, IDBDocChange } from '../models'
+import { IDBDocChange } from '../models'
+import { IUserDB } from 'src/models/user.models'
+
+/** Helper function to check if the only field changed is lastActive
+ * (updates on login), in which case we will not want
+ * to backup the user again.
+ */
+const hasUserDataUpdated = (
+  prevUser: IUserDB,
+  updatedUser: IUserDB,
+): boolean => {
+  return Object.keys(prevUser).some(
+    key =>
+      key !== '_modified' &&
+      key !== '_lastActive' &&
+      prevUser[key] !== updatedUser[key],
+  )
+}
 
 /**
  * Automatically create user revision on update
@@ -7,8 +24,9 @@ import { DBDoc, IDBDocChange } from '../models'
  */
 export const backupUser = (change: IDBDocChange) => {
   const { before, after } = change
-  const rev = before.data() as DBDoc
-  if (rev && rev._modified) {
+  const rev = before.data() as IUserDB
+  const updated = after.data() as IUserDB
+  if (rev && rev._modified && hasUserDataUpdated(rev, updated)) {
     return before.ref
       .collection('revisions')
       .doc(rev._modified)

--- a/functions/src/userUpdates/backupUser.ts
+++ b/functions/src/userUpdates/backupUser.ts
@@ -1,14 +1,10 @@
-import { IDBDocChange } from '../models'
-import { IUserDB } from 'src/models/user.models'
+import { DBDoc, IDBDocChange } from '../models'
 
 /** Helper function to check if the only field changed is lastActive
  * (updates on login), in which case we will not want
  * to backup the user again.
  */
-const hasUserDataUpdated = (
-  prevUser: IUserDB,
-  updatedUser: IUserDB,
-): boolean => {
+const hasUserDataUpdated = (prevUser: DBDoc, updatedUser: DBDoc): boolean => {
   return Object.keys(prevUser).some(
     key =>
       key !== '_modified' &&
@@ -24,8 +20,8 @@ const hasUserDataUpdated = (
  */
 export const backupUser = (change: IDBDocChange) => {
   const { before, after } = change
-  const rev = before.data() as IUserDB
-  const updated = after.data() as IUserDB
+  const rev = before.data() as DBDoc
+  const updated = after.data() as DBDoc
   if (rev && rev._modified && hasUserDataUpdated(rev, updated)) {
     return before.ref
       .collection('revisions')

--- a/functions/src/userUpdates/index.ts
+++ b/functions/src/userUpdates/index.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions'
 import { db } from '../Firebase/firestoreDB'
-import { IUserDB, IDBDocChange, DB_ENDPOINTS } from '../models'
+import { DB_ENDPOINTS, IDBDocChange, IUserDB } from '../models'
+import { backupUser } from './backupUser'
 
 /*********************************************************************
  * Side-effects to be carried out on various user updates, namely:
@@ -12,6 +13,7 @@ export const handleUserUpdates = functions.firestore
   .document(`${DB_ENDPOINTS.users}/{id}`)
   .onUpdate(async (change, context) => {
     await processCountryUpdates(change)
+    await backupUser(change)
   })
 
 async function processCountryUpdates(change: IDBDocChange) {

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -82,6 +82,12 @@ export class UserStore extends ModuleStore {
       if (userMeta) {
         this.updateUser(userMeta)
         console.log('userMeta', userMeta)
+
+        // Update last active for user
+        await this.db
+          .collection<IUserPP>(COLLECTION_NAME)
+          .doc(userMeta._id)
+          .set({ ...userMeta, _lastActive: new Date().toISOString() })
       } else {
         // user profile not found, either it has been deleted or not migrated correctly from legacy format
         // create a new profile to use for now and make a log to the error handler in case required


### PR DESCRIPTION
PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)
- [ ] - Passes Tests

## Description

A login now updates the user's last active status to the current time, as discussed in #984. The update is done in the `userSignedIn` method in the store. I tested with a custom pin and the last active info is updating correctly now.
Also, in order to not backup a user every time he logs in, I added a shallow comparator on a previous and updated user, to check if `lastActive` is the only field updated. This hasn't been tested though as I'm not sure how to test the backup function and see the backup data. If the test is desirable I'd be happy to test it, just will need some directions.

## Git Issues

_Closes #984_

## Screenshots/Videos
