### PR TITLE
[FIX] #1238 howto search cleaning after navigation

### DIFF
--- a/packages/cypress/src/integration/howto/search.spec.ts
+++ b/packages/cypress/src/integration/howto/search.spec.ts
@@ -1,0 +1,25 @@
+describe('[How To]', () => {
+    beforeEach(() => {
+      cy.visit('/how-to')
+    })
+
+    it('[By Everyone]', () => {
+        cy.get('[data-cy=how-to-search-box]')
+        .clear()
+        .type(`raincoat`)
+
+        cy.url().should('include', 'search=raincoat')
+
+        cy.get('[data-cy=page-link]')
+        .contains('Events')
+        .click()
+
+        cy.get('[data-cy=page-link]')
+        .contains('How-to')
+        .click()
+
+        cy.get('[data-cy=how-to-search-box]')
+        .invoke('val')
+        .then(searchText => expect(searchText).to.equal(''));
+    })
+})

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -85,6 +85,10 @@ export class HowtoList extends React.Component<any, IState> {
     }
   }
 
+  componentWillUnmount(): void {
+    this.props.howtoStore.updateSearchValue('')
+  }
+
   public render() {
     const {
       filteredHowtos,
@@ -137,6 +141,7 @@ export class HowtoList extends React.Component<any, IState> {
           </Flex>
           <Flex ml={[0, 0, '8px']} mr={[0, 0, 'auto']} mb={['10px', '10px', 0]}>
             <SearchInput
+              data-cy="how-to-search-box"
               value={searchValue}
               placeholder="Search for a how-to"
               onChange={value => {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

I added a flush of the search value in the howToStore when the component invokes `componentWillUnmount` and the respective e2e in cypress test.

## Git Issues

Closes #1238 

## Screenshots/Videos

![1238](https://user-images.githubusercontent.com/5114020/147612030-8318f109-6e48-4892-ae90-9a364109cb62.gif)
---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
