### PR TITLE
fix: add functions build wait for docker emulator

### DIFF
--- a/packages/documentation/docs/Backend Development/firebase-emulators-docker.md
+++ b/packages/documentation/docs/Backend Development/firebase-emulators-docker.md
@@ -44,7 +44,9 @@ Note - any data populated into the emulator will be deleted after the emulator h
 
 ## Resetting seed data
 
-When the emulator is stopped the image is destroyed, so each time the emulators are restarted a clean set of data will be available
+When the emulator is stopped the image is destroyed, so each time the emulators are restarted a clean set of data will be available.
+
+If using the frontend data changes may still persist due to the browser's own caching mechanisms. In this case the browser indexeddb cache will need to be manually cleared
 
 ## Frontend
 

--- a/packages/emulators-docker/README.md
+++ b/packages/emulators-docker/README.md
@@ -25,6 +25,7 @@ By providing a docker image we can address all issues above and provide better p
 [ ] - Find means to have functions-specific lock file and use as part of build process
 [ ] - Automate seed data update (cron action to export and make pr)
 [ ] - Add docker-compose image for easier customisation/volume mapping (?)
+[ ] - Possible option to use without functions dist (currently requires functions build during start)
 [ ] - Provide windows-based docker image (for live-reload on windows)
 
 ## Known Issues

--- a/packages/emulators-docker/src/start.ts
+++ b/packages/emulators-docker/src/start.ts
@@ -1,6 +1,7 @@
 import Dockerode from 'dockerode'
 import boxen from 'boxen'
 import logUpdate from 'log-update'
+import fs from 'fs-extra'
 import {
   CONTAINER_NAME,
   getFirebasePortMapping,
@@ -95,11 +96,18 @@ function attachContainer(container: Dockerode.Container) {
 }
 
 async function createNewContainer() {
+  // ensure functions dist exists for binding
+  if (!fs.existsSync(PATHS.functionsDistIndex)) {
+    console.log('Waiting for functions to be built...')
+    await _wait(5000)
+    return createNewContainer()
+  }
+  // pull remote image if required
   if (REPOSITORY) {
     await pullRemoteImage(IMAGE_NAME)
   }
   const { ExposedPorts, PortBindings } = rewritePortMapping()
-  return new Promise<Dockerode.Container>((resolve, reject) => {
+  return new Promise<Dockerode.Container>(async (resolve, reject) => {
     docker.createContainer(
       {
         // Image: 'goatlab/firebase-emulator:latest',
@@ -235,6 +243,13 @@ function execContainerCmd(container: Dockerode.Container, Cmd: string[]) {
       })
     },
   )
+}
+
+/** Wait an aribitrary number of milliseconds before continuing */
+async function _wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
 }
 
 start()

--- a/packages/emulators-docker/src/start.ts
+++ b/packages/emulators-docker/src/start.ts
@@ -107,7 +107,7 @@ async function createNewContainer() {
     await pullRemoteImage(IMAGE_NAME)
   }
   const { ExposedPorts, PortBindings } = rewritePortMapping()
-  return new Promise<Dockerode.Container>(async (resolve, reject) => {
+  return new Promise<Dockerode.Container>((resolve, reject) => {
     docker.createContainer(
       {
         // Image: 'goatlab/firebase-emulator:latest',


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Adds an additional wait step to ensure functions are built before starting the docker emulator (otherwise will fail to successfully link up the functions code with the emulator)

Adds additional line to docs for clearing cached data

## Git Issues

Closes #

## Screenshots/Videos
Now CLI will show `waiting for functions to be built...` instead of trying to proceed without the functions code (and crashing)

![image](https://user-images.githubusercontent.com/10515065/165841807-fa1657d1-07b3-42ab-91a4-e53c4eb4ac75.png)


## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
