### PR TITLE
chore(ci): adjust order of Release generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,10 +433,16 @@ workflows:
               ignore:
                 - production
       #---------------------- Development Instances Build and Deploy ----------------------
+      - release:
+          requires:
+            - test_e2e
+          name: Release new version to GitHub
+          context:
+            - release-context
       - deploy:
           name: 'Deploy: dev.onearmy.world'
           requires:
-            - test_e2e
+            - 'Release new version to GitHub'
           <<: *filter_only_master
           DEPLOY_ALIAS: 'default'
           NOTIFY_SLACK: false
@@ -446,7 +452,7 @@ workflows:
       - deploy:
           name: 'Deploy: dev.community.projectkamp.com'
           requires:
-            - test_e2e
+            - 'Release new version to GitHub'
           <<: *filter_only_master
           DEPLOY_ALIAS: project-kamp-development
           NOTIFY_SLACK: false
@@ -456,20 +462,13 @@ workflows:
       - deploy:
           name: 'Deploy: fixing-fashion-dev.web.app'
           requires:
-            - test_e2e
+            - 'Release new version to GitHub'
           <<: *filter_only_master
           DEPLOY_ALIAS: fixing-fashion-dev
           NOTIFY_SLACK: false
           context:
             - circle-ci-slack-context
             - fixing-fashion-dev
-      - release:
-          requires:
-            - 'Deploy: community.preciousplastic.com'
-            - 'Deploy: community.projectkamp.com'
-          name: Release new version to GitHub
-          context:
-            - release-context
       - build:
           name: Build Production Release
           context: build-context


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

The Release should be generated _before_ we deploy
our code to the production environments.

We have already merged the code to `production` so
regardless of whether it makes it out to the live sites
it has been released.