### PR TITLE
chore: make npm scripts use concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "private": true,
   "main": "lib/index.js",
   "scripts": {
-    "start": "yarn workspace oa-components dev & yarn start:platform",
+    "start": "concurrently --kill-others \"yarn workspace oa-components dev\" \"yarn start:platform\"",
     "start:platform": "cross-env FAST_REFRESH=false yarn react-scripts start",
-    "start:emulated": "concurrently \"yarn workspace functions start\" \"cross-env PORT=4000 yarn start\" -- ",
+    "start:emulated": "concurrently --kill-others \"yarn workspace functions start\" \"yarn workspace oa-components dev\" \"cross-env PORT=4000 yarn start:platform\"",
     "build:components": "yarn workspace oa-components build",
     "build:cra": "react-scripts build",
     "build:post": "yarn workspace oa-scripts post-cra-build",


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Change main npm scripts to use concurrently package instead of `&` operator. This allows cli output to be a bit cleaner (distinguish what logs are coming from which process) and allow failure in one process to kill over (e.g. component compile fail stops server instead of just disappearing into the night). 

This is particularly useful for things like start:emulated which needs to run 3 tasks in parallel without outputs getting garbled up along the way

## Git Issues

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
