### PR TITLE
fix: increase caching for static JS resources

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -42,6 +42,19 @@
         ]
       },
       {
+        "source": "/static/**/*.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000"
+          },
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          }
+        ]
+      },
+      {
         "source": "/service-worker.js",
         "headers": [
           {


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

After deploying a new iteration of the site a user
can hit an error state due to the service worker
attempting to load a JS file which no longer exists
on the Firebase hosting. This results in a 
broken white page. 

The default caching is 1 hour. However as the JS
bundles include a md5 string they are unique so can
be cached indefinitely. 

The intent of this change is to reduce the number of times
people encounter this white page of death. As each deployment
removes all previous files from the hosting, the aim 
here is for users to be able to load from their own cache.