### PR TITLE
feat: moves external links to theme definition

### DIFF
--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import theme from 'src/themes/styled.theme'
 import styled from 'styled-components'
 import { Box } from 'rebass/styled-components'
 import { NavLink } from 'react-router-dom'
@@ -19,14 +18,14 @@ interface IInjectedProps extends IProps {
 }
 
 const PanelItem = styled(Box)`
-  padding: ${theme.space[3]}px 0px;
+  padding: ${props => props.theme.space[3]}px 0px;
 `
 
 const MenuLink = styled(NavLink).attrs(() => ({
   activeClassName: 'current',
 }))`
-  color: ${'black'};
-  font-size: ${theme.fontSizes[2]}px;
+  color: ${props => props.theme.colors.black};
+  font-size: ${props => props.theme.fontSizes[2]}px;
   position: relative;
   > span {
     z-index: 1;
@@ -43,7 +42,7 @@ const MenuLink = styled(NavLink).attrs(() => ({
       display: block;
       position: absolute;
       bottom: -5px;
-      background-color: ${theme.colors.yellow.base};
+      background-color: ${props => props.theme.colors.yellow.base};
       mask-size: contain;
       mask-image: url(${MenuCurrent});
       mask-repeat: no-repeat;

--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
@@ -6,9 +6,10 @@ import { Box } from 'rebass/styled-components'
 import Profile from 'src/pages/common/Header/Menu/Profile/Profile'
 import MenuMobileLink from 'src/pages/common/Header/Menu/MenuMobile/MenuMobileLink'
 import MenuMobileExternalLink from './MenuMobileExternalLink'
-import { BAZAR_URL, GLOBAL_SITE_URL } from 'src/utils/urls'
 import { AuthWrapper } from 'src/components/Auth/AuthWrapper'
 import { getSupportedModules } from 'src/modules'
+import { inject } from 'mobx-react'
+import { ThemeStore } from 'src/stores/Theme/theme.store'
 
 const PanelContainer = styled(Box)`
   width: 100%;
@@ -43,7 +44,14 @@ export const MenuMobileLinkContainer = styled(Box as any)`
   margin-top: 5px;
 `
 
+@inject('themeStore')
 export class MenuMobilePanel extends Component {
+  injected() {
+    return this.props as {
+      themeStore: ThemeStore
+    }
+  }
+
   render() {
     return (
       <>
@@ -67,11 +75,17 @@ export class MenuMobilePanel extends Component {
             })}
             <Profile isMobile={true} />
             <MenuMobileLinkContainer>
-              <MenuMobileExternalLink content={'Bazar'} href={BAZAR_URL} />
-              <MenuMobileExternalLink
-                content={'Global Site'}
-                href={GLOBAL_SITE_URL}
-              />
+              {this.injected()
+                .themeStore.getExternalNavigationItems()
+                .map((navigationItem, idx) => {
+                  return (
+                    <MenuMobileExternalLink
+                      key={idx}
+                      content={navigationItem.label}
+                      href={navigationItem.url}
+                    />
+                  )
+                })}
             </MenuMobileLinkContainer>
           </PanelMenu>
         </PanelContainer>

--- a/src/stores/Theme/theme.store.tsx
+++ b/src/stores/Theme/theme.store.tsx
@@ -22,4 +22,11 @@ export class ThemeStore {
       this.currentTheme = themeMap[themeId]
     }
   }
+
+  public getExternalNavigationItems():{
+    label: string
+    url: string
+  }[] {
+    return this.currentTheme.externalLinks || [];
+  }
 }

--- a/src/themes/precious-plastic/index.ts
+++ b/src/themes/precious-plastic/index.ts
@@ -8,6 +8,16 @@ const Theme: PlatformTheme = {
   howtoHeading: `Learn & share how to recycle, build and work with plastic`,
   styles,
   academyResource: 'https://onearmy.github.io/academy/',
+  externalLinks: [
+    {
+      url: 'https://bazar.preciousplastic.com/',
+      label: 'Bazar'
+    },
+    {
+      url: 'https://preciousplastic.com/',
+      label: 'Global Site'
+    },
+  ]
 }
 
 export default Theme

--- a/src/themes/project-kamp/index.ts
+++ b/src/themes/project-kamp/index.ts
@@ -8,6 +8,16 @@ const Theme: PlatformTheme = {
   howtoHeading: `Learn & share how to recycle, build and work`,
   styles,
   academyResource: 'https://project-kamp-academy.netlify.app/',
+  externalLinks: [
+    {
+      url: 'https://projectkamp.com/support.html',
+      label: 'Support Us'
+    },
+    {
+      url: 'https://projectkamp.com/',
+      label: 'Project Homepage'
+    }
+  ]
 }
 
 

--- a/src/themes/types.tsx
+++ b/src/themes/types.tsx
@@ -1,7 +1,13 @@
+interface LinkList {
+  label: string
+  url: string
+}
+
 export interface PlatformTheme {
   siteName: string
   logo: string
   howtoHeading: string
   styles: any
   academyResource: string
+  externalLinks: LinkList[]
 }


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Moves the external links out so that they
can be defined at the theme layer.

Attached screen grab demonstrates different navigation items appearing for Project Kamp instance:
![Screenshot 2021-12-18 at 11 39 12](https://user-images.githubusercontent.com/472589/146638120-c904b8b7-cfc1-40b4-9a28-382eb94cc668.jpg)


