### PR TITLE
fix: service worker cache headers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -40,6 +40,15 @@
             "value": "*"
           }
         ]
+      },
+      {
+        "source": "/service-worker.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
PR Checklist

- [X] - Latest `master` branch merged
- [X] - PR title descriptive (can be used in release notes)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Over the last month we've shipped multiple
releases to production, at a far higher
cadence then recent months.

A side effect of this has been observing
multiple "odd" behaviour on the production
deployments which can not be recreated locally.

The primary candidate for causing these issues
is the service worker. The service worker is a
built in component of create react app (CRA).

Interestingly in the CRA documentation when discussing
servic workers they mention:
> they (service workers) can make debugging deployments more challenging.

So as a result I have been hunting out for more information around
other folks encountering this behaviour.

An interesting thread here around the combination of
service workers AND firebase:
https://github.com/facebook/create-react-app/issues/2440#issuecomment-305592301

Potentially related, is all of the _ChunkLoadError_ we are seeing from the production environment. 