### PR TITLE
fix: open links in new tab

### DIFF
--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -23,6 +23,7 @@ import { FlagIconHowTos } from 'oa-components'
 import { VerifiedUserBadge } from 'src/components/VerifiedUserBadge/VerifiedUserBadge'
 import { UsefulStatsButton } from 'src/components/UsefulStatsButton/UsefulStatsButton'
 import { DownloadExternal } from 'src/pages/Howto/DownloadExternal/DownloadExternal'
+import Linkify from 'react-linkify'
 
 interface IProps {
   howto: IHowtoDB
@@ -186,7 +187,9 @@ export default class HowtoDescription extends PureComponent<IProps> {
             <Text
               sx={{ ...theme.typography.paragraph, whiteSpace: 'pre-line' }}
             >
-              {howto.description}
+              <Linkify properties={{ target: '_blank' }}>
+                {howto.description}
+              </Linkify>
             </Text>
           </Box>
 

--- a/src/pages/Howto/Content/Howto/Step/Step.tsx
+++ b/src/pages/Howto/Content/Howto/Step/Step.tsx
@@ -71,7 +71,7 @@ export default class Step extends PureComponent<IProps> {
                         whiteSpace: 'pre-line',
                       }}
                     >
-                      <Linkify>
+                      <Linkify properties={{ target: '_blank' }}>
                         {/* HACK 2021-07-16 - new howtos auto capitalize title but not older */}
                         {capitalizeFirstLetter(step.text)}
                       </Linkify>

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -11,6 +11,7 @@ import theme from 'src/themes/styled.theme'
 import type { IUser } from 'src/models/user.models'
 import { VerifiedUserBadge } from 'src/components/VerifiedUserBadge/VerifiedUserBadge'
 import { UsefulStatsButton } from 'src/components/UsefulStatsButton/UsefulStatsButton'
+import Linkify from 'react-linkify'
 
 interface IProps {
   research: IResearch.ItemDB
@@ -162,7 +163,9 @@ const ResearchDescription: React.FC<IProps> = ({
             {research.title}
           </Heading>
           <Text sx={{ whiteSpace: 'pre-line', ...theme.typography.paragraph }}>
-            {research.description}
+            <Linkify properties={{ target: '_blank' }}>
+              {research.description}
+            </Linkify>
           </Text>
         </Box>
       </Flex>

--- a/src/pages/Research/Content/ResearchUpdate.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.tsx
@@ -123,7 +123,9 @@ const ResearchUpdate: React.FC<IProps> = ({
                   color={'grey'}
                   sx={{ whiteSpace: 'pre-line', ...theme.typography.paragraph }}
                 >
-                  <Linkify>{update.description}</Linkify>
+                  <Linkify properties={{ target: '_blank' }}>
+                    {update.description}
+                  </Linkify>
                 </Text>
               </Box>
             </Flex>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Implements behaviour proposed in #1619
- Parses in-content links with [react-linkify](https://tasti.github.io/react-linkify/) and adds the `target="_blank"` attribute so they open in a new tab
- Applies to how-to descriptions, how-to steps, research descriptions, and research updates
- Based on [this approach](https://github.com/ONEARMY/community-platform/pull/1639/files#diff-7aab05b5c350e50591b3ebe276a7734835df27cdd7b6e1f8f607576f2023cbddR76) for how-to comments and research comments in #1639

## Git Issues

Closes #1619

## Screenshots/Videos

Examples
- [How-to description and step](http://localhost:3000/how-to/test-links-in-description-and-step)
- [Research description](http://localhost:3000/research/test-test)
- Research update: could you, kind reviewer, test this one? 😅 (I couldn't figure out how)

![image](https://user-images.githubusercontent.com/36117635/170902407-479a1c8d-5113-4636-8e20-46962d41bf3e.png)
