### PR TITLE
fix: yarn install script

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5,31 +5,31 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"@algolia/autocomplete-core@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@algolia/autocomplete-core@npm:1.2.1"
+"@algolia/autocomplete-core@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@algolia/autocomplete-core@npm:1.2.2"
   dependencies:
-    "@algolia/autocomplete-shared": 1.2.1
-  checksum: e6cbd814b7a6733214637f6113ebd1d845bfc4b32811da9a8f5cfb72c4aa84084b6ef6073dc1015b577d5a06300fdc4c91d1761fb9fd4419eabf56e0a93b5d5c
+    "@algolia/autocomplete-shared": 1.2.2
+  checksum: f050e4955189ac569b3b2bbbdae97a3df112e6299406d33e50296e9527eedda8ed5ababa38c0aa319b74f35ad484c06ccaa5ac4ad078beb684824942f5ce67b1
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-preset-algolia@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@algolia/autocomplete-preset-algolia@npm:1.2.1"
+"@algolia/autocomplete-preset-algolia@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@algolia/autocomplete-preset-algolia@npm:1.2.2"
   dependencies:
-    "@algolia/autocomplete-shared": 1.2.1
+    "@algolia/autocomplete-shared": 1.2.2
   peerDependencies:
     "@algolia/client-search": ^4.9.1
     algoliasearch: ^4.9.1
-  checksum: 9d03c13651704f67b3347ff18244fe48b10aadaf9c78ba334e065e91499b0a3c4adf67cd5315d8ac1e1685e4cde16db3ed102900170af4c0cbf357bb9f9f25c3
+  checksum: 95437f2a191ea5f14a9f9494278152bfc2449f449a78b5736985192164cfb0a68d6e1e66d18a166f13cdf6a491898822ab9b256a434284b37846af4607284c05
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-shared@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@algolia/autocomplete-shared@npm:1.2.1"
-  checksum: dc875f9e59d5a83b87df055f56f91b0b73d86c60fe869924fc28b7347c104afce996ac9e5742779906af27d32d22f6005b2672836f58994160879b74dadab1e3
+"@algolia/autocomplete-shared@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@algolia/autocomplete-shared@npm:1.2.2"
+  checksum: cc35ab3f03a232e05aa748f2b9abe85204f2214f2d4556aa70224292f5e8efc103c65d477e28e1fcec1d934680c6515913a49a26513b510cd9e0e78dc7872e37
   languageName: node
   linkType: hard
 
@@ -2118,32 +2118,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:3.0.0-alpha.37":
-  version: 3.0.0-alpha.37
-  resolution: "@docsearch/css@npm:3.0.0-alpha.37"
-  checksum: a0c005e4da8903eec42c5cb969a509cb2212cdeb64d18e205d76f1e0eb5c04461b6b81a30ca6e86213e84e12d85259c983ece8e55a454f48514a690dcde4db66
+"@docsearch/css@npm:3.0.0-alpha.40":
+  version: 3.0.0-alpha.40
+  resolution: "@docsearch/css@npm:3.0.0-alpha.40"
+  checksum: 97fb8e72020d69569a90deff7b8600fd6b357798a0e3164eedd433541b502deb16a6d41ba6819ccdb7abd7eeca587809a03ac1eba36695680d27ff9290c0ead7
   languageName: node
   linkType: hard
 
-"@docsearch/react@npm:^3.0.0-alpha.33":
-  version: 3.0.0-alpha.37
-  resolution: "@docsearch/react@npm:3.0.0-alpha.37"
+"@docsearch/react@npm:^3.0.0-alpha.39":
+  version: 3.0.0-alpha.40
+  resolution: "@docsearch/react@npm:3.0.0-alpha.40"
   dependencies:
-    "@algolia/autocomplete-core": 1.2.1
-    "@algolia/autocomplete-preset-algolia": 1.2.1
-    "@docsearch/css": 3.0.0-alpha.37
+    "@algolia/autocomplete-core": 1.2.2
+    "@algolia/autocomplete-preset-algolia": 1.2.2
+    "@docsearch/css": 3.0.0-alpha.40
     algoliasearch: ^4.0.0
   peerDependencies:
     "@types/react": ">= 16.8.0 < 18.0.0"
     react: ">= 16.8.0 < 18.0.0"
     react-dom: ">= 16.8.0 < 18.0.0"
-  checksum: ec847c0bf80ccace0c028b34458b7f93b31d513bdac22fbf9ba72e353f72ca7dbc045acac77daee4296d2364042d008bd76aaadf36e29d6e4707dd17ff09cc07
+  checksum: 8bb42335cd56d4f2eac59838085711c2402ae9dac843220cb5739222b4bc6381fb1db1e2dd7ac4cc3de3f181528dcadf1b356a8c101807a54675aa7bb9157896
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/core@npm:2.0.0-beta.0"
+"@docusaurus/core@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/core@npm:2.0.0-beta.6"
   dependencies:
     "@babel/core": ^7.12.16
     "@babel/generator": ^7.12.15
@@ -2155,47 +2155,49 @@ __metadata:
     "@babel/runtime": ^7.12.5
     "@babel/runtime-corejs3": ^7.12.13
     "@babel/traverse": ^7.12.13
-    "@docusaurus/cssnano-preset": 2.0.0-beta.0
+    "@docusaurus/cssnano-preset": 2.0.0-beta.6
     "@docusaurus/react-loadable": 5.5.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
-    "@endiliey/static-site-generator-webpack-plugin": ^4.0.0
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-common": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
+    "@slorber/static-site-generator-webpack-plugin": ^4.0.0
     "@svgr/webpack": ^5.5.0
     autoprefixer: ^10.2.5
     babel-loader: ^8.2.2
     babel-plugin-dynamic-import-node: 2.3.0
-    boxen: ^5.0.0
-    chalk: ^4.1.0
+    boxen: ^5.0.1
+    chalk: ^4.1.1
     chokidar: ^3.5.1
-    clean-css: ^5.1.1
+    clean-css: ^5.1.5
     commander: ^5.1.0
-    copy-webpack-plugin: ^8.1.0
+    copy-webpack-plugin: ^9.0.0
     core-js: ^3.9.1
     css-loader: ^5.1.1
-    css-minimizer-webpack-plugin: ^2.0.0
-    cssnano: ^5.0.1
+    css-minimizer-webpack-plugin: ^3.0.1
+    cssnano: ^5.0.4
     del: ^6.0.0
     detect-port: ^1.3.0
+    escape-html: ^1.0.3
     eta: ^1.12.1
     express: ^4.17.1
     file-loader: ^6.2.0
-    fs-extra: ^9.1.0
+    fs-extra: ^10.0.0
     github-slugger: ^1.3.0
     globby: ^11.0.2
     html-minifier-terser: ^5.1.1
     html-tags: ^3.1.0
-    html-webpack-plugin: ^5.2.0
+    html-webpack-plugin: ^5.3.2
     import-fresh: ^3.3.0
     is-root: ^2.1.0
     leven: ^3.1.0
     lodash: ^4.17.20
-    mini-css-extract-plugin: ^1.4.0
+    mini-css-extract-plugin: ^1.6.0
     module-alias: ^2.2.2
     nprogress: ^0.2.0
-    postcss: ^8.2.10
-    postcss-loader: ^5.2.0
-    prompts: ^2.4.0
+    postcss: ^8.2.15
+    postcss-loader: ^5.3.0
+    prompts: ^2.4.1
     react-dev-utils: ^11.0.1
     react-error-overlay: ^6.0.9
     react-helmet: ^6.1.0
@@ -2204,110 +2206,115 @@ __metadata:
     react-router: ^5.2.0
     react-router-config: ^5.1.1
     react-router-dom: ^5.2.0
+    remark-admonitions: ^1.2.1
     resolve-pathname: ^3.0.0
-    rtl-detect: ^1.0.2
+    rtl-detect: ^1.0.3
     semver: ^7.3.4
     serve-handler: ^6.1.3
     shelljs: ^0.8.4
     std-env: ^2.2.1
     strip-ansi: ^6.0.0
-    terser-webpack-plugin: ^5.1.1
-    tslib: ^2.1.0
+    terser-webpack-plugin: ^5.1.3
+    tslib: ^2.2.0
     update-notifier: ^5.1.0
     url-loader: ^4.1.1
-    wait-on: ^5.2.1
-    webpack: ^5.28.0
-    webpack-bundle-analyzer: ^4.4.0
+    wait-on: ^5.3.0
+    webpack: ^5.40.0
+    webpack-bundle-analyzer: ^4.4.2
     webpack-dev-server: ^3.11.2
-    webpack-merge: ^5.7.3
+    webpack-merge: ^5.8.0
     webpackbar: ^5.0.0-3
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
   bin:
     docusaurus: bin/docusaurus.js
-  checksum: 39d1e07288e150536a64ae04b5415d9c17b98798617cb6363a7454243e9f2977acf1b8b1ab55779cb0e86cd4dee1e716ee187e418c8561473ec373637cccc72d
+  checksum: 92198f51dfc506e7129289bc34406e5435cf80d51d98e1a9e3d581699b9682f1da87d3b0362d0148d882c9962b28d9e3ebf6fda2af4c94e796645186c6774e0c
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.0"
+"@docusaurus/cssnano-preset@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.6"
   dependencies:
-    cssnano-preset-advanced: ^5.0.0
-    postcss: ^8.2.10
-    postcss-sort-media-queries: ^3.8.9
-  checksum: 398b82fc45acd29c5f7e66fa0c5ec73951e292bd39122edabb8752c4aa1de70777276a708df9d4bef9696001e4a3bca5a59a4e6b4e2ac440fbded7cbcd9cca56
+    cssnano-preset-advanced: ^5.1.1
+    postcss: ^8.2.15
+    postcss-sort-media-queries: ^3.10.11
+  checksum: f789dec53c7b969f16dc0dff73b8e957cdd4e3bf61b84d9e86634a1106cf7d0c2816c966113cb7c718679fb02074ee1ad02ca05df30b076ff9c62f9c05f7e505
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.0"
+"@docusaurus/mdx-loader@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.6"
   dependencies:
     "@babel/parser": ^7.12.16
     "@babel/traverse": ^7.12.13
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
+    chalk: ^4.1.1
     escape-html: ^1.0.3
     file-loader: ^6.2.0
-    fs-extra: ^9.1.0
+    fs-extra: ^10.0.0
     github-slugger: ^1.3.0
-    gray-matter: ^4.0.2
+    gray-matter: ^4.0.3
     mdast-util-to-string: ^2.0.0
     remark-emoji: ^2.1.0
     stringify-object: ^3.3.0
     unist-util-visit: ^2.0.2
     url-loader: ^4.1.1
-    webpack: ^5.28.0
+    webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: b702d8b3f4d92d3113068981af6e686abd0faa88ea46bb68963b62433116613c64a412d08f9e92c1834dfcf64d4e723fe91718925697c12518650f2c5fa31900
+  checksum: 38bbfa6f7f6e1730ae301451f9b0e232ad6152481479029333c8ccd009cd9329d8f0f2f5bb3cb8336215964c90c642092a2ed4984bf85a3f438eba7317a9733e
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.0"
+"@docusaurus/plugin-content-blog@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/mdx-loader": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
-    chalk: ^4.1.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/mdx-loader": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
+    chalk: ^4.1.1
+    escape-string-regexp: ^4.0.0
     feed: ^4.2.2
-    fs-extra: ^9.1.0
+    fs-extra: ^10.0.0
     globby: ^11.0.2
+    js-yaml: ^4.0.0
     loader-utils: ^2.0.0
     lodash: ^4.17.20
     reading-time: ^1.3.0
     remark-admonitions: ^1.2.1
-    tslib: ^2.1.0
-    webpack: ^5.28.0
+    tslib: ^2.2.0
+    webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: eed7187f3773a01ce42dcb2f556b69aa590f5ee55a926b09f6e087cb6d00cd0ab6ecae3a643cd2f0938ee9c0fbf626d1728b0bffa845b3381de43c212c2512d9
+  checksum: ee23d4f1a2a7e63a3f9a93809edb0306145655627780833cbb1c7a0e8e38d2df0ef7980d79f1ca69a81e7c6b534cbed18746c501f60cea153d4d7f63834c4d41
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.0"
+"@docusaurus/plugin-content-docs@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/mdx-loader": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
-    chalk: ^4.1.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/mdx-loader": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
+    chalk: ^4.1.1
     combine-promises: ^1.1.0
+    escape-string-regexp: ^4.0.0
     execa: ^5.0.0
-    fs-extra: ^9.1.0
+    fs-extra: ^10.0.0
     globby: ^11.0.2
     import-fresh: ^3.2.2
     js-yaml: ^4.0.0
@@ -2315,115 +2322,115 @@ __metadata:
     lodash: ^4.17.20
     remark-admonitions: ^1.2.1
     shelljs: ^0.8.4
-    tslib: ^2.1.0
+    tslib: ^2.2.0
     utility-types: ^3.10.0
-    webpack: ^5.28.0
+    webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 5d952efd787036102c6e0cd93fb5f00e08f32e03449649289d904c9faf7b88eb8bde5fd2bab26593a7c7559bf8dac2ef859cae25107199e1d573241f3f97be72
+  checksum: df9cc60a98d235b90084b64d2485223f30c5528bdc42036e1828ed69f6a59e26d4440246536321b3518ca8b15ac2ec6d841430e057c423cb9bc533584091bde4
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.0"
+"@docusaurus/plugin-content-pages@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/mdx-loader": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/mdx-loader": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
     globby: ^11.0.2
     lodash: ^4.17.20
-    minimatch: ^3.0.4
     remark-admonitions: ^1.2.1
-    slash: ^3.0.0
     tslib: ^2.1.0
-    webpack: ^5.28.0
+    webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: ee0d7426622274b45c576d33b46d3d3bc25e0d2876c9c72fe74f8e0ab42f0e32a0d9ee0ded79cb64240e7b7965c266cd3fedc40795004fb72bf044a112b9d6fa
+  checksum: af9e8f9acff46e9ee3a0a28234bc43f98983b3f2977a5d8eaf518b65283fc98e0bd4f0f9d6e4e48eb83d980d44dfda6613f38e826996cbb9ca8ff2cbcbb41d94
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.0"
+"@docusaurus/plugin-debug@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    react-json-view: ^1.21.1
-    tslib: ^2.1.0
-  peerDependencies:
-    react: ^16.8.4 || ^17.0.0
-    react-dom: ^16.8.4 || ^17.0.0
-  checksum: daf4fd1c227d3b20fddb9facee2ca9094e409de409457a6f6ee97f11a20b373d6ceb9d9c4b8ae8a4fd2ed323c0739d2248c0ddcaa70286bb4c14ad9d8b033d53
-  languageName: node
-  linkType: hard
-
-"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.0"
-  dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-  peerDependencies:
-    react: ^16.8.4 || ^17.0.0
-    react-dom: ^16.8.4 || ^17.0.0
-  checksum: 65a729fd6b545891c50a7975fc4603ef494db283277c6bc8545218c0dc719bb229b4aed806d82c748f039da15fd1f1c1d0cb588f5d9047ea009127355cb65817
-  languageName: node
-  linkType: hard
-
-"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.0"
-  dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-  peerDependencies:
-    react: ^16.8.4 || ^17.0.0
-    react-dom: ^16.8.4 || ^17.0.0
-  checksum: 1c4ea81e62ade274b4bb2e9ffba654bae8338857b49ca1152ecec566fd99e0ac2cfd7f4a684fa80524e23a2c4fb809a6dc2bc5dc208a27e5656be0e8971129f4
-  languageName: node
-  linkType: hard
-
-"@docusaurus/plugin-sitemap@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.0"
-  dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
     fs-extra: ^9.1.0
-    sitemap: ^6.3.6
+    react-json-view: ^1.21.3
     tslib: ^2.1.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 79881c60e3f2a7d32f286ad123a57e54eac27d77e59eaa420d0af98f20cf40a283d13ae20ad8524f2db40c7a632d3335175b5e0801e89f9159db8451e33e579b
+  checksum: 2b2784c9ca199b30d0092ece04b0212612886da29b281c488a2d2f625cb9c071c5d2c9520b21c8d521e9705293f85322b0347ebaa5303f6e8096b110e8cd0fd4
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.0"
+"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.0
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.0
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.0
-    "@docusaurus/plugin-debug": 2.0.0-beta.0
-    "@docusaurus/plugin-google-analytics": 2.0.0-beta.0
-    "@docusaurus/plugin-google-gtag": 2.0.0-beta.0
-    "@docusaurus/plugin-sitemap": 2.0.0-beta.0
-    "@docusaurus/theme-classic": 2.0.0-beta.0
-    "@docusaurus/theme-search-algolia": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 89948e95f38969ebbd2d0329f4c26eb927bfc16ef7c759666130ff7b6b476fb929b40e0f4d482c01f836dc314efbd8c17db9940d42dad75d927cdbad97ba88f6
+  checksum: b0937bb5a88e8c899197f7f8235ac9adf28bc82f1fe30568475f0ebc2a9cc1a0a98b9454e3fee51dd1a2e3d2c04ad0244de06949b11e291b795458d47d697870
+  languageName: node
+  linkType: hard
+
+"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.6"
+  dependencies:
+    "@docusaurus/core": 2.0.0-beta.6
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+  checksum: 33bea70ac2896af46d81a8f6b5745ea525970c60da257627326dee3079de40dab5696aa666754f7de894918c58e6cec83301a902491cfe22bcac77e9ea847bdd
+  languageName: node
+  linkType: hard
+
+"@docusaurus/plugin-sitemap@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.6"
+  dependencies:
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-common": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
+    fs-extra: ^10.0.0
+    sitemap: ^7.0.0
+    tslib: ^2.2.0
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+  checksum: 51e143030372868f3a218ca1977b4015af92e7877f1dbe3cfb772325c6d2174c5ff631004a277d88c2ec153b7c534c9347d637c0f8e6b986c7994190c65b79ca
+  languageName: node
+  linkType: hard
+
+"@docusaurus/preset-classic@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.6"
+  dependencies:
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.6
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.6
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.6
+    "@docusaurus/plugin-debug": 2.0.0-beta.6
+    "@docusaurus/plugin-google-analytics": 2.0.0-beta.6
+    "@docusaurus/plugin-google-gtag": 2.0.0-beta.6
+    "@docusaurus/plugin-sitemap": 2.0.0-beta.6
+    "@docusaurus/theme-classic": 2.0.0-beta.6
+    "@docusaurus/theme-search-algolia": 2.0.0-beta.6
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+  checksum: 9cde751de81210937b4f14b72c4700de64938eaa05cc060c0a0964de5c2031e19561d10958ef3292d6dd5977013ecd312a2bbebd8a24493f556805bc334d781c
   languageName: node
   linkType: hard
 
@@ -2438,30 +2445,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.0"
+"@docusaurus/theme-classic@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.0
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.0
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.0
-    "@docusaurus/theme-common": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.6
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.6
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.6
+    "@docusaurus/theme-common": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-common": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.0
+    chalk: ^4.1.1
     clsx: ^1.1.1
-    copy-text-to-clipboard: ^3.0.0
-    fs-extra: ^9.1.0
+    copy-text-to-clipboard: ^3.0.1
+    fs-extra: ^10.0.0
     globby: ^11.0.2
-    infima: 0.2.0-alpha.23
+    infima: 0.2.0-alpha.33
     lodash: ^4.17.20
     parse-numeric-range: ^1.2.0
-    postcss: ^8.2.10
-    prism-react-renderer: ^1.1.1
+    postcss: ^8.2.15
+    prism-react-renderer: ^1.2.1
     prismjs: ^1.23.0
     prop-types: ^15.7.2
     react-router-dom: ^5.2.0
@@ -2469,37 +2477,39 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 62e7a8f3d80afb2de99a08e81d6c94891efa34c68515e49f8a0807b800115d49ce3a96bd5449a13060a15c138d01b2d70f0a0926e31addde30bb1d625e89f715
+  checksum: 6ecb1f6926e3d134b4bc7a5da499b37a6c341cc5a93286953af671d7cc7813e0d7275a93f8cdedef74f1cc0b59c9be5499959c95bf9c024a644ae68dd34588ca
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.0"
+"@docusaurus/theme-common@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.0
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.0
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.0
-    "@docusaurus/types": 2.0.0-beta.0
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.6
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.6
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.6
+    "@docusaurus/types": 2.0.0-beta.6
+    clsx: ^1.1.1
+    fs-extra: ^10.0.0
     tslib: ^2.1.0
   peerDependencies:
-    prism-react-renderer: ^1.1.1
+    prism-react-renderer: ^1.2.1
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 5412163750dd457e157953640d97f3fde359c5415728fc1b327398983e3b0a4c88620a5effb6b805b53b1bc96c2319471b33743f3938dc3c2fab5157d5dfe952
+  checksum: 09a0ff6d5f22c9a41ce9f89981d952204ea0869117c1b9ae68f424b92a4837c2b503304b74899cb5f11dc499aa0cb4d929fd43b6a71c42641ea3f515ed31923e
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.0"
+"@docusaurus/theme-search-algolia@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.6"
   dependencies:
-    "@docsearch/react": ^3.0.0-alpha.33
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/theme-common": 2.0.0-beta.0
-    "@docusaurus/utils": 2.0.0-beta.0
-    "@docusaurus/utils-validation": 2.0.0-beta.0
+    "@docsearch/react": ^3.0.0-alpha.39
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/theme-common": 2.0.0-beta.6
+    "@docusaurus/utils": 2.0.0-beta.6
+    "@docusaurus/utils-validation": 2.0.0-beta.6
     algoliasearch: ^4.8.4
     algoliasearch-helper: ^3.3.4
     clsx: ^1.1.1
@@ -2508,49 +2518,61 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 9627d886315f0923bf1bb80f5e3076c8a0ca781f0b7576b27fd06230dd03a631159b271aa4ec66d04e3819b6ef8c4897b24a8ed62a9b31b847de4fc6a4fcec07
+  checksum: f432e913d45f4b4348a95e1b2e020d20385f15b31ae1b8d035657f5fe76c0078f4953aeee594ab0e1fb67432bcaf97eeb2a49792e5b7db8d7067f868db68c1a3
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/types@npm:2.0.0-beta.0"
+"@docusaurus/types@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/types@npm:2.0.0-beta.6"
   dependencies:
     commander: ^5.1.0
     joi: ^17.4.0
     querystring: 0.2.0
-    webpack: ^5.28.0
-    webpack-merge: ^5.7.3
-  checksum: 5743bcd50a9c8f545f42ea50117ad82bf6a8e821856d6e7ede332daa53a672cd428bced9510128d07088ba99fd880d77cd04b904ae49c0ba385380277d5082d2
+    webpack: ^5.40.0
+    webpack-merge: ^5.8.0
+  checksum: ac1512abd5436c2d455a165e10cc7afbf87b142ea56216fea439a226fd28558b4b2e0ac7d98e1805a6e55df8c956469ac1f1bcf8677be5241119b8a9599e4cf9
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.0"
+"@docusaurus/utils-common@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/utils": 2.0.0-beta.0
-    chalk: ^4.1.0
+    "@docusaurus/types": 2.0.0-beta.6
+    tslib: ^2.2.0
+  checksum: eb161560e07c57275497c0251bc45a4f17f251b41d7c34d6ce9f0a71bf790bb037b9ec7a6e4af1b0c6e12578ebf9003e3f7f486df82009c910b9253dcf22063d
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils-validation@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.6"
+  dependencies:
+    "@docusaurus/utils": 2.0.0-beta.6
+    chalk: ^4.1.1
     joi: ^17.4.0
     tslib: ^2.1.0
-  checksum: da51047fec60d2d357ff48c01b2d3de484a25c9416dd67bcc7abc4dea8b34a2197765bf4cc57ab5cf7df83a7cc210f4996eca909ebc38465fa0d62b3950e58bb
+  checksum: e96f6c568512454adce3878dfe79b1e0eedca9bcc7a1c155cca2a5c79c9bceee62d56f719bb9eaacadf5ca088de27b0a1c659643e096b9278c87d99c6c11c771
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.0"
+"@docusaurus/utils@npm:2.0.0-beta.6":
+  version: 2.0.0-beta.6
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.6"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.0
+    "@docusaurus/types": 2.0.0-beta.6
     "@types/github-slugger": ^1.3.0
-    chalk: ^4.1.0
+    chalk: ^4.1.1
     escape-string-regexp: ^4.0.0
-    fs-extra: ^9.1.0
-    gray-matter: ^4.0.2
+    fs-extra: ^10.0.0
+    globby: ^11.0.4
+    gray-matter: ^4.0.3
     lodash: ^4.17.20
+    micromatch: ^4.0.4
     resolve-pathname: ^3.0.0
-    tslib: ^2.1.0
-  checksum: d5eaf5fa530b15606370f9d56eb32ce4f9e71449490a96dc7c535918c155906ea21c672820713917143a401872b767f97a6cf5358afa30dfc65c595c3c5710a8
+    tslib: ^2.2.0
+  checksum: e7a831da46d37c6816fceeff328b029c6b9b4000411074e4130a51aef5a2049628277d8eac0077b2ba52ac65fcdb83d8ef7105cbdba3652d2a694cc9c4b66e41
   languageName: node
   linkType: hard
 
@@ -2757,19 +2779,6 @@ __metadata:
   version: 0.2.5
   resolution: "@emotion/weak-memoize@npm:0.2.5"
   checksum: 9fe31f0c9d761468d7868be2faf924ddef3506160c72a1979ced8f72cec5d90499403a29c904af570496ef06803e484495f84d4c311bd0787259c89dba4119ed
-  languageName: node
-  linkType: hard
-
-"@endiliey/static-site-generator-webpack-plugin@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@endiliey/static-site-generator-webpack-plugin@npm:4.0.0"
-  dependencies:
-    bluebird: ^3.7.1
-    cheerio: ^0.22.0
-    eval: ^0.1.4
-    url: ^0.11.0
-    webpack-sources: ^1.4.3
-  checksum: 094e9800fe9050ed4ac1ce3617f6e011cab6fb0aebe601d49c8d7e6c2386c498c919920941a37194c5517a9c42d3abcd68753fe8d93e4506b3c6cd3969c7696a
   languageName: node
   linkType: hard
 
@@ -4134,6 +4143,19 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 64458b908773638dda08b555a00e6fbbbc679735348291dc1b7f437ada2f60242537fdc48e4ee82d2573d86984ec87e755b66a96c0ed9ebf0f46b4c6687ccde2
+  languageName: node
+  linkType: hard
+
+"@slorber/static-site-generator-webpack-plugin@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@slorber/static-site-generator-webpack-plugin@npm:4.0.1"
+  dependencies:
+    bluebird: ^3.7.1
+    cheerio: ^0.22.0
+    eval: ^0.1.4
+    url: ^0.11.0
+    webpack-sources: ^1.4.3
+  checksum: 038bd34bae0f551ca70bc8beaca0e7ae4b9d4bdfbc4a2a7832e7b7ad05f371354f046c6cdee9fa6e036ba41dcd761276278ff21741f121da08ca346c30c573a8
   languageName: node
   linkType: hard
 
@@ -6178,7 +6200,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.6":
+"@types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.8":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
   checksum: 3252f0faa7aada7ad27c59bb64ff7bee0c9ad0fb7c21a3b7d255f56c732b94fe94a876f5a5f6fee27a41feac09efac082fad54314c3ce542db02445d7a6059f8
@@ -6301,10 +6323,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^14.0.10, @types/node@npm:^14.14.28, @types/node@npm:^14.14.31":
+"@types/node@npm:^14.0.10, @types/node@npm:^14.14.31":
   version: 14.17.5
   resolution: "@types/node@npm:14.17.5"
   checksum: bd2c9bd617d36fea3b6380f5f7bbf56b59dbfb97ba5ff6d04fdf8ec47402ba4bb4cc902087a7f40d17c91845cc949c811a366679f3421a965e80fbce328a2750
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^15.0.1":
+  version: 15.14.9
+  resolution: "@types/node@npm:15.14.9"
+  checksum: 4ffd4b5f5a6880658fa81b248458c2ac8ed91589df65979e1f4b09edc83c1f8dbe293329bd29e738a808097e7aa1cb61d0fb8f4ffd06c3fa6990b37500737aba
   languageName: node
   linkType: hard
 
@@ -7742,6 +7771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: c944e1229f022a2071f7477ea425964328c577d2c752083fe564ea0513b6d733c9ec65102f6d4d2b54cba0cb2dc969648b60d567abeff13dc95ecc0b9b97737d
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^2.2.1":
   version: 2.2.1
   resolution: "ansi-styles@npm:2.2.1"
@@ -9059,6 +9095,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boxen@npm:^5.0.1":
+  version: 5.1.2
+  resolution: "boxen@npm:5.1.2"
+  dependencies:
+    ansi-align: ^3.0.0
+    camelcase: ^6.2.0
+    chalk: ^4.1.0
+    cli-boxes: ^2.2.1
+    string-width: ^4.2.2
+    type-fest: ^0.20.2
+    widest-line: ^3.1.0
+    wrap-ansi: ^7.0.0
+  checksum: 77582b2494723ceff00463a08997be58e9728884e5bd9d4d7287f33daf255a31669dbe13de5beccc822584909015742bb59067de5e894e41e3b9c8e59ed547fc
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -9685,6 +9737,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^4.1.1":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: ^4.1.0
+    supports-color: ^7.1.0
+  checksum: e3901b97d953991712bf0b941d586175be7ca5da56a97d25187e07453c6b26cae0ac8d9c7aa9e87e7c5c986fff870771b3a8e2705b3becda868829e2e12c2a65
+  languageName: node
+  linkType: hard
+
 "change-emitter@npm:^0.1.2":
   version: 0.1.6
   resolution: "change-emitter@npm:0.1.6"
@@ -9903,12 +9965,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-css@npm:^5.1.1":
-  version: 5.1.3
-  resolution: "clean-css@npm:5.1.3"
+"clean-css@npm:^5.1.5":
+  version: 5.2.1
+  resolution: "clean-css@npm:5.2.1"
   dependencies:
     source-map: ~0.6.0
-  checksum: 07055f71d9370d0290c00c46e3d97404d0c0c2e0c3ef7ed25e600ce86581eb2782dd9c7f1ee27bc78d1cd339fc27691dfd7a6ee732344c6167523579d446bb01
+  checksum: 0d94030bcf04ecc0bd5b25ffcad52744aaa50e9f4d3322b21140d18e4279f7d04f39b216f3efe708b033c1b0b654dbea169a35c87d1bdbd6af037e914d9addbe
   languageName: node
   linkType: hard
 
@@ -10218,6 +10280,13 @@ __metadata:
   version: 2.1.0
   resolution: "colord@npm:2.1.0"
   checksum: f619c5b431bf69ebfd1750f587de6576bfcdc6cf66fce0ea6e6e82bae9b2be5cb30897e3f5436b01164d0f6a03e43ff1c178f11990590d3939e86e2b3006d776
+  languageName: node
+  linkType: hard
+
+"colord@npm:^2.6":
+  version: 2.8.0
+  resolution: "colord@npm:2.8.0"
+  checksum: 3a4d13ae0846e2b37214cd25ebdeba284eb849dafd1369e25a5066930ba996423f42ca949858c8ba5792ea7500e3bc8584c050dff0a41aa60423e7a7e35569e3
   languageName: node
   linkType: hard
 
@@ -10581,7 +10650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-text-to-clipboard@npm:^3.0.0":
+"copy-text-to-clipboard@npm:^3.0.1":
   version: 3.0.1
   resolution: "copy-text-to-clipboard@npm:3.0.1"
   checksum: 6ceb71f65fd7da997100ce22adc8ed4171043a65fbe1b00d11f0c4c241fdab1a7b4b4706c86dfc3f9fba2af50a6890abde63c1b53bb977e0d1d94b9799605f17
@@ -10597,20 +10666,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^8.1.0":
-  version: 8.1.1
-  resolution: "copy-webpack-plugin@npm:8.1.1"
+"copy-webpack-plugin@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "copy-webpack-plugin@npm:9.0.1"
   dependencies:
     fast-glob: ^3.2.5
-    glob-parent: ^5.1.1
+    glob-parent: ^6.0.0
     globby: ^11.0.3
     normalize-path: ^3.0.0
     p-limit: ^3.1.0
     schema-utils: ^3.0.0
-    serialize-javascript: ^5.0.1
+    serialize-javascript: ^6.0.0
   peerDependencies:
     webpack: ^5.1.0
-  checksum: b06d77fa66b83b331831c74a8a2e29a66d79f0ad732dc90e4508e7301c832900fc7ee74a92766526f8853e28dfbab9bc71065b5164f14f373d88152e4a2858c0
+  checksum: 9c5a4694b049be0f16070d53b932d47ccb4e44a8ea3259f7e0883367177a203cf251c369f8ad58277a088c3227b89548abdaa89340b8f50c76627d7413b9fef4
   languageName: node
   linkType: hard
 
@@ -11103,16 +11172,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-minimizer-webpack-plugin@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "css-minimizer-webpack-plugin@npm:2.0.0"
+"css-minimizer-webpack-plugin@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "css-minimizer-webpack-plugin@npm:3.0.2"
   dependencies:
-    cssnano: ^5.0.0
-    jest-worker: ^26.3.0
+    cssnano: ^5.0.6
+    jest-worker: ^27.0.2
     p-limit: ^3.0.2
-    postcss: ^8.2.9
+    postcss: ^8.3.5
     schema-utils: ^3.0.0
-    serialize-javascript: ^5.0.1
+    serialize-javascript: ^6.0.0
     source-map: ^0.6.1
   peerDependencies:
     webpack: ^5.0.0
@@ -11121,7 +11190,7 @@ __metadata:
       optional: true
     csso:
       optional: true
-  checksum: 7a83a1295a3c21d7148857e58e114a9d268212dc381f01bf989c63f16e6fca92e13bb02cb3bb0ec8fb45a03460cd5e1a3d4842832b062a6ca70f27ffb0f4c9ba
+  checksum: 179debffae069fe5ec44be5a0bb8bda0df48f0adae7fde1cbc266f2b28a9d5c5a13d843c22c8682279ac3bd0371bbfe78146cbf5e92538fccb6b662316f6cf2d
   languageName: node
   linkType: hard
 
@@ -11296,19 +11365,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-advanced@npm:^5.0.0":
-  version: 5.1.3
-  resolution: "cssnano-preset-advanced@npm:5.1.3"
+"cssnano-preset-advanced@npm:^5.1.1":
+  version: 5.1.4
+  resolution: "cssnano-preset-advanced@npm:5.1.4"
   dependencies:
     autoprefixer: ^10.2.0
-    cssnano-preset-default: ^5.1.3
+    cssnano-preset-default: ^5.1.4
     postcss-discard-unused: ^5.0.1
     postcss-merge-idents: ^5.0.1
     postcss-reduce-idents: ^5.0.1
     postcss-zindex: ^5.0.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: fac9686e2d2dd7ef30467bf820724fdac018762960482d84a38898ea2ec3f6bb047e400743e3946c566235ec81355e8f9b86d0a2370d4008401dd24edd345044
+  checksum: c54e0fca95d9c61e310ea92fb8d753d9e3a1ffa4efe13349d1092bd0e3a5c1f502a8ca85928562b17159bdf8f6804c9d6069b0e3c97ba0d472b796cdebb683b3
   languageName: node
   linkType: hard
 
@@ -11350,9 +11419,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-default@npm:^5.1.3":
-  version: 5.1.3
-  resolution: "cssnano-preset-default@npm:5.1.3"
+"cssnano-preset-default@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "cssnano-preset-default@npm:5.1.4"
   dependencies:
     css-declaration-sorter: ^6.0.3
     cssnano-utils: ^2.0.1
@@ -11366,7 +11435,7 @@ __metadata:
     postcss-merge-longhand: ^5.0.2
     postcss-merge-rules: ^5.0.2
     postcss-minify-font-values: ^5.0.1
-    postcss-minify-gradients: ^5.0.1
+    postcss-minify-gradients: ^5.0.2
     postcss-minify-params: ^5.0.1
     postcss-minify-selectors: ^5.1.0
     postcss-normalize-charset: ^5.0.1
@@ -11385,7 +11454,7 @@ __metadata:
     postcss-unique-selectors: ^5.0.1
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 81590cb54b12012c175a98d2e8d09b39574083974abae3abb55f67694f9db8b864707b21b16f2db8d89bb48d27375bb0f48449b3551f794f5bf558640d0c1113
+  checksum: 2c3e33496c2832e169070f0ad37226ab53d64274be8419f59fd37e826e2940772fc2789db9d4a07b95b1af4ec124dd010ef1209d1411b696730799bd185e6202
   languageName: node
   linkType: hard
 
@@ -11440,16 +11509,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^5.0.0, cssnano@npm:^5.0.1":
-  version: 5.0.6
-  resolution: "cssnano@npm:5.0.6"
+"cssnano@npm:^5.0.4, cssnano@npm:^5.0.6":
+  version: 5.0.8
+  resolution: "cssnano@npm:5.0.8"
   dependencies:
-    cosmiconfig: ^7.0.0
-    cssnano-preset-default: ^5.1.3
+    cssnano-preset-default: ^5.1.4
     is-resolvable: ^1.1.0
+    lilconfig: ^2.0.3
+    yaml: ^1.10.2
   peerDependencies:
     postcss: ^8.2.15
-  checksum: 086ad98e2c55f2307ab3ca15c584d2ed8924456c3893a755155778bf2203ba5318699fefb4e91e15e6e4c4b38cb364c889e366ca44c95b3a4c9d34c23fedb9a2
+  checksum: 9dfcd57d9f887d986443f6ed55a07b17a4d28e1c288cdfe05f4a2c2065513d94236062e1cb2847c9835db29011828fc6eef2de38b6872fe9d9e94ce97487dd0f
   languageName: node
   linkType: hard
 
@@ -14686,6 +14756,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 84632d143fe3125b8c3c2b1fedbbdfcfb84fc3e087522b4e138cc07edf574619925713a6609f6d5e53ede2e31ab319c7d528ea4a4a770ba6622a16bf4447cd8b
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^5.0.0":
   version: 5.0.0
   resolution: "fs-extra@npm:5.0.0"
@@ -15168,12 +15249,21 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: ^4.0.1
   checksum: 82fcaa4ce102a0ae01370ed8fd5299ca32184af0418e1c1b613ed851240160558c0cc9712868eb9ca1924f687b07cd9c70c25f303f39f9f376d9a32f94f28e76
+  languageName: node
+  linkType: hard
+
+"glob-parent@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: ^4.0.3
+  checksum: 226293dc9d952acbe87d89eb4d87a1901a3eb64d9ec7338a65cb4dc8b337fe129d695e0bd5903b64f70c5044c6c3dfd5736fa18904f1d43d0136a752cb4d988f
   languageName: node
   linkType: hard
 
@@ -15314,7 +15404,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.3":
+"globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.3, globby@npm:^11.0.4":
   version: 11.0.4
   resolution: "globby@npm:11.0.4"
   dependencies:
@@ -15492,7 +15582,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"gray-matter@npm:^4.0.2":
+"gray-matter@npm:^4.0.3":
   version: 4.0.3
   resolution: "gray-matter@npm:4.0.3"
   dependencies:
@@ -16037,7 +16127,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.2.0":
+"html-webpack-plugin@npm:^5.3.2":
   version: 5.3.2
   resolution: "html-webpack-plugin@npm:5.3.2"
   dependencies:
@@ -16491,10 +16581,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.23":
-  version: 0.2.0-alpha.23
-  resolution: "infima@npm:0.2.0-alpha.23"
-  checksum: 01d26aa757fd72c0cfa6ddde2db3082a48c740559075bfa3fa2b403286294f10fb9ca1e16de56844f2a49dfaadee568244cdb8dfdde9656c763e05dc56a9bb41
+"infima@npm:0.2.0-alpha.33":
+  version: 0.2.0-alpha.33
+  resolution: "infima@npm:0.2.0-alpha.33"
+  checksum: 959072e4d25da1b9032d48f7807778da02870341b64c1d4be852b764890254a7fbbb51a57ef362fdee1aeeb9555f9b326a3bd31a61f17c268ccf2596403cf7b8
   languageName: node
   linkType: hard
 
@@ -16816,7 +16906,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-color-stop@npm:^1.0.0, is-color-stop@npm:^1.1.0":
+"is-color-stop@npm:^1.0.0":
   version: 1.1.0
   resolution: "is-color-stop@npm:1.1.0"
   dependencies:
@@ -17017,6 +17107,15 @@ fsevents@^1.2.7:
   dependencies:
     is-extglob: ^2.1.1
   checksum: 98cd4f715f0fb81da34aa6c8be4a5ef02d8cfac3ebc885153012abc2a0410df5a572f9d0393134fcba9192c7a845da96142c5f74a3c02787efe178ed798615e6
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: ^2.1.1
+  checksum: 8f6b4c42b78ece93a17dc6c83cd7e6f104319d6381ab24c8ba5643fcc14bec97dbdf6f8a5739d6333572557cb54e58a41c1edc89ffdb61d0277ec88ca9c3d6e3
   languageName: node
   linkType: hard
 
@@ -18060,7 +18159,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^26.3.0, jest-worker@npm:^26.5.0, jest-worker@npm:^26.6.2":
+"jest-worker@npm:^26.5.0, jest-worker@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
   dependencies:
@@ -18079,6 +18178,17 @@ fsevents@^1.2.7:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 8d7ab8cdf6e66fd676b933f142191158be3541bcdc29c4f839e4b9e03ef755dc8741623645758f75ee23acc98038b28f6e9141e49ec7ffef56c51561f7db06f6
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^27.0.6":
+  version: 27.2.4
+  resolution: "jest-worker@npm:27.2.4"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 38a5f42f2415ce1e021c0c91afcf01f9f630c21af61965209c51b4251887afdf6522d7b64c026f33791ddb3c4781e3ffd1c73ac239bb0de4552c6ba2e03f0f2d
   languageName: node
   linkType: hard
 
@@ -18795,6 +18905,13 @@ fsevents@^1.2.7:
   dependencies:
     immediate: ~3.0.5
   checksum: 6c758fbea382ca251d8f6f32b4066b4c57b4c5d574babc7c6abf7bd20e522a54bcd364dd95d6695103b189a005fcaf9e55d7c58a6c243d4ebdd0cc803898c8bd
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "lilconfig@npm:2.0.3"
+  checksum: c792addea06835943362dc3d7fccedbd256202ec4a1f424399bd0f3ab8888e0f5c1df9abf6fd6c644fcd87b152b37c6914c1de57146a12862abe9c9c5a0f45fc
   languageName: node
   linkType: hard
 
@@ -20178,7 +20295,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^1.4.0":
+"mini-css-extract-plugin@npm:^1.6.0":
   version: 1.6.2
   resolution: "mini-css-extract-plugin@npm:1.6.2"
   dependencies:
@@ -20534,12 +20651,28 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"nanocolors@npm:^0.2.2":
+  version: 0.2.12
+  resolution: "nanocolors@npm:0.2.12"
+  checksum: 6f66a8cccb3bf419aacc9ec416dc948d4cea10681f6cf19ecfebdf707b593ea53f6dd6d675128c41e0a4164e734e54497beb20ddd00dacd859c4b5cad2a8c60f
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.1.23":
   version: 3.1.23
   resolution: "nanoid@npm:3.1.23"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: e6dea1da5a593ffdc8cf2676d1d02f0626f07a54a5947a7a1f5ff1fd07901b2f53044c285e98b87eb367f016fde285fd8785d54a2dceeab9c3721f4e618f8326
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.1.25":
+  version: 3.1.28
+  resolution: "nanoid@npm:3.1.28"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 615abb31f9b23bc80100adcbb6e2b9dfb98c8d75c2a70b1eaf5d903c130f7e40cd82a05d56eb1f796c35cf544fb5e4b3323d54c2fed204a677968af54568252d
   languageName: node
   linkType: hard
 
@@ -21083,9 +21216,9 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "oa-docs@workspace:packages/documentation"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.0
-    "@docusaurus/preset-classic": 2.0.0-beta.0
-    "@mdx-js/react": ^1.6.21
+    "@docusaurus/core": 2.0.0-beta.6
+    "@docusaurus/preset-classic": 2.0.0-beta.6
+    "@mdx-js/react": ^1.6.22
     clsx: ^1.1.1
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -22703,7 +22836,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-loader@npm:^5.2.0":
+"postcss-loader@npm:^5.3.0":
   version: 5.3.0
   resolution: "postcss-loader@npm:5.3.0"
   dependencies:
@@ -22834,16 +22967,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-minify-gradients@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-minify-gradients@npm:5.0.1"
+"postcss-minify-gradients@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-minify-gradients@npm:5.0.2"
   dependencies:
+    colord: ^2.6
     cssnano-utils: ^2.0.1
-    is-color-stop: ^1.1.0
     postcss-value-parser: ^4.1.0
   peerDependencies:
     postcss: ^8.2.15
-  checksum: b5a401d189dc2720513ec34f63a46389a49dcd0f94d98b351117dd404d00ba0d7f9845151490ac5f5598e832bcfcb760819895dc04e5f3ef18fd39c7a47d8868
+  checksum: 1d518ae8ada6f1a301f0ad5275710a352aec7a57c75958256d6b3239ebb96cbbe5d5628bb90144bdf250ea01cc6f33ab9aefdd46f2980b0f58f2ec6885b244c7
   languageName: node
   linkType: hard
 
@@ -23444,14 +23577,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss-sort-media-queries@npm:^3.8.9":
-  version: 3.11.12
-  resolution: "postcss-sort-media-queries@npm:3.11.12"
+"postcss-sort-media-queries@npm:^3.10.11":
+  version: 3.12.13
+  resolution: "postcss-sort-media-queries@npm:3.12.13"
   dependencies:
-    sort-css-media-queries: 1.5.4
+    sort-css-media-queries: 2.0.4
   peerDependencies:
-    postcss: ^8.3.1
-  checksum: 18e378536f5aef6292e0e790329c135cf3087bb922314e5ff6ab17ede8eb1ea0d169deaaa2335de16887a3a4a6e8d357700b2d15bb4af630d4aa4ad3c84de460
+    postcss: ^8.3.6
+  checksum: df755f302dcd54de62a7fc55f6e123fe432831fdb09efe9e93f0bf1769251bd7aecfa37efdd51ec11f8f6a9289dcf156bd0f472e4f2e024597ceeaab9557c45f
   languageName: node
   linkType: hard
 
@@ -23547,7 +23680,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.0, postcss@npm:^8.2.10, postcss@npm:^8.2.15, postcss@npm:^8.2.4, postcss@npm:^8.2.9":
+"postcss@npm:^8.1.0, postcss@npm:^8.2.15, postcss@npm:^8.2.4":
   version: 8.3.5
   resolution: "postcss@npm:8.3.5"
   dependencies:
@@ -23555,6 +23688,17 @@ fsevents@^1.2.7:
     nanoid: ^3.1.23
     source-map-js: ^0.6.2
   checksum: 87dc16efcf40286fad4ded0a433497ddbc55dfad3d7ddb200ba9c0761ec376280fa2c06a522628583c9284def85894c52bc361cffedf0679f4936370c084a145
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.3.5":
+  version: 8.3.8
+  resolution: "postcss@npm:8.3.8"
+  dependencies:
+    nanocolors: ^0.2.2
+    nanoid: ^3.1.25
+    source-map-js: ^0.6.2
+  checksum: bea4f2f367c803739ca89c6773aa80ecad6480171db7e1ebb211fabe7eaf7ff68b3b4d007e41f84d561344a588d62d1b50b3e46e1f5c368712100df553fc09ca
   languageName: node
   linkType: hard
 
@@ -23705,7 +23849,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prism-react-renderer@npm:^1.1.1":
+"prism-react-renderer@npm:^1.2.1":
   version: 1.2.1
   resolution: "prism-react-renderer@npm:1.2.1"
   peerDependencies:
@@ -23845,7 +23989,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.0.1, prompts@npm:^2.4.0":
+"prompts@npm:^2.0.1, prompts@npm:^2.4.0, prompts@npm:^2.4.1":
   version: 2.4.1
   resolution: "prompts@npm:2.4.1"
   dependencies:
@@ -24673,7 +24817,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-json-view@npm:^1.21.1":
+"react-json-view@npm:^1.21.3":
   version: 1.21.3
   resolution: "react-json-view@npm:1.21.3"
   dependencies:
@@ -26190,7 +26334,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rtl-detect@npm:^1.0.2":
+"rtl-detect@npm:^1.0.3":
   version: 1.0.4
   resolution: "rtl-detect@npm:1.0.4"
   checksum: 63e6b4a1e6ff0e8df91d2c0ed76c2c0626ec35844cc8912f80d371dd2e9f1a6f48636ae315fe2e25c6136fe606038894ef9bab3b264cd2769c95ec4198a08f21
@@ -26426,6 +26570,17 @@ resolve@^2.0.0-next.3:
     ajv: ^6.12.5
     ajv-keywords: ^3.5.2
   checksum: 804b78a4d212eff70e072263ef241a5ef5b26684a1a9d2611879bb3fa8497637f3a0e8212053b4bf6e9d7ab8b12a1c98ad0fe8db23497e6a057579db8ded8313
+  languageName: node
+  linkType: hard
+
+"schema-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "schema-utils@npm:3.1.1"
+  dependencies:
+    "@types/json-schema": ^7.0.8
+    ajv: ^6.12.5
+    ajv-keywords: ^3.5.2
+  checksum: c4f4c4c511a07ac7a0be5bf1da60b1756753effc3ff9c1f5153b0238f7e293aa4494466fb436b0a778d63e70e8e6b2cd6ac1d7a1cce176dde6e3f3e3a31d2962
   languageName: node
   linkType: hard
 
@@ -26884,17 +27039,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"sitemap@npm:^6.3.6":
-  version: 6.4.0
-  resolution: "sitemap@npm:6.4.0"
+"sitemap@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "sitemap@npm:7.0.0"
   dependencies:
-    "@types/node": ^14.14.28
+    "@types/node": ^15.0.1
     "@types/sax": ^1.2.1
     arg: ^5.0.0
     sax: ^1.2.4
   bin:
     sitemap: dist/cli.js
-  checksum: e978fe75af2d5db02846156d1bca3e62c5983e534f4e7705054da05df9f98ebde202dbef43d4a96ed118196496e6db153c7101c3c96e01ecf59bda224a039ba5
+  checksum: c3a7169c475d2f9c944eccb102e98ff2f8182c14fc8c8ca319faf74a417ff18a50ab4ad6f8902989ad8bd3d24eb87f6e7dd15a9f9bcd6293135a3fde688acb31
   languageName: node
   linkType: hard
 
@@ -27037,10 +27192,10 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"sort-css-media-queries@npm:1.5.4":
-  version: 1.5.4
-  resolution: "sort-css-media-queries@npm:1.5.4"
-  checksum: d45cfe2578438bdc88dae0aed9f6d6bca98ae62f0bc4ac8e27dd753a75a7676116b97a5b959aad6c2b0bc71f12b8cc8713cdc170bd251b99c0a1c33d663ad75b
+"sort-css-media-queries@npm:2.0.4":
+  version: 2.0.4
+  resolution: "sort-css-media-queries@npm:2.0.4"
+  checksum: 4785c3436ee306bff5f1896dfe069eeeb3ec287bdb8687e7a545aa3595e2329689938ec2e2a1a68093e6fae1447a4eeb7098e685ba1306331ccad030ab836212
   languageName: node
   linkType: hard
 
@@ -27097,6 +27252,16 @@ resolve@^2.0.0-next.3:
     buffer-from: ^1.0.0
     source-map: ^0.6.0
   checksum: 59d4efaae97755155b078413ecba63517e3ef054cc7ab767bbd30e6f3054be2ae8e8f5cce7eef53b7eb93e98fe27a58dd8f5e7abfb13144ba420ddaf5267bbb2
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:~0.5.20":
+  version: 0.5.20
+  resolution: "source-map-support@npm:0.5.20"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 2c5821ee94732b2ddbb1e1d9e61ed76ef00f72415fa686ab96d5f5c711789d55424866fa7d6c493beea380e44418053d86ec490b82c101008eac311463da84a9
   languageName: node
   linkType: hard
 
@@ -27561,6 +27726,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"string-width@npm:^4.2.2":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: 748c97988904505fc6af52ccdf6f354445c714c38d067f22e0cdc6a3ad3d9c5ea29582ef9a6277dc7a813775bb48390ea064b488913239d58601b6d1fcb725b4
+  languageName: node
+  linkType: hard
+
 "string.prototype.matchall@npm:^4.0.0 || ^3.0.1, string.prototype.matchall@npm:^4.0.5":
   version: 4.0.5
   resolution: "string.prototype.matchall@npm:4.0.5"
@@ -27688,6 +27864,15 @@ resolve@^2.0.0-next.3:
   dependencies:
     ansi-regex: ^4.1.0
   checksum: 44a0d0d354f5f7b15f83323879a9112ea746daae7bef0b68238a27626ee757d9a04ce6590433841e14b325e8e7c5d62b8442885e50497e21b7cbca6da40d54ea
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+  checksum: 9d3061240b03abe5beaf403893464fdc924f43664debe822d5e9146b56c1398b88003f8afdb97eb0cea955c568f6bbfa4923d2b2a08a3a079fd09ee3b5402efb
   languageName: node
   linkType: hard
 
@@ -28287,19 +28472,26 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.1":
-  version: 5.1.4
-  resolution: "terser-webpack-plugin@npm:5.1.4"
+"terser-webpack-plugin@npm:^5.1.3":
+  version: 5.2.4
+  resolution: "terser-webpack-plugin@npm:5.2.4"
   dependencies:
-    jest-worker: ^27.0.2
+    jest-worker: ^27.0.6
     p-limit: ^3.1.0
-    schema-utils: ^3.0.0
+    schema-utils: ^3.1.1
     serialize-javascript: ^6.0.0
     source-map: ^0.6.1
-    terser: ^5.7.0
+    terser: ^5.7.2
   peerDependencies:
     webpack: ^5.1.0
-  checksum: dac075a86ddcd4beae294cd9fbbce50532c6a06703a4c114fbc99ac64796503ba75d704106427a05c9371efb15b78e82bc75485f9efc8608ce772654121669f8
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 6ba5e19dcfbb81643d8a4865e841ea0b2ad2e59ab59528fd1617fed3139113a0cee682c65223f9f4176d16cda49076f2430a33fbef132908a4a1b1a6cab4ef77
   languageName: node
   linkType: hard
 
@@ -28316,7 +28508,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.3.4, terser@npm:^5.7.0":
+"terser@npm:^5.3.4":
   version: 5.7.1
   resolution: "terser@npm:5.7.1"
   dependencies:
@@ -28326,6 +28518,19 @@ resolve@^2.0.0-next.3:
   bin:
     terser: bin/terser
   checksum: 0a1ad5f9be4a2a815f14e85d16437dd73116f5d1b5c0623a292c5bcbdf7dc73c93a966063344678a04891d9433dfda055c1e2ad542e1295ad58837526e9fe848
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.7.2":
+  version: 5.9.0
+  resolution: "terser@npm:5.9.0"
+  dependencies:
+    commander: ^2.20.0
+    source-map: ~0.7.2
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: 7603e5a3dc0317cc4b3251e855aa90ef397b03780a1d0d747b20b832d857b50d4c017b1342007f562e20e3e538044daa71e5addd5ab6aad64ee926c5d4b0c88f
   languageName: node
   linkType: hard
 
@@ -29745,7 +29950,7 @@ typescript@4.2.4:
   languageName: node
   linkType: hard
 
-"wait-on@npm:5.3.0, wait-on@npm:^5.2.1":
+"wait-on@npm:5.3.0, wait-on@npm:^5.2.1, wait-on@npm:^5.3.0":
   version: 5.3.0
   resolution: "wait-on@npm:5.3.0"
   dependencies:
@@ -29882,7 +30087,7 @@ typescript@4.2.4:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.4.0":
+"webpack-bundle-analyzer@npm:^4.4.2":
   version: 4.4.2
   resolution: "webpack-bundle-analyzer@npm:4.4.2"
   dependencies:
@@ -30103,7 +30308,7 @@ typescript@4.2.4:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.7.3":
+"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.8.0
   resolution: "webpack-merge@npm:5.8.0"
   dependencies:
@@ -30886,7 +31091,7 @@ typescript@4.2.4:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0, yaml@npm:^1.7.2":
+"yaml@npm:^1.10.0, yaml@npm:^1.10.2, yaml@npm:^1.7.2":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: 8d72062ea3dbfd8fae3d6ddd5b741c2aeb5835a31b0719bf14fac71dd84adde0829763d6fbac46387309da00af1440194c796da5efc349b0baf9de39d82ae69e


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Generate a new yarn lock file as I noticed other PRs raised against this repo fail at dependency install step currently.

Not to sure about the _why_ here, I don't work with Yarn too much currently. From what I understand it looks like the current immutable lock file can not be used (🤯) and instead requires a new lock file to be generated. So I have done just that without any meaningful context on how this will affect things as a _lot_ of dependencies have changed.

Let's see what Circle thinks…


