### PR TITLE
chore: reduce react icon bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "terser-webpack-plugin": "4.2.3"
   },
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "@sentry/react": "^6.15.0",
     "@uppy/core": "^2.1.4",
     "@uppy/dashboard": "^2.1.3",
@@ -103,7 +104,6 @@
     "react-foco": "^1.3.1",
     "react-ga": "^2.5.7",
     "react-hamburger-menu": "^1.1.1",
-    "react-icons": "^3.2.2",
     "react-image-lightbox": "^5.1.0",
     "react-lazy-load-image-component": "^1.5.1",
     "react-leaflet": "^2.5.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,6 +14,7 @@
     "lint:code": "eslint . --ext .js,.jsx,.ts,.tsx src --color"
   },
   "dependencies": {
+    "@react-icons/all-files": "^4.1.0",
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-flag-icon-css": "^1.0.25",

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -6,41 +6,40 @@ import {
   SpaceProps,
 } from 'styled-system'
 
-import {
-  MdFileDownload,
-  MdAdd,
-  MdCheck,
-  MdArrowBack,
-  MdArrowDownward,
-  MdArrowUpward,
-  MdKeyboardArrowDown,
-  MdMailOutline,
-  MdNotifications,
-  MdAccountCircle,
-  MdLock,
-  MdClose,
-  MdMoreVert,
-  MdComment,
-  MdTurnedIn,
-  MdEdit,
-  MdAccessTime,
-  MdList,
-  MdImage,
-  MdArrowForward,
-  MdLocationOn,
-  MdMail,
-  MdChevronLeft,
-  MdChevronRight,
-} from 'react-icons/md'
-import {
-  GoCloudUpload,
-  GoFilePdf,
-  GoTrashcan,
-  GoLinkExternal,
-} from 'react-icons/go'
-import { AiFillThunderbolt } from 'react-icons/ai'
-import { FaSignal, FaFacebookF, FaSlack, FaInstagram } from 'react-icons/fa'
-import { IconContext } from 'react-icons'
+import { MdFileDownload } from '@react-icons/all-files/md/MdFileDownload'
+import { MdAdd } from '@react-icons/all-files/md/MdAdd'
+import { MdCheck } from '@react-icons/all-files/md/MdCheck'
+import { MdArrowBack } from '@react-icons/all-files/md/MdArrowBack'
+import { MdArrowDownward } from '@react-icons/all-files/md/MdArrowDownward'
+import { MdArrowUpward } from '@react-icons/all-files/md/MdArrowUpward'
+import { MdKeyboardArrowDown } from '@react-icons/all-files/md/MdKeyboardArrowDown'
+import { MdMailOutline } from '@react-icons/all-files/md/MdMailOutline'
+import { MdNotifications } from '@react-icons/all-files/md/MdNotifications'
+import { MdAccountCircle } from '@react-icons/all-files/md/MdAccountCircle'
+import { MdLock } from '@react-icons/all-files/md/MdLock'
+import { MdClose } from '@react-icons/all-files/md/MdClose'
+import { MdMoreVert } from '@react-icons/all-files/md/MdMoreVert'
+import { MdComment } from '@react-icons/all-files/md/MdComment'
+import { MdTurnedIn } from '@react-icons/all-files/md/MdTurnedIn'
+import { MdEdit } from '@react-icons/all-files/md/MdEdit'
+import { MdAccessTime } from '@react-icons/all-files/md/MdAccessTime'
+import { MdList } from '@react-icons/all-files/md/MdList'
+import { MdImage } from '@react-icons/all-files/md/MdImage'
+import { MdArrowForward } from '@react-icons/all-files/md/MdArrowForward'
+import { MdLocationOn } from '@react-icons/all-files/md/MdLocationOn'
+import { MdMail } from '@react-icons/all-files/md/MdMail'
+import { MdChevronLeft } from '@react-icons/all-files/md/MdChevronLeft'
+import { MdChevronRight } from '@react-icons/all-files/md/MdChevronRight'
+import { GoCloudUpload } from '@react-icons/all-files/go/GoCloudUpload'
+import { GoFilePdf } from '@react-icons/all-files/go/GoFilePdf'
+import { GoTrashcan } from '@react-icons/all-files/go/GoTrashcan'
+import { GoLinkExternal } from '@react-icons/all-files/go/GoLinkExternal'
+import { AiFillThunderbolt } from '@react-icons/all-files/ai/AiFillThunderbolt'
+import { FaSignal } from '@react-icons/all-files/fa/FaSignal'
+import { FaFacebookF } from '@react-icons/all-files/fa/FaFacebookF'
+import { FaSlack } from '@react-icons/all-files/fa/FaSlack'
+import { FaInstagram } from '@react-icons/all-files/fa/FaInstagram'
+import { IconContext } from '@react-icons/all-files'
 import { iconMap } from './svgs'
 import { DownloadIcon } from './DownloadIcon'
 import type { IGlyphs } from './types'

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,5 +1,6 @@
 import React, { createRef, useEffect, useState } from 'react'
-import { FaTrash, FaRegEdit } from 'react-icons/fa'
+import { FaTrash } from '@react-icons/all-files/fa/FaTrash'
+import { FaRegEdit } from '@react-icons/all-files/fa/FaRegEdit'
 import { Flex } from 'rebass/styled-components'
 import { IComment } from 'src/models'
 import { CommentHeader } from './CommentHeader'
@@ -26,7 +27,7 @@ export const Comment: React.FC<IProps> = ({
   handleEdit,
   ...props
 }) => {
-  const textRef = createRef<any>();
+  const textRef = createRef<any>()
   const [showEditModal, setShowEditModal] = useState(false)
   const [textHeight, setTextHeight] = useState(0)
   const [isShowMore, setShowMore] = useState(false)
@@ -47,7 +48,7 @@ export const Comment: React.FC<IProps> = ({
   }, [])
 
   const showMore = () => {
-    setShowMore(!isShowMore);
+    setShowMore(!isShowMore)
   }
 
   return (
@@ -61,30 +62,30 @@ export const Comment: React.FC<IProps> = ({
     >
       <CommentHeader {...props} />
       <Text
-        my={2} 
-        style={{ 
+        my={2}
+        style={{
           whiteSpace: 'pre-wrap',
           wordBreak: 'break-word',
-          overflow: "hidden",
-          lineHeight: "1em",
-          maxHeight: isShowMore ? "max-content" : "10em",
+          overflow: 'hidden',
+          lineHeight: '1em',
+          maxHeight: isShowMore ? 'max-content' : '10em',
         }}
         ref={textRef}
       >
         {text}
       </Text>
-      {textHeight > 160 &&
-          <a 
-            onClick={showMore}
-            style={{
-              color: "gray",
-              cursor: "pointer",
-              fontSize: "14px",
-            }}
-          >
-            {isShowMore ? 'Show less' : 'Show more'}
-          </a>
-      }
+      {textHeight > 160 && (
+        <a
+          onClick={showMore}
+          style={{
+            color: 'gray',
+            cursor: 'pointer',
+            fontSize: '14px',
+          }}
+        >
+          {isShowMore ? 'Show less' : 'Show more'}
+        </a>
+      )}
       <Flex ml="auto">
         <AuthWrapper roleRequired="admin" additionalAdmins={[_creatorId]}>
           <Text

--- a/yarn.lock
+++ b/yarn.lock
@@ -4871,6 +4871,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-icons/all-files@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@react-icons/all-files@npm:4.1.0"
+  peerDependencies:
+    react: "*"
+  checksum: c34c644650a144e4f2157c20b3106200ac1f76b3132dcda1a40f061e000a34c78df188266395afae571d5c85bf48365824db7b1bf8b7ae6229fdc148c941ab85
+  languageName: node
+  linkType: hard
+
 "@react-theming/flatten@npm:^0.1.1":
   version: 0.1.1
   resolution: "@react-theming/flatten@npm:0.1.1"
@@ -22827,6 +22836,7 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/core": ^7.14.3
     "@mdx-js/react": ^1.6.22
+    "@react-icons/all-files": ^4.1.0
     "@react-theming/storybook-addon": ^1.1.5
     "@storybook/addon-actions": ^6.4.19
     "@storybook/addon-docs": ^6.4.19
@@ -23105,6 +23115,7 @@ fsevents@^1.2.7:
     "@commitlint/cli": ^16.0.3
     "@commitlint/config-conventional": ^16.0.0
     "@commitlint/cz-commitlint": ^16.0.3
+    "@react-icons/all-files": ^4.1.0
     "@semantic-release/changelog": ^6.0.1
     "@semantic-release/git": ^10.0.1
     "@sentry/react": ^6.15.0
@@ -23185,7 +23196,6 @@ fsevents@^1.2.7:
     react-foco: ^1.3.1
     react-ga: ^2.5.7
     react-hamburger-menu: ^1.1.1
-    react-icons: ^3.2.2
     react-image-lightbox: ^5.1.0
     react-lazy-load-image-component: ^1.5.1
     react-leaflet: ^2.5.0
@@ -26540,17 +26550,6 @@ fsevents@^1.2.7:
   peerDependencies:
     react: ">=16.3.0"
   checksum: a4998479dab7fc1c2799eddefb1870a9d881b5f71cfdf97979a9882e42f4bb50402d55335f308f461e735e01a06f46b16cc7b4e6bcb22c7a4a6f85a753c5c106
-  languageName: node
-  linkType: hard
-
-"react-icons@npm:^3.2.2":
-  version: 3.11.0
-  resolution: "react-icons@npm:3.11.0"
-  dependencies:
-    camelcase: ^5.0.0
-  peerDependencies:
-    react: "*"
-  checksum: 2d45d47387aa85692ee431abe814c3984bc303b0ff25146de86a3cecf7f144c75bc9755df296c626bf133a05622b812fbf95d99776d9a92c7edd90fa7fbbead1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

It seems that although we are only using
a limited selection of icons from this package
we are seeing the react-icons bundle at 2.61Mb

Switching to use @react-icons/all-files instead
which seems to offer better tree shaking.

The linked GitHub issue thread suggests that
webpack _should_ be able to optimise the bundle
size. However I think owing to our dependency
on an outdated CRA we are not getting those benefits.

https://github.com/react-icons/react-icons/issues/154

Before: 

![Screenshot 2022-03-17 at 22 24 05](https://user-images.githubusercontent.com/472589/158901980-129c1cf7-fcd5-4e6f-8a1d-0fd03ec5f86f.jpg)

After:

![Screenshot 2022-03-17 at 22 57 58](https://user-images.githubusercontent.com/472589/158902021-fd14029a-0be6-4871-baea-e23dde765e85.jpg)
