### PR TITLE
test: reinstate loads of time consuming tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,10 +350,6 @@ workflows:
       # Note - when calling test we also let the test script handle building as it injects random variables for seeding the DB
       - build:
           name: build_test
-          filters: 
-            branches:
-              ignore:
-                - production
           matrix:
             parameters:
               BUILD_ENV: ['FORCE_COLOR=1 REACT_APP_SITE_VARIANT=test-ci']
@@ -363,10 +359,6 @@ workflows:
           name: e2e-<< matrix.CI_BROWSER >>-<< matrix.CI_NODE >>
           requires:
             - 'build_test'
-          filters: 
-            branches:
-              ignore:
-                - production
           matrix:
             parameters:
               CI_NODE: [1, 2]
@@ -402,6 +394,8 @@ workflows:
       - build:
           name: build_production
           context: community-platform-production
+          requires:
+            - 'test_e2e'
           <<: *filter_only_production
       # Require manual approval on CirclCI website prior to release
       - hold:


### PR DESCRIPTION
This reverts the recent changes which removed the e2e from the `production` branch pipelines.