### PR TITLE
chore: prevent redirect of static assets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,13 +9,7 @@
       },
       {
         "source": "/static/**",
-        "destination": "/static/**",
-        "headers": [
-          {
-            "key": "Access-Control-Allow-Origin",
-            "value": "*"
-          }
-        ]
+        "destination": "/static/**"
       },
       {
         "source": "**",

--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,7 @@
         ]
       },
       {
-        "source": "**/*.@(jpg|jpeg|gif|png)",
+        "source": "**/*.@(jpg|jpeg|gif|png|svg)",
         "headers": [
           {
             "key": "Cache-Control",
@@ -46,7 +46,7 @@
         ]
       },
       {
-        "source": "static/**/*.js",
+        "source": "static/**/*.@(js|css|map)",
         "headers": [
           {
             "key": "Cache-Control",

--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,16 @@
         "function": "api"
       },
       {
+        "source": "/static/**",
+        "destination": "/static/**",
+        "headers": [
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          }
+        ]
+      },
+      {
         "source": "**",
         "destination": "/index.html",
         "headers": [

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -35,7 +35,23 @@ precacheAndRoute(coreManifest)
 
 // static assets are already cachebusted with their file names so can just serve cacheFirst
 // for same origin (https://developers.google.com/web/tools/workbox/modules/workbox-routing)
-registerRoute(new RegExp('/static/'), new CacheFirst())
+registerRoute(
+  new RegExp('/static/'),
+  new CacheFirst({
+    plugins: [
+      // Allow static assets to be cached for up to 1 month
+      // NOTE - workbox will ignore default max-age settings from hosting
+      new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 30 }),
+      new CacheableResponsePlugin({
+        statuses: [200],
+        // Firebase hosting - confirm received intended via header
+        headers: {
+          'x-cache': 'HIT',
+        },
+      }),
+    ],
+  }),
+)
 
 // Set up App Shell-style routing, so that all navigation requests
 // are fulfilled with your index.html shell. Learn more at

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -38,10 +38,11 @@ precacheAndRoute(coreManifest)
 registerRoute(
   new RegExp('/static/'),
   new CacheFirst({
+    cacheName: 'oa-runtime',
     plugins: [
-      // Allow static assets to be cached for up to 1 month
+      // Allow static assets to be cached for up to 1 year
       // NOTE - workbox will ignore default max-age settings from hosting
-      new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 30 }),
+      new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 365 }),
     ],
   }),
 )

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -81,6 +81,10 @@ registerRoute(
   ({ url }) => url.host.includes('tile.openstreetmap.org'),
   new CacheFirst({
     cacheName: 'oa-maptiles',
+    fetchOptions: {
+      credentials: 'same-origin',
+      mode: 'cors',
+    },
     plugins: [
       new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 30 }),
       new CacheableResponsePlugin({

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -76,9 +76,17 @@ registerRoute(
   createHandlerBoundToURL(process.env.PUBLIC_URL + '/index.html'),
 )
 
-// Cache map tiles for up to 30 days
+// Cache osm tiles for up to 30 days (servers from https://wiki.openstreetmap.org/wiki/Tile_servers)
+// NOTE - depending on server load could be sent from any endpoint which may recache same asset
+// TODO - explore workarounds such as manually checking cache for file cached from any of the hostnames or having 3 separate caches
+const tileHostnames = [
+  'a.tile.openstreetmap.org',
+  'b.tile.openstreetmap.org',
+  'c.tile.openstreetmap.org',
+]
 registerRoute(
-  ({ url }) => url.host.includes('tile.openstreetmap.org'),
+  ({ url, request }) =>
+    request.destination === 'image' && tileHostnames.includes(url.hostname),
   new CacheFirst({
     cacheName: 'oa-maptiles',
     fetchOptions: {

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -38,7 +38,7 @@ precacheAndRoute(coreManifest)
 registerRoute(
   new RegExp('/static/'),
   new CacheFirst({
-    cacheName: 'oa-runtime',
+    cacheName: 'oa-static-v1',
     plugins: [
       // Allow static assets to be cached for up to 1 year
       // NOTE - workbox will ignore default max-age settings from hosting
@@ -74,6 +74,20 @@ registerRoute(
     return true
   },
   createHandlerBoundToURL(process.env.PUBLIC_URL + '/index.html'),
+)
+
+// Cache map tiles for up to 30 days
+registerRoute(
+  ({ url }) => url.host.includes('tile.openstreetmap.org'),
+  new CacheFirst({
+    cacheName: 'oa-maptiles',
+    plugins: [
+      new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 30 }),
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+    ],
+  }),
 )
 
 // image assets not hard-coded

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -42,13 +42,6 @@ registerRoute(
       // Allow static assets to be cached for up to 1 month
       // NOTE - workbox will ignore default max-age settings from hosting
       new ExpirationPlugin({ maxAgeSeconds: 60 * 60 * 24 * 30 }),
-      new CacheableResponsePlugin({
-        statuses: [200],
-        // Firebase hosting - confirm received intended via header
-        headers: {
-          'x-cache': 'HIT',
-        },
-      }),
     ],
   }),
 )


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The default behaviour in the platform hosting is to redirect any URLs that don't match an exact file to the main index.html. This is needed for us to handle spa routing for urls like `/howto` within the main app (via the react-router), because there is not /howto.html page). A weird caveat of this is fetching of static resources (like the main build js and CSS files), which firebase defaults to not redirecting IF AND ONLY IF the file exists. So any requests for JS/CSS that does not exist in the server is instead sent a copy of the index.html page, which will be stored in cache and throw an error when accessed. In production this can sometimes mean the user sees a blank white screen and the app won't load until the cache has had time to sort itself out (usually requiring the tab to be closed and reopened)

A larger question this opens is why does the site want to serve JS/CSS that no longer exists. I'm not sure the exact reason, but likely linked to a combination of imperfect caching of the main index.html file and required assets, and our general code-splitting strategy.

This is a small patch to try and prevent firebase from redirecting static assets to the main index.html file. It doesn't address the reason why this is happening, but hopefully should at least stop html being cached as JS (!)

## Review Notes
I've added a preview link, ideally it should show that trying to load a static file does not exist, e.g. `/static/js/doesnotexist.js`, results in a 404 page instead of redirect to home index like on the main site.

## Git Issues

Closes #

## Screenshots/Videos

Serving locally, missing static file returns 404 response
![image](https://user-images.githubusercontent.com/10515065/161342323-bda24fd4-e0d8-4c5e-93a9-7630f2121e75.png)

Existing site, missing static shows page redirect (to custom 404 page)
![image](https://user-images.githubusercontent.com/10515065/161342386-b8f3af35-ff3f-4777-af3a-fb85368b9bc9.png)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
