### PR TITLE
docs: update pr template to link through to commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 PR Checklist
 
+- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
 - [ ] - Latest `master` branch merged
-- [ ] - PR title descriptive (can be used in release notes)
 
 PR Type
 


### PR DESCRIPTION
The project recently switched to use commit messages
to generate the release notes rather than a semi-manual
method based on PR titles.

This change aims to make it easier for contributors to
understand how to address linting failures.

PR Checklist

- [X] - Latest `master` branch merged
- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)
