### PR TITLE
chore(ci): remove manual approval step from release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,16 +492,9 @@ workflows:
           name: Release new version to GitHub
           context:
             - release-context
-      # Require manual approval on CirclCI website prior to release
       - build:
           name: Build Production Release
           context: build-context
-          <<: *filter_only_production
-      - hold:
-          name: approve_release
-          type: approval
-          requires:
-            - Build Production Release
           <<: *filter_only_production
       # Send a slack notification to approve the hold above (required config supplied in circleci-slack-context)
       - slack/on-hold:
@@ -514,7 +507,7 @@ workflows:
       - deploy:
           name: 'Deploy: community.preciousplastic.com'
           requires:
-            - 'approve_release'
+            - 'Build Production Release'
           <<: *filter_only_production
           DEPLOY_ALIAS: 'production'
           NOTIFY_SLACK: true
@@ -524,7 +517,7 @@ workflows:
       - deploy:
           name: 'Deploy: community.projectkamp.com'
           requires:
-            - 'approve_release'
+            - 'Build Production Release'
           <<: *filter_only_production
           DEPLOY_ALIAS: project-kamp-production
           NOTIFY_SLACK: true


### PR DESCRIPTION
There is a manual step involved when raising raising and then
merging a PR from `master` into the `production` branch.

As a result this manual step in the CircleCI configuration adds
an unnecessary and duplicative manual process into the release.

PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)
