### PR TITLE
feat: removes collapsible behaviour from settings

### DIFF
--- a/src/pages/Settings/content/formSections/AccountSettings.section.tsx
+++ b/src/pages/Settings/content/formSections/AccountSettings.section.tsx
@@ -4,7 +4,7 @@ import Flex from 'src/components/Flex'
 import Heading from 'src/components/Heading'
 import type { UserStore } from 'src/stores/User/user.store'
 import { Box } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { ChangePasswordForm } from './ChangePassword.form'
 import { ChangeEmailForm } from './ChangeEmail.form'
 import { ProfileDelete } from '../ProfileDelete'
@@ -14,17 +14,12 @@ interface IProps {}
 interface IInjectedProps extends IProps {
   userStore: UserStore
 }
-interface IState {
-  isOpen: boolean
-}
+
 @inject('userStore')
 @observer
-export class AccountSettingsSection extends React.Component<any, IState> {
+export class AccountSettingsSection extends React.Component<any> {
   constructor(props: IProps) {
     super(props)
-    this.state = {
-      isOpen: false,
-    }
   }
   get injected() {
     return this.props as IInjectedProps
@@ -35,19 +30,12 @@ export class AccountSettingsSection extends React.Component<any, IState> {
   }
 
   render() {
-    const { isOpen } = this.state
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small>Account settings</Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
-        <Box mt={2} sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box mt={2}>
           <ChangeEmailForm userStore={this.props.userStore} />
           <ChangePasswordForm userStore={this.props.userStore} />
           <ProfileDelete

--- a/src/pages/Settings/content/formSections/Collection.section.tsx
+++ b/src/pages/Settings/content/formSections/Collection.section.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import Flex from 'src/components/Flex'
 import Heading from 'src/components/Heading'
 import { Box, Text } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { OpeningHoursPicker } from './Fields/OpeningHoursPicker.field'
 
 import { FieldArray } from 'react-final-form-arrays'
@@ -17,33 +17,19 @@ interface IProps {
   required: boolean
 }
 
-interface IState {
-  isOpen: boolean
-}
-
-export class CollectionSection extends React.Component<IProps, IState> {
+export class CollectionSection extends React.Component<IProps> {
   constructor(props: IProps) {
     super(props)
-    this.state = {
-      isOpen: true,
-    }
   }
 
   render() {
-    const { isOpen } = this.state
     const { required } = this.props
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small>Collection</Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
-        <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box>
           <Flex sx={{ wrap: 'nowrap', alignItems: 'center', width: '100%' }}>
             <Text mt={4} mb={4}>
               Opening time *

--- a/src/pages/Settings/content/formSections/Expertise.section.tsx
+++ b/src/pages/Settings/content/formSections/Expertise.section.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import Flex from 'src/components/Flex'
 import Heading from 'src/components/Heading'
 import { Box, Text } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { FieldArray } from 'react-final-form-arrays'
 import { MACHINE_BUILDER_XP } from 'src/mocks/user_pp.mock'
 import { CustomCheckbox } from './Fields/CustomCheckbox.field'
@@ -15,26 +15,16 @@ interface IProps {
 export class ExpertiseSection extends React.Component<IProps, any> {
   constructor(props: any) {
     super(props)
-    this.state = {
-      isOpen: true,
-    }
   }
 
   render() {
-    const { isOpen } = this.state
     const { required } = this.props
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small>Expertise</Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
-        <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box>
           <Text mt={4} mb={4}>
             What are you specialised in ? *
           </Text>

--- a/src/pages/Settings/content/formSections/Focus.section.tsx
+++ b/src/pages/Settings/content/formSections/Focus.section.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import Flex from 'src/components/Flex'
 import Heading from 'src/components/Heading'
 import { Box, Text } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { Link } from 'theme-ui'
 import { Button } from 'oa-components'
 import type { ProfileTypeLabel } from 'src/models/user_pp.models'
@@ -12,14 +12,8 @@ import { CustomRadioField } from './Fields/CustomRadio.field'
 import theme from 'src/themes/styled.theme'
 import { Field } from 'react-final-form'
 
-interface IState {
-  isOpen: boolean
-}
-
-export class FocusSection extends React.Component<any, IState> {
-  state = { isOpen: true }
+export class FocusSection extends React.Component<any> {
   render() {
-    const { isOpen } = this.state
     return (
       <Field
         name="profileType"
@@ -27,14 +21,8 @@ export class FocusSection extends React.Component<any, IState> {
           <FlexSectionContainer>
             <Flex sx={{ justifyContent: 'space-between' }}>
               <Heading small>Focus</Heading>
-              <ArrowIsSectionOpen
-                onClick={() => {
-                  this.setState({ isOpen: !isOpen })
-                }}
-                isOpen={isOpen}
-              />
             </Flex>
-            <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+            <Box>
               <Text mt={4} mb={4} style={{ display: 'inline-block' }}>
                 What is your main Precious Plastic activity?
               </Text>

--- a/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
@@ -6,7 +6,7 @@ import { Text } from 'theme-ui'
 import { Button } from 'oa-components'
 import { TextAreaField } from 'src/components/Form/Fields'
 import { Box, Flex } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { MAP_GROUPINGS } from 'src/stores/Maps/maps.groupings'
 import theme from 'src/themes/styled.theme'
 import { required } from 'src/utils/validators'
@@ -18,7 +18,6 @@ import { randomIntFromInterval } from 'src/utils/helpers'
 interface IState {
   showAddressEdit: boolean
   hasMapPin: boolean
-  isOpen?: boolean
 }
 
 @inject('mapsStore', 'userStore')
@@ -29,7 +28,6 @@ export class MemberMapPinSection extends React.Component<any, IState> {
     super(props)
     this.state = {
       showAddressEdit: true,
-      isOpen: true,
       hasMapPin: false,
     }
   }
@@ -47,23 +45,15 @@ export class MemberMapPinSection extends React.Component<any, IState> {
   }
 
   render() {
-    const { isOpen } = this.state
-
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small id="your-map-pin">
             Add yourself to the map!
           </Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
 
-        <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box>
           <Text mt={4} mb={4} sx={{ display: 'block' }}>
             Add yourself to the map as an individual who wants to get started.
             Find local community members and meetup to join forces and

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -7,7 +7,7 @@ import { Button } from 'oa-components'
 import theme from 'src/themes/styled.theme'
 import { FieldArray } from 'react-final-form-arrays'
 import { ProfileLinkField } from './Fields/Link.field'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { Box, Text } from 'theme-ui'
 import { required } from 'src/utils/validators'
 import type { IUserPP } from 'src/models/user_pp.models'
@@ -24,7 +24,6 @@ interface IState {
   readOnly: boolean
   isSaving?: boolean
   showNotification?: boolean
-  isOpen?: boolean
 }
 
 const CoverImages = ({
@@ -117,27 +116,19 @@ export class UserInfosSection extends React.Component<IProps, IState> {
     super(props)
     this.state = {
       readOnly: true,
-      isOpen: true,
     }
   }
 
   render() {
     const { formValues } = this.props
     const { profileType, links, coverImages } = formValues
-    const { isOpen } = this.state
     const isMemberProfile = profileType === 'member'
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small>Infos</Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
-        <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box>
           <Flex sx={{ flexWrap: 'wrap' }}>
             <Text
               sx={{

--- a/src/pages/Settings/content/formSections/Workspace.section.tsx
+++ b/src/pages/Settings/content/formSections/Workspace.section.tsx
@@ -3,24 +3,15 @@ import * as React from 'react'
 import Flex from 'src/components/Flex'
 import Heading from 'src/components/Heading'
 import { Box, Text } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { WORKSPACE_TYPES } from 'src/mocks/user_pp.mock'
 import { CustomRadioField } from './Fields/CustomRadio.field'
 import { required } from 'src/utils/validators'
 import theme from 'src/themes/styled.theme'
 import { Field } from 'react-final-form'
 
-interface IState {
-  isOpen?: boolean
-}
-
-export class WorkspaceSection extends React.Component<any, IState> {
-  state = {
-    isOpen: true,
-  }
-
+export class WorkspaceSection extends React.Component<any> {
   render() {
-    const { isOpen } = this.state
     return (
       <Field
         name="workspaceType"
@@ -30,14 +21,8 @@ export class WorkspaceSection extends React.Component<any, IState> {
           <FlexSectionContainer>
             <Flex sx={{ justifyContent: 'space-between' }}>
               <Heading small>Workspace</Heading>
-              <ArrowIsSectionOpen
-                onClick={() => {
-                  this.setState({ isOpen: !isOpen })
-                }}
-                isOpen={isOpen}
-              />
             </Flex>
-            <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+            <Box>
               <Text mt={4} mb={4}>
                 What kind of Precious Plastic workspace do you run?
               </Text>

--- a/src/pages/Settings/content/formSections/WorkspaceMapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/WorkspaceMapPin.section.tsx
@@ -4,7 +4,7 @@ import Heading from 'src/components/Heading'
 import { Field } from 'react-final-form'
 import { TextAreaField } from 'src/components/Form/Fields'
 import { Box, Flex, Link, Text } from 'theme-ui'
-import { FlexSectionContainer, ArrowIsSectionOpen } from './elements'
+import { FlexSectionContainer } from './elements'
 import { MAP_GROUPINGS } from 'src/stores/Maps/maps.groupings'
 import theme from 'src/themes/styled.theme'
 import { required } from 'src/utils/validators'
@@ -12,36 +12,21 @@ import type { ILocation } from 'src/models/common.models'
 import MapWithDraggablePin from 'src/components/MapWithDraggablePin/MapWithDraggablePin'
 import { randomIntFromInterval } from 'src/utils/helpers'
 
-interface IState {
-  isOpen?: boolean
-}
-
 @inject('mapsStore', 'userStore')
 @observer
-export class WorkspaceMapPinSection extends React.Component<any, IState> {
+export class WorkspaceMapPinSection extends React.Component<any> {
   pinFilters = MAP_GROUPINGS
   constructor(props) {
     super(props)
-    this.state = {
-      isOpen: true,
-    }
   }
 
   render() {
-    const { isOpen } = this.state
-
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Heading small id="your-map-pin">
             Your map pin
           </Heading>
-          <ArrowIsSectionOpen
-            onClick={() => {
-              this.setState({ isOpen: !isOpen })
-            }}
-            isOpen={isOpen}
-          />
         </Flex>
         <Box bg={theme.colors.red2} mt={2} p={3} sx={{ borderRadius: '3px' }}>
           <Text sx={{ fontSize: 2 }}>
@@ -57,7 +42,7 @@ export class WorkspaceMapPinSection extends React.Component<any, IState> {
             and how you can join.
           </Text>
         </Box>
-        <Box sx={{ display: isOpen ? 'block' : 'none' }}>
+        <Box>
           <Text mb={2} mt={4} sx={{ fontSize: 2 }}>
             Short description of your pin*
           </Text>

--- a/src/pages/Settings/content/formSections/elements.tsx
+++ b/src/pages/Settings/content/formSections/elements.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled'
 import theme from 'src/themes/styled.theme'
 import Flex from 'src/components/Flex'
-import { Box } from 'theme-ui'
-import { Icon } from 'oa-components'
 import { Field } from 'react-final-form'
 
 export const Label = (props) => (
@@ -48,20 +46,4 @@ export const FlexSectionContainer = (props) => (
   >
     {props.children}
   </Flex>
-)
-
-export const ArrowIsSectionOpen = (props) => (
-  <Box
-    height="20px"
-    sx={{
-      transform: props.isOpen ? 'rotate(180deg)' : null,
-      transformOrigin: 'center',
-      ':hover': {
-        cursor: 'pointer',
-      },
-    }}
-    {...props}
-  >
-    <Icon size="20" glyph="arrow-full-down" />
-  </Box>
 )


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Latest `master` branch merged

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The collapsible behaviour on these blocks had a different implementation for each of the sections, so there are two approaches we could take here, either extract or standardise into a reusable component or remove it entirely if the behaviour is not worth the investment.

Before this change the functionality within the Account Settings pane was hidden behind _three_ required user interactions:
1. The user must scroll to the bottom of the page
2. The user must know to and then expand the Account Settings pane
3. The user must click the action they required. 

This change simplifies the interaction for our intreprid user by 33.33333% 

The following screenshot shows how this page renders _without_ the collapsible icon/behaviour. 

![Screenshot 2022-05-18 at 07-57-55 Community Platform](https://user-images.githubusercontent.com/472589/168968683-4bb9d188-0873-4ba6-81fd-ecca530808a5.png)
