### PR TITLE
chore: remove empty function lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,8 @@
       }
     ],
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    // https://github.com/standard/eslint-config-standard-with-typescript/issues/248
+    "@typescript-eslint/no-empty-function": "off",
     "react/no-deprecated": "warn",
     "react/no-unescaped-entities": "off",
     "react/jsx-no-target-blank": "warn",

--- a/src/pages/Howto/Content/Common/Howto.form.test.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.test.tsx
@@ -35,7 +35,7 @@ describe('Howto form', function() {
           image: 'test img',
         },
       ],
-      setTagsCategory: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+      setTagsCategory: () => {},
     }
     formValues = {
       files: [],

--- a/src/stores/common/__mocks__/module.store.ts
+++ b/src/stores/common/__mocks__/module.store.ts
@@ -1,11 +1,9 @@
 export class ModuleStore {
-    db = {
-        collection: jest.fn().mockReturnThis(),
-        doc: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-    };
+  db = {
+    collection: jest.fn().mockReturnThis(),
+    doc: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    constructor() {
-    }
+  constructor() {}
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

As raised in #1378, the lint rule `@typescript-eslint/no-empty-function` can be a bit annoying when doing things like stubbing/mocking tests. It is possible to work around by adding a disable statement (already been done twice previously), however probably makes sense to just remove it as most use cases are intentional as opposed to true code-quality issues.

An alternative would be to modify to just provide warning, however as these will be thrown as errors during CI build (and for reason above) I think best to just remove.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
