### PR TITLE
chore(ci): remove firefox e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ workflows:
           matrix:
             parameters:
               CI_NODE: [1, 2]
-              CI_BROWSER: ['chrome', 'firefox']
+              CI_BROWSER: ['chrome']
           filters:
             branches:
               ignore:


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

Description

The Cypress tests are now consistently failing
when running against the Firefox browser. However
driving the browser through the same steps it
is not possible to encounter the same issue.

This _appears_ to be a false positive, however
it is now blocking the production pipeline.

This change aims to remove this blockage so we
can debug this issue around Cypress + Firefox
stability separately.

Failing builds on default branch:
https://app.circleci.com/pipelines/github/ONEARMY/community-platform?branch=master&filter=all