### PR TITLE
fix: regression in background colour

### DIFF
--- a/src/components/ProfileModal/ProfileModal.tsx
+++ b/src/components/ProfileModal/ProfileModal.tsx
@@ -104,7 +104,7 @@ export class ProfileModal extends React.Component<IProps> {
               to={window.location.pathname}
               data-cy="menu-Logout"
             >
-              <Flex color="rgba(27,27,27,0.5)">Log out</Flex>
+              <Flex>Log out</Flex>
             </ModalLink>
           </Flex>
         </ModalContainerInner>

--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
@@ -43,11 +43,11 @@ const MenuLink = styled(NavLink).attrs(() => ({
       display: block;
       position: absolute;
       bottom: -5px;
-      background-position: 50% 70%;
-      background-image: url(${MenuCurrent});
+      background-color: ${theme.colors.yellow.base};
+      mask-size: contain;
+      mask-image: url(${MenuCurrent});
+      mask-repeat: no-repeat;
       z-index: 0;
-      background-repeat: no-repeat;
-      background-size: contain;
       left: 50%;
       transform: translateX(-50%);
     }

--- a/src/pages/common/Header/Menu/Profile/Profile.tsx
+++ b/src/pages/common/Header/Menu/Profile/Profile.tsx
@@ -5,7 +5,6 @@ import { inject, observer } from 'mobx-react'
 import Flex from 'src/components/Flex'
 import { Avatar } from 'src/components/Avatar'
 import { ProfileModal } from 'src/components/ProfileModal/ProfileModal'
-import theme from 'src/themes/styled.theme'
 import MenuMobileLink from 'src/pages/common/Header/Menu/MenuMobile/MenuMobileLink'
 import ProfileButtons from './ProfileButtons'
 import { MenuMobileLinkContainer } from '../MenuMobile/MenuMobilePanel'
@@ -62,7 +61,6 @@ export default class Profile extends Component<IProps, IState> {
               <MenuMobileLink
                 path={window.location.pathname}
                 content={'Log out'}
-                style={{ color: theme.colors.silver }}
                 onClick={() => this.injected.userStore.logout()}
               />
             </MenuMobileLinkContainer>


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A recent change moved the colour definition
out of the SVG into a CSS file using CSS masks. We missed
the usage of the SVG within the mobile navigation.

## Screenshots/Videos

Before:

![The decorative SVG is black making the text illegible](https://user-images.githubusercontent.com/472589/143686406-d0d9dd32-ab54-43d5-b5fc-1f499944423e.jpg)

After: 

![The decorative SVG uses the CSS colour](https://user-images.githubusercontent.com/472589/143686426-bd1dca1e-a4a4-4c35-92b1-066ab8f9cd1e.jpg)
