### PR TITLE
fix: storybook instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,15 @@ jobs:
           root: .
           paths:
             - build
+  storybook: 
+    docker: *docker
+    resource_class: medium
+    steps:
+      - setup_repo
+      - attach_workspace:
+          at: '.'
+      - run:
+          command: yarn workspace oa-storybook build
   deploy:
     docker: *docker
     resource_class: small
@@ -374,6 +383,12 @@ workflows:
           filters: 
             branches:
               ignore:
+                - production
+      - storybook:
+          name: Build Storybook
+          filters:
+            branches:
+              ignore: 
                 - production
       - test_e2e:
           name: e2e-<< matrix.CI_BROWSER >>-<< matrix.CI_NODE >>

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-nmHoistingLimits: workspaces
+# nmHoistingLimits: workspaces
 
 nodeLinker: node-modules
 

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -20,5 +20,8 @@
     "fs-extra": "^10.0.0",
     "ts-node": "^10.2.1",
     "wait-on": "^6.0.0"
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   }
 }


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Reverts a configuration change to yarn which prevented the [Storybook](https://storybook.js.org/) instance from booting. Originally reported by @kfern in #1308.

Also introduces a Circle CI job which builds the Storybook site. This is a sanity check to prevent us inadvertently breaking it in the future. It may be interesting to publish to a standalone site at some point but that's something that can wait for another PR. 