### PR TITLE
feat: add country dropdown in profile settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@uppy/react": "^2.1.2",
     "browser-image-compression": "^1.0.15",
     "cheerio": "^1.0.0-rc.10",
+    "countries-list": "^2.6.1",
     "date-fns": "^1.30.1",
     "debounce": "^1.2.0",
     "dexie": "^2.0.4",

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -167,7 +167,7 @@ describe('[Settings]', () => {
     })
   })
 
-  describe('[Focus Member]', () => {
+  describe.only('[Focus Member]', () => {
     const freshSettings = {
       _authID: 'pbx4jStD8sNj4OEZTg4AegLTl6E3',
       _id: 'settings_member_new',
@@ -240,7 +240,7 @@ describe('[Settings]', () => {
       })
     })
 
-    it.only('[Add a user pin]', () => {
+    it('[Add a user pin]', () => {
       const expected = {
         _authID: 'pbx4jStD8sNj4OEZTg4AegLTl6E3',
         _deleted: false,
@@ -287,6 +287,8 @@ describe('[Settings]', () => {
       cy.clickMenuItem(UserMenuItem.Settings)
       selectFocus(expected.profileType)
 
+      cy.get('[data-cy=location-dropdown]').should('exist')
+
       cy.get('[data-cy="add-a-map-pin"]').click()
 
       setInfo({
@@ -307,6 +309,11 @@ describe('[Settings]', () => {
         searchKeyword: 'singapo',
         locationName: expected.location.value,
       })
+      cy.get('[data-cy=location-dropdown]').should('not.exist')
+
+      cy.step('Remove a user pin')
+      cy.get('[data-cy="remove-a-member-map-pin"]').click()
+      cy.get('[data-cy=location-dropdown]').should('exist')
 
       cy.get('[data-cy=save]').click()
       cy.get('[data-cy=save]').should('not.be.disabled')

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -42,6 +42,7 @@ interface IState {
   formValues: IUserPP
   notification: { message: string; icon: string; show: boolean }
   showDeleteDialog?: boolean
+  showLocationDropdown: boolean
   user?: IUserPP
 }
 
@@ -80,6 +81,7 @@ export class UserSettings extends React.Component<IProps, IState> {
       formValues,
       notification: { message: '', icon: '', show: false },
       user,
+      showLocationDropdown: true,
     })
   }
 
@@ -229,11 +231,19 @@ export class UserSettings extends React.Component<IProps, IState> {
 
                       {values.profileType === ProfileType.MEMBER &&
                         isModuleSupported(MODULE.MAP) && (
-                          <MemberMapPinSection />
+                          <MemberMapPinSection
+                            toggleLocationDropdown={() =>
+                              this.setState((prevState) => ({
+                                showLocationDropdown:
+                                  !prevState.showLocationDropdown,
+                              }))
+                            }
+                          />
                         )}
                       <UserInfosSection
                         formValues={values}
                         mutators={form.mutators}
+                        showLocationDropdown={this.state.showLocationDropdown}
                       />
                     </Flex>
                   </form>

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -81,7 +81,7 @@ export class UserSettings extends React.Component<IProps, IState> {
       formValues,
       notification: { message: '', icon: '', show: false },
       user,
-      showLocationDropdown: true,
+      showLocationDropdown: !user?.location?.latlng,
     })
   }
 
@@ -136,6 +136,19 @@ export class UserSettings extends React.Component<IProps, IState> {
       errors.links[ARRAY_ERROR] = 'Must have at least one link'
     }
     return errors
+  }
+
+  toggleLocationDropdown = () => {
+    this.setState((prevState) => ({
+      ...prevState,
+      showLocationDropdown: !prevState.showLocationDropdown,
+      formValues: {
+        ...prevState.formValues,
+        mapPinDescription: '',
+        location: null,
+        country: null,
+      },
+    }))
   }
 
   render() {
@@ -232,12 +245,7 @@ export class UserSettings extends React.Component<IProps, IState> {
                       {values.profileType === ProfileType.MEMBER &&
                         isModuleSupported(MODULE.MAP) && (
                           <MemberMapPinSection
-                            toggleLocationDropdown={() =>
-                              this.setState((prevState) => ({
-                                showLocationDropdown:
-                                  !prevState.showLocationDropdown,
-                              }))
-                            }
+                            toggleLocationDropdown={this.toggleLocationDropdown}
                           />
                         )}
                       <UserInfosSection

--- a/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
@@ -142,6 +142,7 @@ export class MemberMapPinSection extends React.Component<any, IState> {
                         />
 
                         <Button
+                          data-cy="remove-a-member-map-pin"
                           mt={4}
                           variant="outline"
                           onClick={() => {

--- a/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
+++ b/src/pages/Settings/content/formSections/MemberMapPin.section.tsx
@@ -65,6 +65,7 @@ export class MemberMapPinSection extends React.Component<any, IState> {
               <Button
                 data-cy="add-a-map-pin"
                 onClick={() => {
+                  this.props.toggleLocationDropdown()
                   this.setState({ hasMapPin: !this.state.hasMapPin })
                 }}
               >
@@ -144,6 +145,7 @@ export class MemberMapPinSection extends React.Component<any, IState> {
                           mt={4}
                           variant="outline"
                           onClick={() => {
+                            this.props.toggleLocationDropdown()
                             this.setState({
                               hasMapPin: false,
                             })

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -164,6 +164,7 @@ export class UserInfosSection extends React.Component<IProps, IState> {
                         label: countries[country].name,
                         value: country,
                       }))}
+                      placeholder="Country"
                       {...field}
                     />
                   )}

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Field } from 'react-final-form'
 import { Heading } from 'theme-ui'
+import { countries } from 'countries-list'
 import { Flex } from 'theme-ui'
 import { InputField, TextAreaField } from 'src/components/Form/Fields'
 import { Button } from 'oa-components'
@@ -16,9 +17,11 @@ import { ErrorMessage } from 'src/components/Form/elements'
 import type { IUser } from 'src/models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { ProfileType } from 'src/modules/profile'
+import { SelectField } from 'src/components/Form/Select.field'
 
 interface IProps {
   formValues: IUserPP
+  showLocationDropdown: boolean
   mutators: { [key: string]: (...args: any[]) => any }
 }
 interface IState {
@@ -149,6 +152,24 @@ export class UserInfosSection extends React.Component<IProps, IState> {
               validate={required}
               validateFields={[]}
             />
+            {this.props.showLocationDropdown && (
+              <Flex sx={{ flexDirection: 'column', width: '100%' }}>
+                <Text my={4} sx={{ fontSize: 2 }}>
+                  Your location
+                </Text>
+                <Field data-cy="location-dropdown" name="country">
+                  {(field) => (
+                    <SelectField
+                      options={Object.keys(countries).map((country) => ({
+                        label: countries[country].name,
+                        value: country,
+                      }))}
+                      {...field}
+                    />
+                  )}
+                </Field>
+              </Flex>
+            )}
 
             <Text mb={2} mt={7} sx={{ fontSize: 2 }}>
               {isMemberProfile

--- a/yarn.lock
+++ b/yarn.lock
@@ -14460,6 +14460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"countries-list@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "countries-list@npm:2.6.1"
+  checksum: 72185813fdd77b6fd1b441d87e103664ef3eb79f2c977124817c2dacb655d97a7369dcf519cc8ae04a92314a69af5396f0b85c38ba8c283ffd5ec01be8769147
+  languageName: node
+  linkType: hard
+
 "cp-file@npm:^7.0.0":
   version: 7.0.0
   resolution: "cp-file@npm:7.0.0"
@@ -26127,6 +26134,7 @@ fsevents@^1.2.7:
     cheerio: ^1.0.0-rc.10
     commitizen: ^4.2.4
     concurrently: ^6.2.0
+    countries-list: ^2.6.1
     cra-bundle-analyzer: ^0.1.0
     cross-env: ^6.0.3
     cspell: ^6.1.0


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

A SelectField which contains countries from the library countries-list has been added. It's shown by default (showLocationDropdown is set to true in the UserSettings components' state) but when we click the button in the MemberMapPinSection component to add a pin, the toggleLocationDropdown() function (which is passed to the component as a prop so we can modify the parent component's state) is called, disabling the locations dropdown.

## Git Issues

Closes #1541

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
