### PR TITLE
fix: component props

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -53,7 +53,11 @@ const translateY = (props: IBtnProps) =>
 
 export type BtnProps = IBtnProps & ThemeUiButtonProps
 
-const BaseButton = styled(ThemeUiButton)`
+const BaseButton = styled(ThemeUiButton, {
+  // avoid passing custom props
+  shouldForwardProp: (prop: keyof IBtnProps) =>
+    !['translateY', 'small', 'medium', 'large'].includes(prop),
+})`
   ${translateY}
   ${small}
   ${medium}

--- a/src/components/Flex/index.tsx
+++ b/src/components/Flex/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { Flex as ThemeUiFlex, FlexProps as ThemeUiFlexProps } from 'theme-ui'
 
-export interface IFlexProps extends ThemeUiFlexProps {
+interface IFlexProps extends ThemeUiFlexProps {
   border?: boolean
   littleRadius?: boolean
   mediumRadius?: boolean
@@ -12,21 +12,19 @@ export interface IFlexProps extends ThemeUiFlexProps {
   mediumScale?: boolean
 }
 
-type FlexProps = IFlexProps & ThemeUiFlexProps
-
-export const card = (props: IFlexProps) =>
+const card = (props: IFlexProps) =>
   props.card ? { border: '2px solid black' } : null
 
-export const littleRadius = (props: IFlexProps) =>
+const littleRadius = (props: IFlexProps) =>
   props.littleRadius ? { borderRadius: '5px' } : null
 
-export const mediumRadius = (props: IFlexProps) =>
+const mediumRadius = (props: IFlexProps) =>
   props.mediumRadius ? { borderRadius: '10px' } : null
 
-export const largeRadius = (props: IFlexProps) =>
+const largeRadius = (props: IFlexProps) =>
   props.largeRadius ? { borderRadius: '15px' } : null
 
-export const littleScale = (props: IFlexProps) =>
+const littleScale = (props: IFlexProps) =>
   props.littleScale
     ? {
         transition: '.2s ease-in-out',
@@ -36,7 +34,7 @@ export const littleScale = (props: IFlexProps) =>
       }
     : null
 
-export const mediumScale = (props: IFlexProps) =>
+const mediumScale = (props: IFlexProps) =>
   props.mediumScale
     ? {
         transition: '.2s ease-in-out',
@@ -46,7 +44,19 @@ export const mediumScale = (props: IFlexProps) =>
       }
     : null
 
-export const BaseFlex = styled(ThemeUiFlex as any)`
+export const Flex = styled(ThemeUiFlex, {
+  // avoid passing on custom props
+  shouldForwardProp: (prop: keyof IFlexProps) => {
+    return ![
+      'littleRadius',
+      'mediumRadius',
+      'largeRadius',
+      'card',
+      'littleScale',
+      'mediumScale',
+    ].includes(prop)
+  },
+})<IFlexProps>`
   ${littleRadius}
   ${mediumRadius}
   ${largeRadius}
@@ -54,10 +64,5 @@ export const BaseFlex = styled(ThemeUiFlex as any)`
   ${littleScale}
   ${mediumScale}
 `
-
-// TODO - incorporate custom css into theme-ui props to allow things like below to be passed
-export const Flex = (props: FlexProps) => (
-  <BaseFlex {...(props as any)}>{props.children}</BaseFlex>
-)
 
 export default Flex

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,5 +1,4 @@
-import { forwardRef } from 'react'
-import { Text as ThemeUiText, TextProps as ThemeUiTextProps } from 'theme-ui'
+import { Text as ThemeUiText } from 'theme-ui'
 import theme from '../../themes/styled.theme'
 import styled from '@emotion/styled'
 
@@ -11,7 +10,6 @@ export interface ITextProps {
   capitalize?: boolean
   bold?: boolean
   txtRight?: boolean
-
   large?: boolean
   medium?: boolean
   small?: boolean
@@ -30,28 +28,28 @@ export interface ITextProps {
   theme?: any
 }
 
-export const uppercase = (props) =>
+export const uppercase = (props: ITextProps) =>
   props.uppercase
-    ? {
+    ? ({
         textTransform: 'uppercase',
-      }
+      } as const)
     : null
 
-export const capitalize = (props) =>
+export const capitalize = (props: ITextProps) =>
   props.capitalize
-    ? {
+    ? ({
         textTransform: 'capitalize',
-      }
+      } as const)
     : null
 
 export const inline = (props: ITextProps) =>
   props.inline ? { display: 'inline-block' } : { display: 'block' }
 
 export const txtcenter = (props: ITextProps) =>
-  props.txtcenter ? { textAlign: 'center' } : null
+  props.txtcenter ? ({ textAlign: 'center' } as const) : null
 
 export const txtRight = (props: ITextProps) =>
-  props.txtRight ? { textAlign: 'right' } : null
+  props.txtRight ? ({ textAlign: 'right' } as const) : null
 
 export const regular = (props: ITextProps) =>
   props.regular ? { fontWeight: 400 } : null
@@ -82,11 +80,15 @@ export const superSmall = (props: ITextProps) =>
 
 export const clipped = (props: ITextProps) =>
   props.clipped
-    ? { whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden' }
+    ? ({
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+      } as const)
     : null
 
 export const preLine = (props: ITextProps) =>
-  props.preLine ? { whiteSpace: 'pre-line' } : null
+  props.preLine ? ({ whiteSpace: 'pre-line' } as const) : null
 
 export const highlight = (props: ITextProps) =>
   props.highlight
@@ -115,38 +117,53 @@ export const cropBottomRight = (props: ITextProps) =>
       }
     : null
 
-// any export to fix: https://github.com/microsoft/TypeScript/issues/37597
-export const BaseText = styled(ThemeUiText as any)`
+export const Text = styled(ThemeUiText, {
+  // avoid passing custom props
+  shouldForwardProp: (prop: keyof ITextProps) =>
+    ![
+      'inline',
+      'uppercase',
+      'capitalize',
+      'regular',
+      'bold',
+      'txtcenter',
+      'large',
+      'medium',
+      'small',
+      'superSmall',
+      'clipped',
+      'preLine',
+      'tags',
+      'auxiliary',
+      'paragraph',
+      'txtRight',
+      'highlight',
+      'critical',
+      'dashed',
+      'cropBottomRight',
+    ].includes(prop),
+})<ITextProps>`
   ${inline}
-  ${uppercase as any}
-  ${capitalize as any}
+  ${uppercase}
+  ${capitalize}
   ${regular}
   ${bold}
-	${txtcenter as any}
+  ${txtcenter}
   ${large}
   ${medium}
   ${small}
   ${superSmall}
-  ${clipped as any}
-	${preLine as any}
-	${tags}
-	${auxiliary}
-	${paragraph}
-  ${txtRight as any}
+  ${clipped}
+  ${preLine}
+  ${tags}
+  ${auxiliary}
+  ${paragraph}
+  ${txtRight}
   ${highlight}
   ${critical}
   ${dashed}
   ${cropBottomRight}
 `
-
-type TextProps = ITextProps & ThemeUiTextProps
-
-// TODO - incorporate custom css into theme-ui props to allow things like below to be passed
-export const Text = forwardRef((props: TextProps, ref) => (
-  <BaseText ref={ref} {...(props as any)}>
-    {props.children}
-  </BaseText>
-))
 // Fix lint issue https://stackoverflow.com/questions/67992894/component-definition-is-missing-display-name-for-forwardref
 Text.displayName = 'Text'
 export default Text

--- a/src/pages/common/Layout/Main.tsx
+++ b/src/pages/common/Layout/Main.tsx
@@ -9,32 +9,36 @@ interface ILayoutProps {
 
 type IProps = FlexProps & ILayoutProps
 
-const Main = (props: IProps) => (
-  <Flex {...(props as any)} sx={{ flexDirection: 'column' }}>
-    <Flex
-      className="main-container"
-      css={props.customStyles}
-      sx={
-        !props.ignoreMaxWidth
-          ? {
-              // Base css for all the pages, except Map & Academy
-              position: 'relative',
-              maxWidth: theme.maxContainerWidth,
-              px: [2, 3, 4],
-              mx: 'auto',
-              my: 0,
-              flexDirection: 'column',
-              width: '100%',
-            }
-          : {
-              flexDirection: 'column',
-              width: '100%',
-            }
-      }
-    >
-      {props.children}
+const Main = (props: IProps) => {
+  // avoid passing custom props
+  const { ignoreMaxWidth, customStyles, ...rest } = props
+  return (
+    <Flex {...rest} sx={{ flexDirection: 'column' }}>
+      <Flex
+        className="main-container"
+        css={customStyles}
+        sx={
+          !ignoreMaxWidth
+            ? {
+                // Base css for all the pages, except Map & Academy
+                position: 'relative',
+                maxWidth: theme.maxContainerWidth,
+                px: [2, 3, 4],
+                mx: 'auto',
+                my: 0,
+                flexDirection: 'column',
+                width: '100%',
+              }
+            : {
+                flexDirection: 'column',
+                width: '100%',
+              }
+        }
+      >
+        {props.children}
+      </Flex>
     </Flex>
-  </Flex>
-)
+  )
+}
 
 export default Main


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Testing locally seems to be logging a lot of errors about invalid props. From what I can understand we use custom props like `<Text medium>` to generate styles, styled components/emotion should strip this out when compiling to underlying html element (e.g. a `<p>` or `<span>` tag, however as our Text components sits on top of another styled component (theme-ui text) this doesn't happen.

It may be this has always been the case and only recently has React started caring, or possibly the change from styled-components to emotion has lost some of the prop-stripping ability. In any case I've added a manual list of props to not pass for some of our most common components (which seem to be logging the most errors).

## Git Issues

Closes #

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/162737205-1dd0d6b0-5cb6-466c-a4c7-35860bc8e78e.png)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
