### PR TITLE
fix: adjust ordering of paths so that auth'd routes take precedent

### DIFF
--- a/src/components/Auth/AuthWrapper.tsx
+++ b/src/components/Auth/AuthWrapper.tsx
@@ -31,8 +31,12 @@ export class AuthWrapper extends React.Component<IProps, IState> {
 
     const { roleRequired } = this.props
     let userRoles = user?.userRoles || []
+
     // if running dev or preview site allow user-overridden permissions (ignoring db user role)
-    if (SITE === 'dev_site' || SITE === 'preview') {
+    if (
+      process.env.NODE_ENV !== 'test' &&
+      (SITE === 'dev_site' || SITE === 'preview')
+    ) {
       // default ignore existing user roles
       if (user) {
         userRoles = []

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { FaTrash, FaRegEdit } from 'react-icons/fa'
 import { Flex } from 'rebass/styled-components'
-import { useCommonStores } from 'src'
+import { useCommonStores } from 'src/index'
 import { IComment } from 'src/models'
 import { CommentHeader } from './CommentHeader'
 import { Text } from 'src/components/Text'

--- a/src/components/Comment/CommentTextArea.tsx
+++ b/src/components/Comment/CommentTextArea.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { Box, Text } from 'rebass/styled-components'
 import { Avatar } from '../Avatar'
-import { useCommonStores } from 'src'
+import { useCommonStores } from 'src/index'
 import { Link } from '../Links'
 
 export interface IProps {

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -3,11 +3,11 @@ import Text, { ITextProps } from 'src/components/Text'
 import { HeadingProps as RebassHeadingProps } from 'rebass/styled-components'
 
 export const large = (props: ITextProps) =>
-  props.large ? { fontSize: props.theme.fontSizes[6] } : null
+  props.large ? { fontSize: props.theme?.fontSizes[6] } : null
 export const medium = (props: ITextProps) =>
-  props.medium ? { fontSize: props.theme.fontSizes[5] } : null
+  props.medium ? { fontSize: props.theme?.fontSizes?.[5] } : null
 export const small = (props: ITextProps) =>
-  props.small ? { fontSize: props.theme.fontSizes[4] } : null
+  props.small ? { fontSize: props.theme?.fontSizes[4] } : null
 
 export const BaseHeading = styled(Text)`
     ${large}

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -40,7 +40,7 @@ export class Loader extends Component<IProps> {
   }
 
   render() {
-    const logo = this.injected.themeStore.currentTheme.logo || null
+    const logo = this.injected.themeStore?.currentTheme?.logo || null
     return (
       <>
         <Flex flexWrap="wrap" justifyContent="center">

--- a/src/components/Tags/TagsSelect.tsx
+++ b/src/components/Tags/TagsSelect.tsx
@@ -72,7 +72,7 @@ class TagsSelect extends Component<IProps, IState> {
     return (
       <FieldContainer
         // provide a data attribute that can be used to see if tags populated
-        data-cy={categoryTags.length > 0 ? 'tag-select' : 'tag-select-empty'}
+        data-cy={categoryTags?.length > 0 ? 'tag-select' : 'tag-select-empty'}
       >
         <Select
           components={{ DropdownIndicator }}
@@ -93,7 +93,7 @@ class TagsSelect extends Component<IProps, IState> {
   // as react-select can't keep track of which object key corresponds to the selected
   // value include manual lookup so that value can also be passed from props
   private _getSelected(categoryTags: ITag[]) {
-    return categoryTags.filter(tag => this.state.selectedTags.includes(tag._id))
+    return categoryTags?.filter(tag => this.state.selectedTags.includes(tag._id))
   }
 
   // whilst we deal with arrays of selected tag ids in the component we want to store as a json map

--- a/src/pages/Academy/Academy.tsx
+++ b/src/pages/Academy/Academy.tsx
@@ -1,5 +1,5 @@
 import { Route } from 'react-router'
-import { useCommonStores } from 'src'
+import { useCommonStores } from 'src/index'
 import ExternalEmbed from 'src/components/ExternalEmbed/ExternalEmbed'
 
 export default function Academy() {

--- a/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
+++ b/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Box, Flex } from 'rebass/styled-components'
-import { useCommonStores } from 'src'
+import { useCommonStores } from 'src/index'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import { Button } from 'src/components/Button'
 import { Comment } from 'src/components/Comment/Comment'

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -155,11 +155,11 @@ const ResearchForm = observer((props: IProps) => {
                     >
                       <Heading medium>
                         {props.parentType === 'create' ? (
-                          <span>Start</span>
+                          <span>Start your Research</span>
                         ) : (
-                          <span>Edit</span>
+                          <span>Edit your Research</span>
                         )}{' '}
-                        your Research
+                        
                       </Heading>
                       <Box ml="15px">
                         <ElWithBeforeIcon

--- a/src/pages/Research/Content/Common/Update.form.tsx
+++ b/src/pages/Research/Content/Common/Update.form.tsx
@@ -54,10 +54,10 @@ const UpdateForm = observer((props: IProps) => {
   const [showSubmitModal, setShowSubmitModal] = React.useState<boolean>(false)
 
   React.useEffect(() => {
-    if (store.updateUploadStatus.Complete) {
+    if (store.updateUploadStatus?.Complete) {
       window.removeEventListener('beforeunload', beforeUnload, false)
     }
-  }, [store.updateUploadStatus.Complete])
+  }, [store.updateUploadStatus?.Complete])
 
   const trySubmitForm = () => {
     const form = document.getElementById('updateForm')
@@ -145,11 +145,11 @@ const UpdateForm = observer((props: IProps) => {
                     >
                       <Heading medium>
                         {props.parentType === 'create' ? (
-                          <span>New</span>
+                          <span>New update</span>
                         ) : (
-                          <span>Edit your</span>
+                          <span>Edit your update</span>
                         )}{' '}
-                        update
+                        
                       </Heading>
                       <Box ml="15px">
                         <ElWithBeforeIcon

--- a/src/pages/Research/Content/EditResearch/index.tsx
+++ b/src/pages/Research/Content/EditResearch/index.tsx
@@ -26,7 +26,7 @@ const EditResearch = observer((props: IProps) => {
     formValues: {} as IResearch.ItemDB,
     formSaved: false,
     _toDocsList: false,
-    isLoading: true,
+    isLoading: !store.activeResearchItem,
     loggedInUser: store.activeUser,
   })
 
@@ -63,6 +63,7 @@ const EditResearch = observer((props: IProps) => {
   }, [store, props.match.params.slug])
 
   const { formValues, isLoading, loggedInUser } = state
+
   if (formValues && !isLoading) {
     if (loggedInUser && isAllowToEditContent(formValues, loggedInUser)) {
       return (

--- a/src/pages/Research/Content/EditUpdate/index.tsx
+++ b/src/pages/Research/Content/EditUpdate/index.tsx
@@ -28,7 +28,7 @@ const EditUpdate = observer((props: IProps) => {
     formValues: {} as IResearch.UpdateDB,
     formSaved: false,
     _toDocsList: false,
-    isLoading: true,
+    isLoading: !store.activeResearchItem,
     loggedInUser: store.activeUser,
   })
 
@@ -94,7 +94,7 @@ const EditUpdate = observer((props: IProps) => {
       <Loader />
     ) : (
       <Text txtcenter mt="50px" width={1}>
-        Research not found
+        Research update not found
       </Text>
     )
   }

--- a/src/pages/Research/Content/ResearchItemDetail.tsx
+++ b/src/pages/Research/Content/ResearchItemDetail.tsx
@@ -54,17 +54,18 @@ const ResearchItemDetail = observer((props: IProps) => {
           moderateResearch={moderateResearch}
         />
         <Box my={16}>
-          {item.updates.map((update, index) => {
-            return (
-              <Update
-                update={update}
-                key={update._id}
-                updateIndex={index}
-                isEditable={isEditable}
-                slug={item.slug}
-              />
-            )
-          })}
+          {item &&
+            item?.updates?.map((update, index) => {
+              return (
+                <Update
+                  update={update}
+                  key={update._id}
+                  updateIndex={index}
+                  isEditable={isEditable}
+                  slug={item.slug}
+                />
+              )
+            })}
         </Box>
         {isEditable && (
           <Flex my={4}>

--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -1,0 +1,294 @@
+import ResearchRoutes from './research.routes'
+import { render, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { Provider } from 'mobx-react'
+
+const mockResearchStore: any = {
+  filteredResearches: [],
+  setActiveResearchItem: jest.fn(),
+  needsModeration: jest.fn().mockResolvedValue(true),
+  activeResearchItem: {
+    title: 'Research article title',
+    updates: [],
+    _createdBy: 'jasper',
+  },
+  researchUploadStatus: {},
+  updateUploadStatus: {},
+  activeUser: {
+    name: 'Jaasper',
+    userName: 'jasper',
+    userRoles: ['admin'],
+  },
+}
+
+jest.mock('src/stores/Research/research.store', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  useResearchStore() {
+    return mockResearchStore
+  },
+}))
+
+describe('research.routes', () => {
+  afterEach(cleanup)
+
+  describe('/research/', () => {
+    it('renders the research listing', async () => {
+      const wrapper = render(
+        <Provider userStore={{}}>
+          <MemoryRouter initialEntries={['/research']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+      await waitFor(() =>
+        expect(wrapper.getByText(/Research topic/)).toBeInTheDocument(),
+      )
+    })
+  })
+
+  describe('/research/:slug', () => {
+    it('renders an individual research article', async () => {
+      const wrapper = render(
+        <Provider userStore={{}} themeStore={{}}>
+          <MemoryRouter initialEntries={['/research/research-slug']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(mockResearchStore.setActiveResearchItem).toHaveBeenCalledWith(
+          'research-slug',
+        )
+        expect(wrapper.getByText(/Research article title/)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('/research/create', () => {
+    it('rejects a request without a user present', async () => {
+      const wrapper = render(
+        <Provider userStore={{}} themeStore={{}}>
+          <MemoryRouter initialEntries={['/research/create']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/beta-tester role required to access this page/),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('rejects a logged in user missing required role', async () => {
+      const wrapper = render(
+        <Provider
+          userStore={{
+            user: { name: 'Jaasper' },
+          }}
+          themeStore={{}}
+        >
+          <MemoryRouter initialEntries={['/research/create']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/beta-tester role required to access this page/),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('accepts a logged in user with required role', async () => {
+      const wrapper = render(
+        <Provider
+          userStore={{
+            user: { name: 'Jaasper', userRoles: ['beta-tester'] },
+          }}
+          themeStore={{}}
+          tagsStore={{
+            setTagsCategory: jest.fn(),
+          }}
+        >
+          <MemoryRouter initialEntries={['/research/create']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(wrapper.getByText(/start your research/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('/research/:slug/edit', () => {
+    it('rejects a request without a user present', async () => {
+      const wrapper = render(
+        <Provider userStore={{}} themeStore={{}}>
+          <MemoryRouter initialEntries={['/research/an-example/edit']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/beta-tester role required to access this page/),
+        ).toBeInTheDocument()
+      })
+    })
+    it('accepts a logged in user with required role', async () => {
+      // Using a mock in this instance as testing the
+      // behaviour of the edit form is out of scope. We
+      // are only looking to verify that a user with
+      // correct access rights has the Research.form component
+      // presented to them.
+      jest.doMock('src/pages/Research/Content/Common/Research.form', () => ({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        default(props) {
+          return <div>{props.parentType} your research</div>
+        },
+      }))
+
+      const wrapper = render(
+        <Provider
+          userStore={{
+            user: { name: 'Jaasper', userRoles: ['beta-tester'] },
+          }}
+          themeStore={{}}
+          tagsStore={{
+            setTagsCategory: jest.fn(),
+          }}
+        >
+          <MemoryRouter initialEntries={['/research/an-example/edit']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(wrapper.getByText(/edit your research/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('/research/:slug/new-update', () => {
+    it('rejects a request without a user present', async () => {
+      const wrapper = render(
+        <Provider userStore={{}} themeStore={{}}>
+          <MemoryRouter initialEntries={['/research/an-example/new-update']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/beta-tester role required to access this page/),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('accepts a logged in user with required role', async () => {
+      // Using a mock in this instance as testing the
+      // behaviour of the edit form is out of scope. We
+      // are only looking to verify that a user with
+      // correct access rights has the Research.form component
+      // presented to them.
+      jest.doMock('src/pages/Research/Content/Common/Research.form', () => ({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        default(props) {
+          return <div>{props.parentType} your research</div>
+        },
+      }))
+
+      const wrapper = render(
+        <Provider
+          userStore={{
+            user: { name: 'Jaasper', userRoles: ['beta-tester'] },
+          }}
+          themeStore={{}}
+          tagsStore={{
+            setTagsCategory: jest.fn(),
+          }}
+        >
+          <MemoryRouter initialEntries={['/research/an-example/new-update']}>
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(wrapper.getByText(/new update/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('/research/:slug/edit-update', () => {
+    it('rejects a request without a user present', async () => {
+      const wrapper = render(
+        <Provider userStore={{}} themeStore={{}}>
+          <MemoryRouter
+            initialEntries={[
+              '/research/an-example/edit-update/nested-research-update',
+            ]}
+          >
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/beta-tester role required to access this page/),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('logged in user present', async () => {
+      // Using a mock in this instance as testing the
+      // behaviour of the edit form is out of scope. We
+      // are only looking to verify that a user with
+      // correct access rights has the EditUpdate component
+      // presented to them.
+      jest.doMock('src/pages/Research/Content/EditUpdate/index.tsx', () => ({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        default() {
+          return <div>Edit update within research</div>
+        },
+      }))
+
+      const wrapper = render(
+        <Provider
+          userStore={{
+            user: { name: 'Jaasper', userRoles: ['beta-tester'] },
+          }}
+          themeStore={{}}
+        >
+          <MemoryRouter
+            initialEntries={[
+              '/research/an-example/edit-update/nested-research-update',
+            ]}
+          >
+            <ResearchRoutes />
+          </MemoryRouter>
+        </Provider>,
+      )
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(/Edit update within research/i),
+        ).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/pages/Research/research.routes.tsx
+++ b/src/pages/Research/research.routes.tsx
@@ -17,7 +17,6 @@ const routes = () => (
         component={CreateResearch}
         roleRequired="beta-tester"
       />
-      <Route path="/research/:slug" component={ResearchItemDetail} />
       <AuthRoute
         exact
         path="/research/:slug/new-update"
@@ -36,6 +35,7 @@ const routes = () => (
         component={UpdateItemEditor}
         roleRequired="beta-tester"
       />
+      <Route path="/research/:slug" component={ResearchItemDetail} />
     </Switch>
   </Suspense>
 )

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -7,7 +7,7 @@ import { includesAll } from 'src/utils/filters'
 import { RootStore } from '..'
 import { IConvertedFileMeta } from 'src/components/ImageInput/ImageInput'
 import { IUploadedFileMeta, Storage } from '../storage'
-import { useCommonStores } from 'src'
+import { useCommonStores } from 'src/index'
 import { logger } from 'src/logger'
 
 /**


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes an issue where a user can not edit a Research item, or add an Update to a Research article.

I _think_ it is happening because the paths are being matched from top to bottom, meaning that the `Route` item here is being matched first before the `AuthRoute` wrappers which contains the edit logic.


Steps to recreate:
1. Add new Research item to the site
2. View the new Research item
3. Clicking either the Add Update or Edit button flashes a 404 page before returning to render the Research item