### PR TITLE
chore: fetch version number from git sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,9 +266,12 @@ jobs:
           command: |
             echo 'export REACT_APP_BRANCH=${CIRCLE_BRANCH}' >> $BASH_ENV
             echo 'export NODE_OPTIONS=--max-old-space-size=4096' >> $BASH_ENV
+            echo 'export REACT_APP_PROJECT_VERSION=$(git rev-parse HEAD)'
       - run:
           name: Check environment variables
-          command: echo REACT_APP_BRANCH=$REACT_APP_BRANCH NODE_OPTIONS=$NODE_OPTIONS
+          command: |
+            echo REACT_APP_BRANCH=$REACT_APP_BRANCH NODE_OPTIONS=$NODE_OPTIONS
+            echo $REACT_APP_PROJECT_VERSION
       - run:
           command: << parameters.BUILD_ENV >> npm run build
       - persist_to_workspace:

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -166,7 +166,7 @@ export const SENTRY_CONFIG: ISentryConfig = {
   environment: siteVariant,
 }
 
-export const VERSION = require('../../package.json').version
+export const VERSION = process.env.REACT_APP_PROJECT_VERSION || require('../../package.json').version
 export const GA_TRACKING_ID = process.env.REACT_APP_GA_TRACKING_ID
 
 /*********************************************************************************************** /


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

At the moment the version is taken from the `package.json` version field. This is manually updated during the release process. However we don't want to rely on such a manual process for our development environments, no deployment to a development environment needs to be mapped to a releaseable artefact.

Development environments are intended to represent the HEAD state of our default branch. So instead of using a value that looks like a [semantic version](https://semver.org/), we can load a SHA value which references a specific point in the project history.  

Hovering over the logo will give you something like this instead:

![Screenshot 2021-12-04 at 15 16 12](https://user-images.githubusercontent.com/472589/144712773-d01e3903-2441-4ecb-9793-778c40e9d39e.jpg)


**Note:** This will only affect the development environments and not the production instances. The production instances will continue to use the more familiar `1.6.x` format. 
