### PR TITLE
Research module live, but only for specific users

### DIFF
--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -32,7 +32,11 @@ export const EventCard = (props: IProps) => (
     data-eventId={props.event._id}
   >
     {props.event.moderation !== 'accepted' && (
-      <ModerationStatusText moderable={props.event} kind="event" top={'0px'} />
+      <ModerationStatusText
+        moderatedContent={props.event}
+        contentType="event"
+        top={'0px'}
+      />
     )}
 
     <Flex flexWrap={'wrap'} flex={'1'} mb={[1, 1, 0]} order={[1, 1, 1]}>

--- a/src/components/HowToCard/HowToCard.tsx
+++ b/src/components/HowToCard/HowToCard.tsx
@@ -23,7 +23,11 @@ export const HowToCard = (props: IProps) => (
     sx={{ position: 'relative' }}
   >
     {props.howto.moderation !== 'accepted' && (
-      <ModerationStatusText moderable={props.howto} kind="howto" top={'62%'} />
+      <ModerationStatusText
+        moderatedContent={props.howto}
+        contentType="howto"
+        top={'62%'}
+      />
     )}
     <Link
       to={`/how-to/${encodeURIComponent(props.howto.slug)}`}

--- a/src/components/ModerationStatusText/index.tsx
+++ b/src/components/ModerationStatusText/index.tsx
@@ -1,25 +1,24 @@
 import React, { FunctionComponent } from 'react'
-import { TextProps } from 'rebass'
 import Text from 'src/components/Text'
 import { IModerable } from 'src/models'
 
 type IProps = {
-  moderable: IModerable
-  kind: 'event' | 'howto' | 'research'
+  moderatedContent: IModerable
+  contentType: 'event' | 'howto' | 'research'
   top?: string
   bottom?: string | (string | number)[]
   cropBottomRight?: boolean
-} & TextProps
+}
 
 export const ModerationStatusText: FunctionComponent<IProps> = ({
-  moderable,
-  kind,
+  moderatedContent,
+  contentType,
   top,
   bottom,
   cropBottomRight,
 }) => {
-  let status = moderable.moderation
-  if (kind === 'event') {
+  let status = moderatedContent.moderation
+  if (contentType === 'event') {
     status = 'draft' !== status ? status : 'awaiting-moderation'
   }
 
@@ -30,7 +29,8 @@ export const ModerationStatusText: FunctionComponent<IProps> = ({
       // eslint-disable-next-line
       break
     case 'rejected':
-      text = 'howto' === kind ? 'Needs to improve to be accepted' : 'Rejected'
+      text =
+        'howto' === contentType ? 'Needs to improve to be accepted' : 'Rejected'
       break
     case 'draft':
       text = 'Draft'

--- a/src/components/Research/ResearchListItem.tsx
+++ b/src/components/Research/ResearchListItem.tsx
@@ -64,10 +64,9 @@ const ResearchListItem: React.FC<IProps> = ({ item }) => (
       </Flex>
       {item.moderation !== 'accepted' && (
         <ModerationStatusText
-          moderable={item}
-          kind="research"
+          moderatedContent={item}
+          contentType="research"
           bottom={['36px', '36px', 0]}
-          color="red"
           cropBottomRight
         />
       )}

--- a/src/components/Research/ResearchListItem.tsx
+++ b/src/components/Research/ResearchListItem.tsx
@@ -49,11 +49,7 @@ const ResearchListItem: React.FC<IProps> = ({ item }) => (
           justifyContent="space-between"
           width={[1, 1, 1 / 4]}
         >
-          <Text color="black">
-            {item.updates.length === 1
-              ? item.updates.length + ' update'
-              : item.updates.length + ' updates'}
-          </Text>
+          <Text color="black">{getUpdateText(item)}</Text>
           <Text
             auxiliary
             alignSelf={item.moderation !== 'accepted' ? 'flex-start' : 'center'}
@@ -73,5 +69,11 @@ const ResearchListItem: React.FC<IProps> = ({ item }) => (
     </Link>
   </Flex>
 )
+
+const getUpdateText = (item: IResearch.ItemDB) => {
+  const count = item.updates?.length || 0
+  const text = count === 1 ? 'update' : 'updates'
+  return `${count} ${text}`
+}
 
 export default ResearchListItem

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -64,4 +64,4 @@ interface IUserStats {
 
 export type IUserDB = IUser & DBDoc
 
-export type UserRole = 'super-admin' | 'subscriber' | 'admin'
+export type UserRole = 'super-admin' | 'subscriber' | 'admin' | 'beta-tester'

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -201,7 +201,11 @@ export default class HowtoDescription extends React.PureComponent<IProps> {
             alt="how-to cover"
           />
           {howto.moderation !== 'accepted' && (
-            <ModerationStatusText moderable={howto} kind="howto" top={'0px'} />
+            <ModerationStatusText
+              moderatedContent={howto}
+              contentType="howto"
+              top={'0px'}
+            />
           )}
         </Flex>
       </Flex>

--- a/src/pages/PageList.tsx
+++ b/src/pages/PageList.tsx
@@ -18,6 +18,7 @@ import { Route } from 'react-router'
 import { PrivacyPolicy } from './policy/privacy'
 import { TermsPolicy } from './policy/terms'
 import { ResearchModule } from './Research'
+import { UserRole } from 'src/models/user.models'
 
 export interface IPageMeta {
   path: string
@@ -27,6 +28,7 @@ export interface IPageMeta {
   exact?: boolean
   fullPageWidth?: boolean
   customStyles?: CSSObject
+  requiredRole?: UserRole
 }
 
 const howTo = {
@@ -149,7 +151,7 @@ const termsPolicy = {
 
 // community pages (various pages hidden on production build)
 const devCommunityPages = [howTo, maps, events, academy, ResearchModule]
-const prodCommunityPages = [howTo, maps, events, academy]
+const prodCommunityPages = [howTo, maps, events, academy, ResearchModule]
 const communityPages =
   SITE === 'production' ? prodCommunityPages : devCommunityPages
 // community 'more' dropdown pages (various pages hidden on production build)

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -121,10 +121,9 @@ const ResearchDescription: React.FC<IProps> = ({
       </Flex>
       {research.moderation !== 'accepted' && (
         <ModerationStatusText
-          moderable={research}
-          kind="research"
+          moderatedContent={research}
+          contentType="research"
           bottom={'0'}
-          color="red"
           cropBottomRight
         />
       )}

--- a/src/pages/Research/index.tsx
+++ b/src/pages/Research/index.tsx
@@ -3,6 +3,7 @@ import {
   ResearchStore,
   ResearchStoreContext,
 } from 'src/stores/Research/research.store'
+import { AuthRoute } from '../common/AuthRoute'
 import ResearchRoutes from './research.routes'
 
 /**
@@ -15,6 +16,7 @@ export const ResearchModule = {
   component: <ResearchModuleContainer />,
   title: 'Research',
   description: 'Welcome to research',
+  requiredRole: 'beta-tester',
 }
 
 /**
@@ -23,7 +25,11 @@ export const ResearchModule = {
 function ResearchModuleContainer() {
   return (
     <ResearchStoreContext.Provider value={new ResearchStore()}>
-      <ResearchRoutes />
+      <AuthRoute
+        component={ResearchRoutes}
+        roleRequired="beta-tester"
+        redirectPath="/"
+      />
     </ResearchStoreContext.Provider>
   )
 }

--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -3,6 +3,7 @@ import { withRouter, Switch, Route } from 'react-router'
 import { AuthRoute } from '../common/AuthRoute'
 import { AdminTags } from './content/AdminTags'
 import { AdminUsers } from './content/AdminUsers'
+import { AdminBetaTesters } from './content/AdminBetaTesters'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import { Link } from 'react-router-dom'
 import Text from 'src/components/Text'
@@ -10,6 +11,16 @@ import Flex from 'src/components/Flex'
 import { Box } from 'rebass'
 import { inject, observer } from 'mobx-react'
 import { AdminStore } from 'src/stores/Admin/admin.store'
+
+const ADMIN_ROUTES = [
+  { name: 'Users', slug: 'users', component: AdminUsers },
+  { name: 'Tags', slug: 'tags', component: AdminTags },
+  {
+    name: 'Beta Testers',
+    slug: 'beta-testers',
+    component: AdminBetaTesters,
+  },
+]
 
 interface IProps {}
 interface IInjectedProps extends IProps {
@@ -31,36 +42,34 @@ class AdminPageClass extends React.Component<IProps, any> {
           <Route
             exact
             path="/admin"
-            render={props => (
+            render={() => (
               <>
                 <Text my={3}>
                   NOTE - This content is only viewable by admins
                 </Text>
                 <AuthWrapper roleRequired="admin">
                   <Flex>
-                    <Box bg="white" p={2} m={2}>
-                      <Link to="/admin/users">Users Admin</Link>
-                    </Box>
-                    <Box bg="white" p={2} m={2}>
-                      <Link to="/admin/tags">Tags Admin</Link>
-                    </Box>
+                    {ADMIN_ROUTES.map(route => (
+                      <Box key={route.name} bg="white" p={2} m={2}>
+                        <Link to={`/admin/${route.slug}`}>
+                          {route.name} Admin
+                        </Link>
+                      </Box>
+                    ))}
                   </Flex>
                 </AuthWrapper>
               </>
             )}
           />
-          <AuthRoute
-            path="/admin/tags"
-            component={AdminTags}
-            redirectPath="/admin"
-            roleRequired="admin"
-          />
-          <AuthRoute
-            path="/admin/users"
-            component={AdminUsers}
-            redirectPath="/admin"
-            roleRequired="admin"
-          />
+          {ADMIN_ROUTES.map(route => (
+            <AuthRoute
+              key={route.name}
+              path={`/admin/${route.slug}`}
+              component={route.component}
+              redirectPath="/admin"
+              roleRequired="admin"
+            />
+          ))}
         </Switch>
       </div>
     )

--- a/src/pages/admin/content/AdminBetaTesters.tsx
+++ b/src/pages/admin/content/AdminBetaTesters.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { inject, observer } from 'mobx-react'
+import { Button } from 'src/components/Button'
+import Heading from 'src/components/Heading'
+import { AdminStore } from 'src/stores/Admin/admin.store'
+import { Box } from 'rebass'
+import { Input } from 'src/components/Form/elements'
+import Text from 'src/components/Text'
+import Flex from 'src/components/Flex'
+import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
+
+// we include props from react-final-form fields so it can be used as a custom field component
+interface IProps {
+  adminStore?: AdminStore
+}
+interface IState {
+  userInput?: string
+  errorMsg?: string
+  updating?: boolean
+}
+
+@inject('adminStore')
+@observer
+export class AdminBetaTesters extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props)
+    this.state = { userInput: '' }
+  }
+
+  handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      userInput: e.target.value,
+    })
+  }
+
+  addBetaTester = async () => {
+    const username = this.state.userInput as string
+    this.setState({ errorMsg: undefined, updating: true })
+    try {
+      await this.props.adminStore!.addUserRole(username, 'beta-tester')
+      this.setState({ updating: false, userInput: '' })
+    } catch (error) {
+      this.setState({ errorMsg: error.message })
+    }
+  }
+
+  removeAdmin = async (username: string) => {
+    this.setState({ errorMsg: undefined, updating: true })
+    try {
+      await this.props.adminStore!.removeUserRole(username, 'beta-tester')
+      this.setState({ updating: false })
+    } catch (error) {
+      this.setState({ errorMsg: error.message })
+    }
+  }
+
+  public render() {
+    const { betaTesters } = this.props.adminStore!
+    const disabled = this.state.userInput === '' || this.state.updating
+    return (
+      <Box mt={4}>
+        <Heading>List of Beta Testers</Heading>
+        <Box mb={3} bg={'white'} p={2}>
+          {betaTesters.map(u => (
+            <Flex key={u.userName}>
+              <Text flex={1}>{u.userName}</Text>
+              <AuthWrapper roleRequired="super-admin">
+                <Button
+                  icon="delete"
+                  disabled={this.state.updating}
+                  onClick={() => this.removeAdmin(u.userName)}
+                />
+              </AuthWrapper>
+            </Flex>
+          ))}
+        </Box>
+        <Box mb={3} bg={'white'} p={2}>
+          <Input
+            type="text"
+            placeholder="Username"
+            value={this.state.userInput}
+            onChange={this.handleInputChange}
+          />
+          <Button disabled={disabled} onClick={this.addBetaTester}>
+            Add beta tester
+          </Button>
+          {this.state.errorMsg && (
+            <Text color="red">{this.state.errorMsg}</Text>
+          )}
+        </Box>
+      </Box>
+    )
+  }
+}

--- a/src/pages/common/Header/Menu/MenuDesktop.tsx
+++ b/src/pages/common/Header/Menu/MenuDesktop.tsx
@@ -6,8 +6,10 @@ import { Flex } from 'rebass/styled-components'
 import styled from 'styled-components'
 import MenuCurrent from 'src/assets/images/menu-current.svg'
 import { zIndex } from 'src/themes/styled.theme'
+import { inject, observer } from 'mobx-react'
+import { UserStore } from 'src/stores/User/user.store'
 
-const MenuLink = styled(NavLink).attrs(({ name }) => ({
+const MenuLink = styled(NavLink).attrs(() => ({
   activeClassName: 'current',
 }))`
   padding: 0px ${theme.space[4]}px;
@@ -37,19 +39,37 @@ const MenuLink = styled(NavLink).attrs(({ name }) => ({
     }
   }
 `
+interface IInjectedProps {
+  userStore: UserStore
+}
 
+@inject('userStore')
+@observer
 export class MenuDesktop extends React.Component {
+  get injected() {
+    return this.props as IInjectedProps
+  }
+
   render() {
+    const user = this.injected.userStore.user
+
     return (
       <>
         <Flex alignItems={'center'}>
-          {COMMUNITY_PAGES.map(page => (
-            <Flex key={page.path}>
-              <MenuLink to={page.path} data-cy="page-link">
-                <Flex>{page.title}</Flex>
-              </MenuLink>
-            </Flex>
-          ))}
+          {COMMUNITY_PAGES.map(page => {
+            const link = (
+              <Flex key={page.path}>
+                <MenuLink to={page.path} data-cy="page-link">
+                  <Flex>{page.title}</Flex>
+                </MenuLink>
+              </Flex>
+            )
+            return page.requiredRole
+              ? user && user.userRoles?.includes(page.requiredRole)
+                ? link
+                : null
+              : link
+          })}
         </Flex>
       </>
     )

--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
@@ -7,6 +7,8 @@ import Profile from 'src/pages/common/Header/Menu/Profile/Profile'
 import MenuMobileLink from 'src/pages/common/Header/Menu/MenuMobile/MenuMobileLink'
 import MenuMobileExternalLink from './MenuMobileExternalLink'
 import { BAZAR_URL, GLOBAL_SITE_URL } from 'src/utils/urls'
+import { inject, observer } from 'mobx-react'
+import { UserStore } from 'src/stores/User/user.store'
 
 const PanelContainer = styled(Box)`
   width: 100%;
@@ -40,20 +42,38 @@ export const MenuMobileLinkContainer = styled(Box)`
   border-bottom: 1px solid #ababac;
   margin-top: 5px;
 `
+interface IInjectedProps {
+  userStore: UserStore
+}
 
+@inject('userStore')
+@observer
 export class MenuMobilePanel extends React.Component {
+  get injected() {
+    return this.props as IInjectedProps
+  }
+
   render() {
+    const user = this.injected.userStore.user
+
     return (
       <>
         <PanelContainer>
           <PanelMenu>
-            {COMMUNITY_PAGES.map(page => (
-              <MenuMobileLink
-                path={page.path}
-                content={page.title}
-                key={page.path}
-              />
-            ))}
+            {COMMUNITY_PAGES.map(page => {
+              const link = (
+                <MenuMobileLink
+                  path={page.path}
+                  content={page.title}
+                  key={page.path}
+                />
+              )
+              return page.requiredRole
+                ? user && user.userRoles?.includes(page.requiredRole)
+                  ? link
+                  : null
+                : link
+            })}
             <Profile isMobile={true} />
             <MenuMobileLinkContainer>
               <MenuMobileExternalLink content={'Bazar'} href={BAZAR_URL} />

--- a/src/stores/Admin/admin.store.ts
+++ b/src/stores/Admin/admin.store.ts
@@ -16,6 +16,8 @@ export class AdminStore extends ModuleStore {
   @observable
   public superAdmins: IUser[] = []
   @observable
+  public betaTesters: IUser[] = []
+  @observable
   public tags: ITag[] = []
   // eslint-disable-next-line
   constructor(rootStore: RootStore) {
@@ -30,6 +32,7 @@ export class AdminStore extends ModuleStore {
   public async init() {
     this.admins = await this._getUsersByRole('admin')
     this.superAdmins = await this._getUsersByRole('admin')
+    this.betaTesters = await this._getUsersByRole('beta-tester')
   }
   public async addUserRole(username: string, role: UserRole) {
     const userRef = this.db.collection<IUser>('users').doc(username)


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)
- [X] - Passes Tests

## Description

With this update, the research module page becomes visible in the production site, but only for users that have the `beta-tester` role. I added a `requiredRole` attribute to the `IPageMeta`, so pages using this attribute will have a rendered link in the menu only for users who have the required role.
Also added an admin page to manage beta tester users.

Also, minor changes to clarify prop names from my last PR (https://github.com/ONEARMY/community-platform/pull/1116#discussion_r607033140).

## Git Issues

_Closes #1118_

