### PR TITLE
chore: increase number of ci cypress runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ jobs:
           environment:
             CI_BROWSER: << parameters.CI_BROWSER >>
             CI_NODE: << parameters.CI_NODE >>
-            CI_GROUP: 2x-<< parameters.CI_BROWSER >>
+            CI_GROUP: ci-<< parameters.CI_BROWSER >>
       - store_artifacts:
           path: ./packages/cypress/src/screenshots/
   release:
@@ -414,7 +414,7 @@ workflows:
             - e2e-tests
           matrix:
             parameters:
-              CI_NODE: [1, 2]
+              CI_NODE: [1, 2, 3, 4]
               CI_BROWSER: ['chrome']
           filters:
             branches:


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Given that we've currently removed firefox testing (see #1522) we might as well put all runners to use to run chrome tests a bit faster. As it happens I think we could still keep if adding back firefox/safari and just run independently on those browsers as a new test run (using parallelism from circleci instead of cypress)

## Git Issues

Closes #

## Screenshots/Videos

Looks like it should shave around 3mins of the tests overall

![image](https://user-images.githubusercontent.com/10515065/157325093-b89d058d-e0bd-4eb9-bd73-0bbcc616e9e7.png)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
