### PR TITLE
fix map pin detail

### DIFF
--- a/src/pages/Maps/Content/View/index.tsx
+++ b/src/pages/Maps/Content/View/index.tsx
@@ -64,7 +64,8 @@ class MapView extends React.Component<IProps> {
     }
   }
 
-  private pinClicked(pin: IMapPin) {
+  private async pinClicked(pin: IMapPin) {
+    await this.injected.mapsStore.setActivePin(pin)
     this.props.history.push('/map#' + pin._id)
   }
 

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -129,10 +129,16 @@ export class MapsStore extends ModuleStore {
    * set undefined to remove any active popup
    */
   @action
-  public setActivePin(pin?: IMapPin | IMapPinWithDetail) {
+  public async setActivePin(pin?: IMapPin | IMapPinWithDetail) {
+    // HACK - CC - 2021-07-14 ignore hardcoded pin details, should be retrieved
+    // from profile on open instead (needs cleaning from DB)
+    if (pin && pin.hasOwnProperty('detail')) {
+      delete pin['detail']
+    }
     this.activePin = pin
-    if (pin && !pin.hasOwnProperty('detail')) {
-      return this.getPinDetail(pin)
+    if (pin) {
+      const pinWithDetail = await this.getPinDetail(pin)
+      this.activePin = pinWithDetail
     }
   }
   // call additional action when pin detail received to inform mobx correctly of update
@@ -141,8 +147,7 @@ export class MapsStore extends ModuleStore {
       ? generatePinDetails()
       : await this.getUserProfilePin(pin._id)
     const pinWithDetail: IMapPinWithDetail = { ...pin, detail }
-    console.log('pin details', pinWithDetail)
-    this.setActivePin(pinWithDetail)
+    return pinWithDetail
   }
 
   // get base pin geo information


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

When mappins load they should retrieve details from db (including verified badge), except some legacy mappins already have details hardcoded and so were skipping this step. This PR fixes the behaviour (force always to look at db and ignore hardcoded data), as well as some minor code tidying. 

## Git Issues

Closes #

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/125700817-78e45dc4-067a-43a0-85b7-cd0003f10376.png)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
