### PR TITLE
chore: remove node-linker

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,5 @@
 # nmHoistingLimits: workspaces
 
-nodeLinker: node-modules
-
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

`nodeLinker=node-modules` sets the yarn resolution to use the old Yarn 1 way of doing things. The documentation does recommend this as a workaround required for specific packages, such as `react-native`.  We should better align with the Yarn Way(TM) 