### PR TITLE
fix: flex style overriding hidden preference

### DIFF
--- a/src/pages/Maps/Content/Controls/index.tsx
+++ b/src/pages/Maps/Content/Controls/index.tsx
@@ -134,7 +134,7 @@ class Controls extends React.Component<IProps, IState> {
             </Link>
           </Box>
         </Flex>
-        <Flex width="95%" sx={{ display: ['flex', 'none', 'none'], mt: '5px' }}>
+        <Box width="95%" sx={{ display: ['flex', 'none', 'none'], mt: '5px' }}>
           <Button
             width="100%"
             sx={{ display: 'block' }}
@@ -151,7 +151,7 @@ class Controls extends React.Component<IProps, IState> {
               style={{ width: '18px', marginLeft: '5px' }}
             />
           </Button>
-        </Flex>
+        </Box>
         {showFiltersMobile && (
           <Modal onDidDismiss={() => this.handleFilterMobileModal()}>
             <Flex p={0} mx={-1} justifyContent="space-between">


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In the production environment _only_ this
box is incorrectly inheriting the display:flex
property which due to ordering of selectors
in the generated CSS are taking preference
over the media query defined display:none.

This is a guess as I haven't been able to recreate
the behaviour locally.