### PR TITLE
fix: responsive comment component

### DIFF
--- a/src/components/ImageGallery/index.tsx
+++ b/src/components/ImageGallery/index.tsx
@@ -84,7 +84,7 @@ export default class ImageGallery extends PureComponent<IProps, IState> {
         <Flex sx={{ width: '100%' }}>
           <ImageWithPointer
             data-cy="active-image"
-            sx={{ width: '100%' }}
+            sx={{ px: 3, py: 5, width: '100%' }}
             src={this.state.activeImage.downloadUrl}
             onClick={() => {
               this.triggerLightbox()

--- a/src/components/ImageGallery/index.tsx
+++ b/src/components/ImageGallery/index.tsx
@@ -84,7 +84,7 @@ export default class ImageGallery extends PureComponent<IProps, IState> {
         <Flex sx={{ width: '100%' }}>
           <ImageWithPointer
             data-cy="active-image"
-            sx={{ px: 3, py: 5, width: '100%' }}
+            sx={{ width: '100%' }}
             src={this.state.activeImage.downloadUrl}
             onClick={() => {
               this.triggerLightbox()

--- a/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
+++ b/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
@@ -132,27 +132,28 @@ export const HowToComments = ({ comments }: IProps) => {
           handleEditRequest={handleEditRequest}
           handleDelete={handleDelete}
         />
+
+        <BoxStyled sx={{ width: `${(2 / 3) * 100}%` }}>
+          <CommentTextArea
+            data-cy="comment-text-area"
+            comment={comment}
+            onChange={setComment}
+            loading={loading}
+          />
+          <Button
+            data-cy="comment-submit"
+            disabled={!Boolean(comment.trim()) || loading}
+            variant="primary"
+            onClick={() => onSubmit(comment)}
+            mt={3}
+            sx={{
+              float: 'right',
+            }}
+          >
+            Comment
+          </Button>
+        </BoxStyled>
       </Flex>
-      <BoxStyled sx={{ width: `${(2 / 3) * 100}%` }}>
-        <CommentTextArea
-          data-cy="comment-text-area"
-          comment={comment}
-          onChange={setComment}
-          loading={loading}
-        />
-        <Button
-          data-cy="comment-submit"
-          disabled={!Boolean(comment.trim()) || loading}
-          variant="primary"
-          onClick={() => onSubmit(comment)}
-          mt={3}
-          sx={{
-            float: 'right',
-          }}
-        >
-          Comment
-        </Button>
-      </BoxStyled>
     </Flex>
   )
 }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

- Made responsive comment component of `how-to` page
- Page was tested in the dimension 401x853

## Review Notes

The issue marked two pages, `research` and `how-to`, to solve the bug, but I noticed that the comment component of the `research` page has been corrected already. 

## Git Issues

Closes [one](https://github.com/ONEARMY/community-platform/issues/1610#issuecomment-1100616771) of #1610 

## Screenshots/Videos

### Appearance before the adjustment
![image](https://user-images.githubusercontent.com/58770704/166396159-3bc1e207-f4d2-4698-bb4e-5eef263cc331.png)

### After the change took effect 
![image](https://user-images.githubusercontent.com/58770704/166396320-c451b256-1e2e-4c01-8d0b-1ee0eb971d82.png)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
