### PR TITLE
fix: use css mask to make background color dynamic

### DIFF
--- a/src/assets/images/menu-current.svg
+++ b/src/assets/images/menu-current.svg
@@ -1,11 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 213.5 61.9" style="enable-background:new 0 0 213.5 61.9;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FEE77B;}
-</style>
-<path class="st0" d="M1.9,16.8c-2.6,9.9-2.3,20,0.2,25.2s10.5,16.5,26.5,18.8c16,2.3,27.2-0.2,34.8-2C71,56.9,94,52.9,113,54.4
-	s49.5-1.3,61.3-4.3c11.8-3,26.2-6.2,31.2-10.3s9.8-11.7,6.8-18.5s-7.5-17.3-33.2-19.2s-43.3-2.8-63-1.5s-33.8,2.8-38,3.7
-	s-4.3,1.7-15.5,0.5S37.4,0.3,22,1.3S4.5,6.8,1.9,16.8z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 213.5 61.9" style="enable-background:new 0 0 213.5 61.9" xml:space="preserve"><path class="st0" d="M1.9 16.8c-2.6 9.9-2.3 20 .2 25.2s10.5 16.5 26.5 18.8c16 2.3 27.2-.2 34.8-2C71 56.9 94 52.9 113 54.4s49.5-1.3 61.3-4.3c11.8-3 26.2-6.2 31.2-10.3s9.8-11.7 6.8-18.5S204.8 4 179.1 2.1s-43.3-2.8-63-1.5-33.8 2.8-38 3.7-4.3 1.7-15.5.5S37.4.3 22 1.3 4.5 6.8 1.9 16.8z"/></svg>

--- a/src/pages/common/Header/Menu/MenuDesktop.tsx
+++ b/src/pages/common/Header/Menu/MenuDesktop.tsx
@@ -29,12 +29,14 @@ const MenuLink = styled(NavLink).attrs(() => ({
       display: block;
       position: absolute;
       bottom: -6px;
-      background-image: url(${MenuCurrent});
+      background-color: ${theme.colors.yellow.base};
+      mask-size: contain;
+      mask-image: url(${MenuCurrent});
+      mask-repeat: no-repeat;
       z-index: ${zIndex.level};
-      background-repeat: no-repeat;
-      background-size: contain;
       left: 50%;
       transform: translateX(-50%);
+      pointer-events: none;
     }
   }
 `


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Moving towards making the platform easier to re-theme this updates the menu link background to use CSS masks instead of relying on a hardcoded hex value in the SVG. This means that updating the colour value in the theme file will be used as the highlight color. 

## Screenshots/Videos

The attached screenshot demostrates how the menu highlight will now align with the base colour defined within `styled.theme.tsx`

![Screenshot 2021-10-08 at 20 38 29](https://user-images.githubusercontent.com/472589/136609712-7dbb74b4-bed2-45bb-8518-fda78a32b75e.jpg)
