### PR TITLE
chore: move ci yarn cache folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ aliases:
   - &install_packages
     run:
       name: Install Packages
-      command: yarn install --immutable
+      # Install to system tmp folder https://github.com/react-native-community/react-native-circleci-orb/issues/44
+      command: yarn install --immutable --cache-folder /tmp/yarn
     # Example debugging commands for use troubleshooting caching (du will exit with status 141)
   - &check_folders
     run:
@@ -58,7 +59,7 @@ aliases:
         # global cache location
         # - ~/.yarn/berry/cache
         # local cache location
-        - ~/project/.yarn/cache
+        - /tmp/yarn
       key: yarn-packages-v12-{{ checksum "yarn.lock" }}
 
   - &filter_only_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,9 @@ aliases:
   - &install_packages
     run:
       name: Install Packages
-      # Install to system tmp folder https://github.com/react-native-community/react-native-circleci-orb/issues/44
-      command: yarn install --immutable --cache-folder /tmp/yarn
+      command: yarn install --immutable
+      environment:
+        YARN_CACHE_FOLDER: /tmp/yarn # Install to system tmp folder https://github.com/react-native-community/react-native-circleci-orb/issues/44
     # Example debugging commands for use troubleshooting caching (du will exit with status 141)
   - &check_folders
     run:


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Latest `master` branch merged

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Some ci workflows seem to have issues with the cache [example failed circleci run](https://app.circleci.com/pipelines/github/ONEARMY/community-platform/1611/workflows/2f8bcec0-534d-44a2-b9c2-cd899cff232b/jobs/8357)

I'm not sure the exact reason, but suggestion in sounds like a possible fix to try from `https://github.com/react-native-community/react-native-circleci-orb/issues/44`

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
