### PR TITLE
1617-add-download-count-howto

### DIFF
--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -4,17 +4,11 @@ import type { IUploadedFileMeta } from 'src/stores/storage'
 import { FileDetails } from './FileDetails'
 import { ExternalLink } from 'oa-components'
 import styled from '@emotion/styled'
-import { useCommonStores } from 'src/index'
 
 interface IProps {
   file: File | IUploadedFileMeta | null
   allowDownload?: boolean
-  howToID?: string
-  setFileDownloadCount?(val: number | undefined): void
-}
-
-interface localStorageExpiry {
-  expiry: number
+  handleClick?: () => Promise<void>
 }
 
 const FileContainer = styled.a`
@@ -24,10 +18,8 @@ const FileContainer = styled.a`
 export const FileInfo: React.FC<IProps> = ({
   file,
   allowDownload,
-  howToID,
-  setFileDownloadCount,
+  handleClick,
 }) => {
-  const { stores } = useCommonStores()
   const meta = file as IUploadedFileMeta
   const size = file ? bytesToSize(file.size) : '0'
 
@@ -35,49 +27,15 @@ export const FileInfo: React.FC<IProps> = ({
     return null
   }
 
-  // not sure where to store these functions, if here is ok?
-  const setCooldownWithExpiry = () => {
-    const now: Date = new Date()
-    const twelveHoursInSeconds: number = 12 * 3600
-    const expiry = { expiry: now.getTime() + twelveHoursInSeconds }
-    localStorage.setItem('downloadCooldown', JSON.stringify(expiry))
-  }
-
-  const checkForExpiry = () => {
-    const downloadCooldown: string | null =
-      localStorage.getItem('downloadCooldown')
-
-    if (typeof downloadCooldown === 'string') {
-      const downloadCooldownParsed: localStorageExpiry =
-        JSON.parse(downloadCooldown)
-
-      const now: Date = new Date()
-      // remove localstorage item if its timestamp is expired
-      if (now.getTime() > downloadCooldownParsed.expiry) {
-        localStorage.removeItem('downloadCooldown')
-      } else {
-        return true
-      }
-    }
-  }
-
-  const handleClick = async () => {
-    if (howToID && setFileDownloadCount && !checkForExpiry()) {
-      const updatedDownloadCount =
-        await stores.howtoStore.incrementDownloadCount(howToID)
-      setFileDownloadCount(updatedDownloadCount)
-      setCooldownWithExpiry()
-    }
-  }
-
   return (
     <>
-      {allowDownload && meta.downloadUrl ? (
+      {allowDownload && meta.downloadUrl && handleClick ? (
         <ExternalLink
           m={1}
           onClick={() => handleClick()}
           href={meta.downloadUrl}
           download={file.name}
+          a
           style={{ width: '300px' }}
         >
           <FileDetails file={file} glyph="download-cloud" size={size} />

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -11,10 +11,6 @@ interface IProps {
   handleClick?: () => Promise<void>
 }
 
-const FileContainer = styled.a`
-  width: 300px;
-  margin: 3px 3px;
-`
 export const FileInfo: React.FC<IProps> = ({
   file,
   allowDownload,

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -3,7 +3,6 @@ import { bytesToSize } from '../ImageInput/ImageInput'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { FileDetails } from './FileDetails'
 import { ExternalLink } from 'oa-components'
-import styled from '@emotion/styled'
 
 interface IProps {
   file: File | IUploadedFileMeta | null

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -35,7 +35,6 @@ export const FileInfo: React.FC<IProps> = ({
           onClick={() => handleClick()}
           href={meta.downloadUrl}
           download={file.name}
-          a
           style={{ width: '300px' }}
         >
           <FileDetails file={file} glyph="download-cloud" size={size} />

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -24,10 +24,10 @@ export const FileInfo: React.FC<IProps> = ({
 
   return (
     <>
-      {allowDownload && meta.downloadUrl && handleClick ? (
+      {allowDownload && meta.downloadUrl ? (
         <ExternalLink
           m={1}
-          onClick={() => handleClick()}
+          onClick={() => handleClick && handleClick()}
           href={meta.downloadUrl}
           download={file.name}
           style={{ width: '300px' }}

--- a/src/components/FileInfo/FileInfo.tsx
+++ b/src/components/FileInfo/FileInfo.tsx
@@ -3,13 +3,27 @@ import { bytesToSize } from '../ImageInput/ImageInput'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { FileDetails } from './FileDetails'
 import { ExternalLink } from 'oa-components'
+import styled from '@emotion/styled'
+import { useCommonStores } from 'src/index'
 
 interface IProps {
   file: File | IUploadedFileMeta | null
   allowDownload?: boolean
+  howToID?: string
+  setFileDownloadCount?(val: number | undefined): void
 }
 
-export const FileInfo: React.FC<IProps> = ({ file, allowDownload }) => {
+const FileContainer = styled.a`
+  width: 300px;
+  margin: 3px 3px;
+`
+export const FileInfo: React.FC<IProps> = ({
+  file,
+  allowDownload,
+  howToID,
+  setFileDownloadCount,
+}) => {
+  const { stores } = useCommonStores()
   const meta = file as IUploadedFileMeta
   const size = file ? bytesToSize(file.size) : '0'
 
@@ -17,11 +31,20 @@ export const FileInfo: React.FC<IProps> = ({ file, allowDownload }) => {
     return null
   }
 
+  const handleClick = async () => {
+    if (howToID && setFileDownloadCount) {
+      const updatedDownloadCount =
+        await stores.howtoStore.incrementDownloadCount(howToID)
+      setFileDownloadCount(updatedDownloadCount)
+    }
+  }
+
   return (
     <>
       {allowDownload && meta.downloadUrl ? (
         <ExternalLink
           m={1}
+          onClick={() => handleClick()}
           href={meta.downloadUrl}
           download={file.name}
           style={{ width: '300px' }}

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -29,8 +29,8 @@ export interface IHowto extends IHowtoFormInput, IModerable {
   steps: IHowtoStep[]
   // Comments were added in V2, old howto's may not have the property
   comments?: IComment[]
-    // total downloads added, old howto's do not have the property, could update all entries to have this
-  total_downloads?: number 
+  // total downloads added, old howto's do not have the property, could update all entries to have this
+  total_downloads?: number
 }
 
 /**

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -29,7 +29,6 @@ export interface IHowto extends IHowtoFormInput, IModerable {
   steps: IHowtoStep[]
   // Comments were added in V2, old howto's may not have the property
   comments?: IComment[]
-  // total downloads added, old howto's do not have the property, could update all entries to have this
   total_downloads?: number
 }
 

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -29,6 +29,8 @@ export interface IHowto extends IHowtoFormInput, IModerable {
   steps: IHowtoStep[]
   // Comments were added in V2, old howto's may not have the property
   comments?: IComment[]
+    // total downloads added, old howto's do not have the property, could update all entries to have this
+  total_downloads?: number 
 }
 
 /**

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -260,7 +260,15 @@ export default class HowtoDescription extends PureComponent<IProps> {
                 />
               ))}
               {typeof this.state.fileDownloadCount !== undefined && (
-                <Text>{this.state.fileDownloadCount} downloads</Text>
+                <Text
+                  sx={{
+                    fontSize: '12px',
+                    color: '#61646B',
+                    paddingLeft: '6px',
+                  }}
+                >
+                  {this.state.fileDownloadCount} downloads
+                </Text>
               )}
             </Flex>
           )}

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -29,7 +29,7 @@ import {
   isHowtoDownloadCooldownExpired,
   addHowtoDownloadCooldown,
   updateHowtoDownloadCooldown,
-} from './utils'
+} from './downloadCooldown'
 
 interface IProps {
   howto: IHowtoDB
@@ -57,7 +57,7 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props)
     this.state = {
-      fileDownloadCount: this.props.howto.total_downloads,
+      fileDownloadCount: this.props.howto.total_downloads || 0,
     }
     this.handleClick = this.handleClick.bind(this)
   }
@@ -305,15 +305,18 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
                   handleClick={this.handleClick}
                 />
               ))}
-              {typeof this.state.fileDownloadCount !== undefined && (
+              {typeof this.state.fileDownloadCount === 'number' && (
                 <Text
                   sx={{
                     fontSize: '12px',
                     color: '#61646B',
-                    paddingLeft: '6px',
+                    paddingLeft: '8px',
                   }}
                 >
-                  {this.state.fileDownloadCount} downloads
+                  {this.state.fileDownloadCount}
+                  {this.state.fileDownloadCount !== 1
+                    ? ' downloads'
+                    : ' download'}
                 </Text>
               )}
             </Flex>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -40,6 +40,10 @@ export default class HowtoDescription extends PureComponent<IProps> {
     super(props)
   }
 
+  state = {
+    fileDownloadCount: this.props.howto.total_downloads
+  }
+
   private dateCreatedByText(howto: IHowtoDB): string {
     return format(new Date(howto._created), 'DD-MM-YYYY')
   }
@@ -52,6 +56,12 @@ export default class HowtoDescription extends PureComponent<IProps> {
     } else {
       return ''
     }
+  }
+
+  private setFileDownloadCount = (val: number) => {
+    this.setState({
+      fileDownloadCount: val
+    });
   }
 
   public render() {
@@ -245,8 +255,13 @@ export default class HowtoDescription extends PureComponent<IProps> {
                   allowDownload
                   file={file}
                   key={file ? file.name : `file-${index}`}
+                  howToID={howto._id}
+                  setFileDownloadCount={this.setFileDownloadCount}
                 />
               ))}
+              { typeof this.state.fileDownloadCount !== undefined && (
+                <Text>{this.state.fileDownloadCount} downloads</Text>)
+              }
             </Flex>
           )}
         </Flex>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -296,7 +296,12 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
               mt={3}
               sx={{ flexDirection: 'column' }}
             >
-              {howto.fileLink ? <DownloadExternal link={howto.fileLink} /> : ''}
+              {howto.fileLink && (
+                <DownloadExternal
+                  handleClick={this.handleClick}
+                  link={howto.fileLink}
+                />
+              )}
               {howto.files.map((file, index) => (
                 <FileInfo
                   allowDownload

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -98,8 +98,6 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
     const howtoDownloadCooldown = retrieveHowtoDownloadCooldown(
       this.props.howto._id,
     )
-    const date = new Date(howtoDownloadCooldown!.expiry)
-    console.log(date.toString())
 
     if (
       howtoDownloadCooldown &&

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -41,7 +41,7 @@ export default class HowtoDescription extends PureComponent<IProps> {
   }
 
   state = {
-    fileDownloadCount: this.props.howto.total_downloads
+    fileDownloadCount: this.props.howto.total_downloads,
   }
 
   private dateCreatedByText(howto: IHowtoDB): string {
@@ -60,8 +60,8 @@ export default class HowtoDescription extends PureComponent<IProps> {
 
   private setFileDownloadCount = (val: number) => {
     this.setState({
-      fileDownloadCount: val
-    });
+      fileDownloadCount: val,
+    })
   }
 
   public render() {
@@ -259,9 +259,9 @@ export default class HowtoDescription extends PureComponent<IProps> {
                   setFileDownloadCount={this.setFileDownloadCount}
                 />
               ))}
-              { typeof this.state.fileDownloadCount !== undefined && (
-                <Text>{this.state.fileDownloadCount} downloads</Text>)
-              }
+              {typeof this.state.fileDownloadCount !== undefined && (
+                <Text>{this.state.fileDownloadCount} downloads</Text>
+              )}
             </Flex>
           )}
         </Flex>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/downloadCooldown.ts
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/downloadCooldown.ts
@@ -3,13 +3,13 @@ interface localStorageExpiry {
   expiry: number
 }
 
-export const retrieveLocalStorageArray = ():
-  | localStorageExpiry[]
-  | undefined => {
+export const retrieveLocalStorageArray = (): localStorageExpiry[] => {
   const downloadCooldownArray: string | null =
     localStorage.getItem('downloadCooldown')
   if (typeof downloadCooldownArray === 'string') {
     return JSON.parse(downloadCooldownArray)
+  } else {
+    return new Array<localStorageExpiry>()
   }
 }
 
@@ -44,16 +44,10 @@ export const createHowtoExpiryObject = (
 }
 
 export const addHowtoDownloadCooldown = (howtoID: string) => {
-  let downloadCooldownArray = retrieveLocalStorageArray()
+  const downloadCooldownArray = retrieveLocalStorageArray()
   const expiryObject = createHowtoExpiryObject(howtoID)
 
-  if (!downloadCooldownArray) {
-    // create array for localstorage if none exists
-    downloadCooldownArray = []
-    downloadCooldownArray.push(expiryObject)
-  } else {
-    downloadCooldownArray.push(expiryObject)
-  }
+  downloadCooldownArray.push(expiryObject)
   localStorage.setItem(
     'downloadCooldown',
     JSON.stringify(downloadCooldownArray),
@@ -63,11 +57,11 @@ export const addHowtoDownloadCooldown = (howtoID: string) => {
 export const updateHowtoDownloadCooldown = (howtoID: string) => {
   const downloadCooldownArray = retrieveLocalStorageArray()
   const expiryObject = createHowtoExpiryObject(howtoID)
-  const foundIndex = downloadCooldownArray!.findIndex(
+  const foundIndex = downloadCooldownArray.findIndex(
     (elem) => elem.howtoID === howtoID,
   )
 
-  downloadCooldownArray![foundIndex] = expiryObject
+  downloadCooldownArray[foundIndex] = expiryObject
   localStorage.setItem(
     'downloadCooldown',
     JSON.stringify(downloadCooldownArray),

--- a/src/pages/Howto/Content/Howto/HowtoDescription/utils.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/utils.tsx
@@ -1,0 +1,75 @@
+interface localStorageExpiry {
+  howtoID: string
+  expiry: number
+}
+
+export const retrieveLocalStorageArray = ():
+  | localStorageExpiry[]
+  | undefined => {
+  const downloadCooldownArray: string | null =
+    localStorage.getItem('downloadCooldown')
+  if (typeof downloadCooldownArray === 'string') {
+    return JSON.parse(downloadCooldownArray)
+  }
+}
+
+export const retrieveHowtoDownloadCooldown = (
+  howtoID: string,
+): localStorageExpiry | undefined => {
+  const downloadCooldownArray = retrieveLocalStorageArray()
+  if (downloadCooldownArray) {
+    return downloadCooldownArray.find((elem) => elem.howtoID === howtoID)
+  }
+}
+
+export const isHowtoDownloadCooldownExpired = (
+  howtoCooldown: localStorageExpiry,
+): boolean => {
+  const now = new Date()
+  if (now.getTime() > howtoCooldown.expiry) {
+    return true
+  } else {
+    return false
+  }
+}
+export const createHowtoExpiryObject = (
+  howtoID: string,
+): localStorageExpiry => {
+  const now = new Date()
+  const twelveHoursInMiliseconds = 12 * 60 * 60 * 1000
+  return {
+    howtoID: howtoID,
+    expiry: now.getTime() + twelveHoursInMiliseconds,
+  }
+}
+
+export const addHowtoDownloadCooldown = (howtoID: string) => {
+  let downloadCooldownArray = retrieveLocalStorageArray()
+  const expiryObject = createHowtoExpiryObject(howtoID)
+
+  if (!downloadCooldownArray) {
+    // create array for localstorage if none exists
+    downloadCooldownArray = []
+    downloadCooldownArray.push(expiryObject)
+  } else {
+    downloadCooldownArray.push(expiryObject)
+  }
+  localStorage.setItem(
+    'downloadCooldown',
+    JSON.stringify(downloadCooldownArray),
+  )
+}
+
+export const updateHowtoDownloadCooldown = (howtoID: string) => {
+  const downloadCooldownArray = retrieveLocalStorageArray()
+  const expiryObject = createHowtoExpiryObject(howtoID)
+  const foundIndex = downloadCooldownArray!.findIndex(
+    (elem) => elem.howtoID === howtoID,
+  )
+
+  downloadCooldownArray![foundIndex] = expiryObject
+  localStorage.setItem(
+    'downloadCooldown',
+    JSON.stringify(downloadCooldownArray),
+  )
+}

--- a/src/pages/Howto/DownloadExternal/DownloadExternal.tsx
+++ b/src/pages/Howto/DownloadExternal/DownloadExternal.tsx
@@ -5,6 +5,7 @@ import theme from 'src/themes/styled.theme'
 
 interface IProps {
   link: string
+  handleClick?: () => Promise<void>
 }
 
 const FileFlex = styled(Flex)`
@@ -15,7 +16,10 @@ const FileFlex = styled(Flex)`
 `
 
 export const DownloadExternal = (props: IProps) => (
-  <ExternalLink href={props.link}>
+  <ExternalLink
+    href={props.link}
+    onClick={() => props.handleClick && props.handleClick()}
+  >
     <FileFlex
       p={2}
       mb={1}

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -148,7 +148,7 @@ export class HowtoStore extends ModuleStore {
     if (howToData) {
       const updatedHowto: IHowto = {
         ...howToData,
-        total_downloads: incrementTotalDownloads()
+        total_downloads: incrementTotalDownloads(),
       }
 
       await dbRef.set(updatedHowto)
@@ -356,7 +356,7 @@ export class HowtoStore extends ModuleStore {
         steps: processedSteps,
         fileLink: values.fileLink ?? '',
         files: processedFiles,
-        total_downloads: (processedFiles) ? 0 : undefined,
+        total_downloads: processedFiles ? 0 : undefined,
         moderation: values.moderation
           ? values.moderation
           : 'awaiting-moderation',

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -139,16 +139,10 @@ export class HowtoStore extends ModuleStore {
     const howToData = await toJS(dbRef.get())
     const totalDownloads = howToData?.total_downloads
 
-    const incrementTotalDownloads = () => {
-      if (totalDownloads != undefined) {
-        return totalDownloads + 1
-      }
-    }
-
     if (howToData) {
       const updatedHowto: IHowto = {
         ...howToData,
-        total_downloads: incrementTotalDownloads(),
+        total_downloads: totalDownloads! + 1,
       }
 
       await dbRef.set(updatedHowto)

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -350,7 +350,6 @@ export class HowtoStore extends ModuleStore {
         steps: processedSteps,
         fileLink: values.fileLink ?? '',
         files: processedFiles,
-        total_downloads: processedFiles && 0,
         moderation: values.moderation
           ? values.moderation
           : 'awaiting-moderation',
@@ -363,6 +362,8 @@ export class HowtoStore extends ModuleStore {
             ? values.creatorCountry
             : '',
       }
+      if (processedFiles) howTo['total_downloads'] = 0
+
       logger.debug('populating database', howTo)
       // set the database document
       await dbRef.set(howTo)

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -137,7 +137,7 @@ export class HowtoStore extends ModuleStore {
   public async incrementDownloadCount(howToID: string) {
     const dbRef = this.db.collection<IHowto>(COLLECTION_NAME).doc(howToID)
     const howToData = await toJS(dbRef.get())
-    const totalDownloads = howToData?.total_downloads
+    const totalDownloads = howToData?.total_downloads || 0
 
     if (howToData) {
       const updatedHowto: IHowto = {
@@ -350,7 +350,7 @@ export class HowtoStore extends ModuleStore {
         steps: processedSteps,
         fileLink: values.fileLink ?? '',
         files: processedFiles,
-        total_downloads: processedFiles ? 0 : undefined,
+        total_downloads: processedFiles && 0,
         moderation: values.moderation
           ? values.moderation
           : 'awaiting-moderation',

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -134,6 +134,28 @@ export class HowtoStore extends ModuleStore {
     return validHowtos
   }
 
+  public async incrementDownloadCount(howToID: string) {
+    const dbRef = this.db.collection<IHowto>(COLLECTION_NAME).doc(howToID)
+    const howToData = await toJS(dbRef.get())
+    const totalDownloads = howToData?.total_downloads
+
+    const incrementTotalDownloads = () => {
+      if (totalDownloads != undefined) {
+        return totalDownloads + 1
+      }
+    }
+
+    if (howToData) {
+      const updatedHowto: IHowto = {
+        ...howToData,
+        total_downloads: incrementTotalDownloads()
+      }
+
+      await dbRef.set(updatedHowto)
+      return updatedHowto.total_downloads
+    }
+  }
+
   public updateSearchValue(query: string) {
     this.searchValue = query
   }
@@ -334,6 +356,7 @@ export class HowtoStore extends ModuleStore {
         steps: processedSteps,
         fileLink: values.fileLink ?? '',
         files: processedFiles,
+        total_downloads: (processedFiles) ? 0 : undefined,
         moderation: values.moderation
           ? values.moderation
           : 'awaiting-moderation',


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type
- [x] New feature (non-breaking change which adds functionality)

## Description

I have added a total downloads counter feature. When the download file button is clicked this increments the total_downloads property of the howto model and also updates state inside of the FileInfo component in order to re-render the newly incremented value. 

 - [x] Implemented the logic to not allow users to repeatedly click the button and inflate the downloads counter. I used local storage with a 12 hour cooldown to not let users spam click download. 
  - [x] Styling fixed

BUG: I am also aware that since older howto's don't have a total_downloads property then they currently just show 'downloads' without a value. I didn't implement a conditional check because I was thinking we would update all howto's to have the total_download property if they have an attached file? Or is this feature not going to be retroactive and only affect newly created howto's?

Potential issue with using LocalStorage: a malicious user could find remove the cooldown manually and spam download.