### PR TITLE
chore(deps): adds prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "oa-shared": "1.0.0",
     "pino": "^7.2.0",
     "pino-logflare": "^0.3.12",
+    "prop-types": "15",
     "pubsub-js": "^1.7.0",
     "react": "^17.0.2",
     "react-datepicker": "^2.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23264,6 +23264,7 @@ fsevents@^1.2.7:
     pino: ^7.2.0
     pino-logflare: ^0.3.12
     prettier: ^1.16.4
+    prop-types: 15
     pubsub-js: ^1.7.0
     react: ^17.0.2
     react-datepicker: ^2.9.6
@@ -25869,6 +25870,17 @@ fsevents@^1.2.7:
     kleur: ^3.0.3
     sisteransi: ^1.0.5
   checksum: 05bf4865870665067b14fc54ced6c96e353f58f57658351e16bb8c12c017402582696fb42d97306b7c98efc0e2cc1ebf27ab573448d5a5da2ac18991cc9e4cad
+  languageName: node
+  linkType: hard
+
+"prop-types@npm:15":
+  version: 15.8.1
+  resolution: "prop-types@npm:15.8.1"
+  dependencies:
+    loose-envify: ^1.4.0
+    object-assign: ^4.1.1
+    react-is: ^16.13.1
+  checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Aims to resolve the following issues reported by yarn during installation:

```
➤ YN0002: │ one-army-community-platform@workspace:. doesn't provide prop-types (p25e4b), requested by react-ga
➤ YN0002: │ one-army-community-platform@workspace:. doesn't provide prop-types (p89ff4), requested by react-hamburger-menu
➤ YN0002: │ one-army-community-platform@workspace:. doesn't provide prop-types (p1f2ea), requested by react-table
```
