### PR TITLE
fix: add image time stamps to uploaded images

### DIFF
--- a/packages/cypress/src/support/custom-assertions.ts
+++ b/packages/cypress/src/support/custom-assertions.ts
@@ -34,11 +34,14 @@ const eqHowto = (chaiObj, utils) => {
       title,
       tags,
     })
-    // note, full cover image meta won't match as uploaded image meta changes
 
-    expect(subject.cover_image.name, 'Cover images').to.eq(
-      expected.cover_image.name,
-    )
+    // We want to validate that uploaded filename matches that originally specified
+    // by the user. The filename will include a timestamp to avoid collisions with
+    // existing files that have been uploaded.
+    // Rather than using a RegExp to validate as our fixture specifies the filename
+    // using a plain, we can break filename into chunks and validate each of those are present.
+    // note, full cover image meta won't match as uploaded image meta changes
+    expect(subject.cover_image.name, 'Cover images').to.satisfy(str => expected.cover_image.name.split('.').filter(Boolean).every(chunk => str.includes(chunk)))
 
     expected.steps.forEach((step, index) => {
       expect(subject.steps[index], `Have step ${index}`).to.eqHowtoStep(

--- a/src/components/ImageInput/ImageConverter.tsx
+++ b/src/components/ImageInput/ImageConverter.tsx
@@ -72,7 +72,7 @@ export class ImageConverter extends React.Component<IProps, IState> {
 
   private _generateFileMeta(c: File) {
     const meta: IConvertedFileMeta = {
-      name: c.name,
+      name: addTimestampToFileName(c.name),
       photoData: c,
       objectUrl: URL.createObjectURL(c),
       type: c.type,
@@ -100,4 +100,24 @@ export class ImageConverter extends React.Component<IProps, IState> {
 }
 ImageConverter.defaultProps = {
   onImgClicked: () => null,
+}
+
+/** Insert a base-16 timestamp into a file's name and return it
+ */
+export const addTimestampToFileName = (str: string): string => {
+  // Return early for malformed input type 🙈
+  if (typeof str !== 'string') return str
+
+  const indexOfDot = str.lastIndexOf('.')
+
+  // Return early if the filename doesn't contain an extension
+  if (indexOfDot <= 0) return str
+
+  // inserts "-[current time in base-16]" right before the file type extension
+  return (
+    str.slice(0, indexOfDot) +
+    '-' +
+    Date.now().toString(16) +
+    str.slice(indexOfDot)
+  )
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fixes #1206, where if multiple images with the same name are uploaded their names collide resulting in only the first one being shown in all instances. It does this by adding a timestamp of the current time in base-16 text with `Date.now().toString(16)`

## Git Issues
 
Closes #1206 

## Screenshots/Videos

2 of the images on this page were named `mc.jpg` and the other 2 were both named `mc.png`.

![1206-fix](https://user-images.githubusercontent.com/23481541/134435482-e002ecae-6edd-4148-8bac-7d0141b9d13a.jpg)