### PR TITLE
Allow notification icon to dim on click

### DIFF
--- a/src/pages/common/Header/Menu/Notifications/NotificationsIcon.tsx
+++ b/src/pages/common/Header/Menu/Notifications/NotificationsIcon.tsx
@@ -1,6 +1,7 @@
 import { Flex } from 'theme-ui'
 import { ReactComponent as IconNotifications } from 'src/assets/icons/icon-notification.svg'
 import styled from '@emotion/styled'
+import { useEffect, useState } from 'react'
 
 const IconWrapper = styled(Flex)`
   display: flex;
@@ -19,12 +20,24 @@ function NotificationsIcon({
   isMobileMenuActive,
   areThereNotifications,
 }) {
+  const [hasUnseenNotifications, setHasUnseenNotifications] = useState<boolean>(
+    areThereNotifications,
+  )
+
+  // To illuminate the icon when new notifications are passed
+  useEffect(() => {
+    setHasUnseenNotifications(areThereNotifications)
+  }, [areThereNotifications])
+
   return (
     <>
       <IconWrapper
         data-cy="toggle-notifications-modal"
         ml={1}
-        onClick={onCLick}
+        onClick={() => {
+          setHasUnseenNotifications(false)
+          onCLick()
+        }}
         style={
           isMobileMenuActive
             ? {
@@ -35,7 +48,7 @@ function NotificationsIcon({
         }
       >
         <IconNotifications
-          color={areThereNotifications ? 'orange' : '#bfbfbf'}
+          color={hasUnseenNotifications ? 'orange' : '#bfbfbf'}
           height="25px"
           width="25px"
         />


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Latest `master` branch merged

PR Type

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Dims the notification icon (to gray colour) on click, regardless of previous state
- Allows user to dismiss orange icon without clearing all unread notifications
- Implements behaviour described by @mattia-io in #1654, common to other platforms
- Does not address @thisislawatts's accessibility concerns in #1654

_First PR here, open to feedback! Eg. not sure if `useState` and `useEffect` are common patterns in this project._

## Git Issues

Closes #1654

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
