### PR TITLE
fix: type definitions for tests

### DIFF
--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import ResearchRoutes from './research.routes'
 import { render, waitFor, cleanup } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "experimentalDecorators": true,
-    "typeRoots": ["./node_modules/@types", "./types"],
+    "typeRoots": ["./node_modules/@types", "./types", "@testing-library/jest-dom"],
     "declaration": true,
     "noEmit": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The recently introduced `.toBeInTheDocument` assertation from `@testing-library` caused the type check as part of the functions precompilation to break. 

There are few interesting things here;

* That typecheck includes tests files, there aren't many of them yet, but they shouldn't be scanned as part of this flow.
* This broken change was mergeable into `master` because we do no validation on the functions before we try to deploy them. There is [a PR](https://github.com/ONEARMY/community-platform/pull/1252), which introduces a Circle CI job to validate their correctness. I would need to do some investigation to see if this would have caught the issue. 