### PR TITLE
feat: adds logflare drain

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "mobx-react": "7.2.0",
     "oa-shared": "1.0.0",
     "pino": "^7.2.0",
+    "pino-logflare": "^0.3.12",
     "pubsub-js": "^1.7.0",
     "react": "^17.0.2",
     "react-datepicker": "^2.9.6",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -21,6 +21,8 @@ export const _supportedConfigurationOptions = [
   'REACT_APP_LOG_LEVEL',
   'REACT_APP_SUPPORTED_MODULES',
   'REACT_APP_PLATFORM_THEME',
+  'REACT_APP_LOGFLARE_KEY',
+  'REACT_APP_LOGFLARE_SOURCE',
 ] as const;
 
 export type ConfigurationOption = typeof _supportedConfigurationOptions[number]

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,6 +1,28 @@
 import Logger from 'pino'
+import { createPinoBrowserSend, createWriteStream } from 'pino-logflare'
 import { getConfigirationOption } from 'src/config/config';
 
 const logLevel = getConfigirationOption('REACT_APP_LOG_LEVEL', 'warn');
 
-export const logger = Logger({ browser: { asObject: false }, level: logLevel })
+let loggerInstance;
+
+if (getConfigirationOption('REACT_APP_LOGFLARE_KEY', '')) {
+    const logflareConfiguration = {
+        apiKey: getConfigirationOption('REACT_APP_LOGFLARE_KEY', ''),
+        sourceToken: getConfigirationOption('REACT_APP_LOGFLARE_SOURCE', '')
+    };
+
+    loggerInstance = Logger({
+        browser: {
+            transmit: {
+                send: createPinoBrowserSend(logflareConfiguration)
+            }
+        },
+        level: logLevel
+    }, createWriteStream(logflareConfiguration))
+} else {
+    loggerInstance = Logger({ browser: { asObject: false }, level: logLevel });
+}
+
+
+export const logger = loggerInstance;

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -2,7 +2,7 @@ import Logger from 'pino'
 import { createPinoBrowserSend, createWriteStream } from 'pino-logflare'
 import { getConfigirationOption } from 'src/config/config';
 
-const logLevel = getConfigirationOption('REACT_APP_LOG_LEVEL', 'warn');
+const logLevel = getConfigirationOption('REACT_APP_LOG_LEVEL', 'info');
 
 let loggerInstance;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6461,6 +6461,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4.14.153":
+  version: 4.14.178
+  resolution: "@types/lodash@npm:4.14.178"
+  checksum: a69a04a60bfc5257c3130a554b4efa0c383f0141b7b3db8ab7cf07ad2a46ea085fce66d0242da41da7e5647b133d5dfb2c15add9cbed8d7fef955e4a1e5b3128
+  languageName: node
+  linkType: hard
+
 "@types/lodash@npm:^4.14.165":
   version: 4.14.175
   resolution: "@types/lodash@npm:4.14.175"
@@ -9076,6 +9083,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"batch2@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "batch2@npm:1.0.6"
+  dependencies:
+    through2: ^3.0.1
+  checksum: 761500425da3a61fd45e404535002febc6fbecba335c55e19723a6a5228b42f159d21e6850d847e5b5364521d87eceb1797ae4b72345e04a118d999a194011b3
+  languageName: node
+  linkType: hard
+
 "batch@npm:0.6.1":
   version: 0.6.1
   resolution: "batch@npm:0.6.1"
@@ -9129,6 +9145,13 @@ __metadata:
   version: 1.6.49
   resolution: "big-integer@npm:1.6.49"
   checksum: eba7af17805b9ceeed1560a7acad0be779520636707651c2b59c457cc062f886cc25656e909d8dd9aa97205aab441e694335309e9c9987515b92ae1601d7d78f
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:^1.6.48":
+  version: 1.6.51
+  resolution: "big-integer@npm:1.6.51"
+  checksum: 3d444173d1b2e20747e2c175568bedeebd8315b0637ea95d75fd27830d3b8e8ba36c6af40374f36bdaea7b5de376dcada1b07587cb2a79a928fccdb6e6e3c518
   languageName: node
   linkType: hard
 
@@ -10562,7 +10585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^5.1.0":
+"commander@npm:^5.0.0, commander@npm:^5.1.0":
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
   checksum: 0b7fec1712fbcc6230fcb161d8d73b4730fa91a21dc089515489402ad78810547683f058e2a9835929c212fead1d6a6ade70db28bbb03edbc2829a9ab7d69447
@@ -11963,7 +11986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decimal.js@npm:^10.2.1":
+"decimal.js@npm:^10.2.0, decimal.js@npm:^10.2.1":
   version: 10.3.1
   resolution: "decimal.js@npm:10.3.1"
   checksum: 0351ac9f05fe050f23227aa6a4573bee2d58fa7378fcf28d969a8c789525032effb488a90320fd3fe86a66e17b4bc507d811b15eada5b7f0e7ec5d2af4c24a59
@@ -14075,6 +14098,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-safe-stringify@npm:^2.0.8":
+  version: 2.1.1
+  resolution: "fast-safe-stringify@npm:2.1.1"
+  checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
+  languageName: node
+  linkType: hard
+
 "fast-text-encoding@npm:^1.0.0, fast-text-encoding@npm:^1.0.3":
   version: 1.0.3
   resolution: "fast-text-encoding@npm:1.0.3"
@@ -14615,6 +14645,13 @@ __metadata:
   bin:
     flat: cli.js
   checksum: 12a1536ac746db74881316a181499a78ef953632ddd28050b7a3a43c62ef5462e3357c8c29d76072bb635f147f7a9a1f0c02efef6b4be28f8db62ceb3d5c7f5d
+  languageName: node
+  linkType: hard
+
+"flatstr@npm:^1.0.12":
+  version: 1.0.12
+  resolution: "flatstr@npm:1.0.12"
+  checksum: e1bb562c94b119e958bf37e55738b172b5f8aaae6532b9660ecd877779f8559dbbc89613ba6b29ccc13447e14c59277d41450f785cf75c30df9fce62f459e9a8
   languageName: node
   linkType: hard
 
@@ -16712,7 +16749,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -19607,6 +19644,20 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"logflare-transport-core@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "logflare-transport-core@npm:0.2.5"
+  dependencies:
+    "@types/lodash": ^4.14.153
+    axios: ^0.21.1
+    big-integer: ^1.6.48
+    bignumber.js: ^9.0.0
+    decimal.js: ^10.2.0
+    lodash: ^4.17.15
+  checksum: 5f7a10d3c734bf5b30b87651f84d982a80eb1cb713e35c6b2d879abc6013d190ec28e638b6c8d5593766eab615af253e5ded1e3c72897c806252c21cb91c9dff
+  languageName: node
+  linkType: hard
+
 "logform@npm:^2.2.0":
   version: 2.3.0
   resolution: "logform@npm:2.3.0"
@@ -21432,6 +21483,7 @@ fsevents@^1.2.7:
     mobx-react-devtools: ^6.0.3
     oa-shared: 1.0.0
     pino: ^7.2.0
+    pino-logflare: ^0.3.12
     prettier: ^1.16.4
     pubsub-js: ^1.7.0
     react: ^17.0.2
@@ -22202,10 +22254,55 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"pino-logflare@npm:^0.3.12":
+  version: 0.3.12
+  resolution: "pino-logflare@npm:0.3.12"
+  dependencies:
+    axios: ^0.21.1
+    batch2: ^1.0.6
+    commander: ^5.0.0
+    fast-json-parse: ^1.0.3
+    lodash: ^4.17.15
+    logflare-transport-core: ^0.2.5
+    pino: ^6.3.2
+    pumpify: ^2.0.1
+    split2: ^3.1.1
+    stream-browserify: ^3.0.0
+    through2: ^3.0.1
+  bin:
+    pino-logflare: dist/cli.js
+  checksum: d26ded27b060742abf5889a7d24e6cc171d2013e4198b87bc1e3b1f6d77a5dfb07e7556ed3e706373614ad99c7937812cbe3f3246e4ad5ab47015df526d21a5d
+  languageName: node
+  linkType: hard
+
+"pino-std-serializers@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "pino-std-serializers@npm:3.2.0"
+  checksum: 77e29675b116e42ae9fe6d4ef52ef3a082ffc54922b122d85935f93ddcc20277f0b0c873c5c6c5274a67b0409c672aaae3de6bcea10a2d84699718dda55ba95b
+  languageName: node
+  linkType: hard
+
 "pino-std-serializers@npm:^4.0.0":
   version: 4.0.0
   resolution: "pino-std-serializers@npm:4.0.0"
   checksum: 89d487729b58c9d3273a0ee851ead068d6d2e2ccc1af8e1c1d28f1b3442423679bec7ec04d9a2aba36f94f335e82be9f4de19dc4fbc161e71c136aaa15b85ad3
+  languageName: node
+  linkType: hard
+
+"pino@npm:^6.3.2":
+  version: 6.13.3
+  resolution: "pino@npm:6.13.3"
+  dependencies:
+    fast-redact: ^3.0.0
+    fast-safe-stringify: ^2.0.8
+    fastify-warning: ^0.2.0
+    flatstr: ^1.0.12
+    pino-std-serializers: ^3.1.0
+    quick-format-unescaped: ^4.0.3
+    sonic-boom: ^1.0.2
+  bin:
+    pino: bin.js
+  checksum: a580decd47a1c8b32a846ba1cb478087b523636d697bd4c57833d10b3f2b35c7d06739715ad9a291b41caf002b8d1bbf98674bfb3e99989fd41b7d934cca861c
   languageName: node
   linkType: hard
 
@@ -24125,7 +24222,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"pumpify@npm:^2.0.0":
+"pumpify@npm:^2.0.0, pumpify@npm:^2.0.1":
   version: 2.0.1
   resolution: "pumpify@npm:2.0.1"
   dependencies:
@@ -25421,6 +25518,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:2 || 3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "readable-stream@npm:3.6.0"
+  dependencies:
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.6, readable-stream@npm:^2.3.7, readable-stream@npm:~2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
@@ -25433,17 +25541,6 @@ fsevents@^1.2.7:
     string_decoder: ~1.1.1
     util-deprecate: ~1.0.1
   checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
   languageName: node
   linkType: hard
 
@@ -27131,6 +27228,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"sonic-boom@npm:^1.0.2":
+  version: 1.4.1
+  resolution: "sonic-boom@npm:1.4.1"
+  dependencies:
+    atomic-sleep: ^1.0.0
+    flatstr: ^1.0.12
+  checksum: 189fa8fe5c2dc05d3513fc1a4926a2f16f132fa6fa0b511745a436010cdcd9c1d3b3cb6a9d7c05bd32a965dc77673a5ac0eb0992e920bdedd16330d95323124f
+  languageName: node
+  linkType: hard
+
 "sonic-boom@npm:^2.2.1":
   version: 2.3.1
   resolution: "sonic-boom@npm:2.3.1"
@@ -27329,6 +27436,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"split2@npm:^3.1.1":
+  version: 3.2.2
+  resolution: "split2@npm:3.2.2"
+  dependencies:
+    readable-stream: ^3.0.0
+  checksum: 8127ddbedd0faf31f232c0e9192fede469913aa8982aa380752e0463b2e31c2359ef6962eb2d24c125bac59eeec76873678d723b1c7ff696216a1cd071e3994a
+  languageName: node
+  linkType: hard
+
 "split2@npm:^4.0.0":
   version: 4.1.0
   resolution: "split2@npm:4.1.0"
@@ -27503,6 +27619,16 @@ resolve@^2.0.0-next.3:
     inherits: ~2.0.1
     readable-stream: ^2.0.2
   checksum: 8de7bcab5582e9a931ae1a4768be7efe8fa4b0b95fd368d16d8cf3e494b897d6b0a7238626de5d71686e53bddf417fd59d106cfa3af0ec055f61a8d1f8fc77b3
+  languageName: node
+  linkType: hard
+
+"stream-browserify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "stream-browserify@npm:3.0.0"
+  dependencies:
+    inherits: ~2.0.4
+    readable-stream: ^3.5.0
+  checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
   languageName: node
   linkType: hard
 
@@ -28434,6 +28560,16 @@ resolve@^2.0.0-next.3:
     readable-stream: ~2.0.0
     xtend: ~4.0.0
   checksum: 7a7d661ed28510d0f4b6f86c129ed7885eeadacb4e1b70aca2f4406176642451521950fa3cf5acda7b67881466d09797f64b2593007097f36a3e30f549a37d87
+  languageName: node
+  linkType: hard
+
+"through2@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "through2@npm:3.0.2"
+  dependencies:
+    inherits: ^2.0.4
+    readable-stream: 2 || 3
+  checksum: 47c9586c735e7d9cbbc1029f3ff422108212f7cc42e06d5cc9fff7901e659c948143c790e0d0d41b1b5f89f1d1200bdd200c7b72ad34f42f9edbeb32ea49e8b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Adds a transport to the pino logger library to
forward your messages to Logflare.

This can be verified locally by adding a `.env` file
with the following values:

```
REACT_APP_LOGFLARE_KEY=<LOG_FLARE_API_KEY>
REACT_APP_LOGFLARE_SOURCE=<LOGFLARE_SOURCE_ID>
```

This is a trial with Logflare, we can easily switch
to another provider at a later date.

See attached screen grab for an example of how a message appears in [Logflare](https://logflare.app/guides/overview)
![Screenshot 2021-12-28 at 21 02 47](https://user-images.githubusercontent.com/472589/147602913-0bc3c458-75eb-481a-8db6-97950cf35c12.jpg)


ℹ️ Before merging this change ensure that environmental variables `REACT_APP_LOGFLARE_KEY` and `REACT_APP_LOGFLARE_SOURCE` have been added for all of the instances we wish to add logging to.
