### PR TITLE
Feat/lazy images

### DIFF
--- a/packages/components/src/MemberBadge/MemberBadge.tsx
+++ b/packages/components/src/MemberBadge/MemberBadge.tsx
@@ -14,6 +14,7 @@ export const MemberBadge = (props: Props) => {
 
   return (
     <Image
+      loading="lazy"
       className="avatar"
       sx={{ width: size ? size : 40, borderRadius: '50%' }}
       height={size ? size : 40}

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -76,6 +76,7 @@ export class Avatar extends Component<IProps, IState> {
     return (
       <>
         <Image
+          loading="lazy"
           className="avatar"
           sx={{ width: width ? width : 40, borderRadius: '25px' }}
           height={width ? width : 40}

--- a/src/components/Comment/CommentHeader.tsx
+++ b/src/components/Comment/CommentHeader.tsx
@@ -30,7 +30,13 @@ export const CommentHeader = ({
             {creatorName}
           </Link>
           {isUserVerified ? (
-            <Image src={VerifiedBadgeIcon} ml={1} height="12px" width="12px" />
+            <Image
+              loading="lazy"
+              src={VerifiedBadgeIcon}
+              ml={1}
+              height="12px"
+              width="12px"
+            />
           ) : null}
         </span>
       </Box>

--- a/src/components/DropdownIndicator/index.tsx
+++ b/src/components/DropdownIndicator/index.tsx
@@ -6,6 +6,6 @@ import ArrowSelectIcon from '../../assets/icons/icon-arrow-select.svg'
 export const DropdownIndicator = (props) =>
   components.DropdownIndicator && (
     <components.DropdownIndicator {...props}>
-      <Image src={ArrowSelectIcon} sx={{ width: '12px' }} />
+      <Image loading="lazy" src={ArrowSelectIcon} sx={{ width: '12px' }} />
     </components.DropdownIndicator>
   )

--- a/src/components/ImageGallery/ImageGallery.tsx
+++ b/src/components/ImageGallery/ImageGallery.tsx
@@ -106,6 +106,7 @@ export class ImageGallery extends PureComponent<IProps, IState> {
                   key={index}
                 >
                   <ThumbImage
+                    loading="lazy"
                     src={image.downloadUrl}
                     key={index}
                     crossOrigin=""

--- a/src/components/ImageGallery/ImageGallery.tsx
+++ b/src/components/ImageGallery/ImageGallery.tsx
@@ -84,6 +84,7 @@ export class ImageGallery extends PureComponent<IProps, IState> {
       <Flex sx={{ flexDirection: 'column' }}>
         <Flex sx={{ width: '100%' }}>
           <ImageWithPointer
+            loading="lazy"
             data-cy="active-image"
             sx={{ width: '100%' }}
             src={this.state.activeImage.downloadUrl}

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -44,7 +44,13 @@ export class Loader extends Component<IProps> {
     return (
       <>
         <Flex sx={{ flexWrap: 'wrap', justifyContent: 'center' }}>
-          {logo && <RotatingLogo src={logo} sx={{ width: [75, 75, 100] }} />}
+          {logo && (
+            <RotatingLogo
+              loading="lazy"
+              src={logo}
+              sx={{ width: [75, 75, 100] }}
+            />
+          )}
           <Text sx={{ width: '100%', textAlign: 'center' }}>loading...</Text>
         </Flex>
       </>

--- a/src/components/VerifiedUserBadge/VerifiedUserBadge.tsx
+++ b/src/components/VerifiedUserBadge/VerifiedUserBadge.tsx
@@ -14,6 +14,7 @@ export const VerifiedUserBadge = (props: IProps) => {
   const isVerified = aggregationsStore.aggregations.users_verified?.[userId]
   return isVerified ? (
     <Image
+      loading="lazy"
       src={VerifiedBadgeIcon}
       height={props.height}
       sx={{ width: props.height }}

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -91,6 +91,7 @@ export default class HowtoDescription extends PureComponent<IProps> {
               >
                 <Flex>
                   <Image
+                    loading="lazy"
                     sx={{
                       width: '10px',
                       marginRight: '4px',
@@ -192,15 +193,30 @@ export default class HowtoDescription extends PureComponent<IProps> {
 
           <Flex mt="4">
             <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
-              <Image src={StepsIcon} height="16" width="23" mr="2" mb="2" />
+              <Image
+                loading="lazy"
+                src={StepsIcon}
+                height="16"
+                width="23"
+                mr="2"
+                mb="2"
+              />
               {howto.steps.length} steps
             </Flex>
             <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
-              <Image src={TimeNeeded} height="16" width="16" mr="2" mb="2" />
+              <Image
+                loading="lazy"
+                src={TimeNeeded}
+                height="16"
+                width="16"
+                mr="2"
+                mb="2"
+              />
               {howto.time}
             </Flex>
             <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
               <Image
+                loading="lazy"
                 src={DifficultyLevel}
                 height="15"
                 width="16"
@@ -241,6 +257,7 @@ export default class HowtoDescription extends PureComponent<IProps> {
           }}
         >
           <Image
+            loading="lazy"
             sx={{
               objectFit: 'cover',
               width: 'auto',

--- a/src/pages/Maps/Content/Controls/GroupingFilterDesktop.tsx
+++ b/src/pages/Maps/Content/Controls/GroupingFilterDesktop.tsx
@@ -83,13 +83,13 @@ class GroupingFilterDesktop extends Component<IProps, IState> {
           key={option.label}
         >
           <Flex sx={{ alignItems: 'center' }}>
-            <Image width="30px" src={option.icon} />
+            <Image loading="lazy" width="30px" src={option.icon} />
             <Text sx={{ fontSize: 2 }} ml="10px">
               {option.label} ({option.number})
             </Text>
           </Flex>
           {selectedItems.includes(option.value) && (
-            <Image src={checkmarkIcon} width="20px" />
+            <Image loading="lazy" src={checkmarkIcon} width="20px" />
           )}
         </Flex>
       )

--- a/src/pages/Maps/Content/Controls/GroupingFilterMobile.tsx
+++ b/src/pages/Maps/Content/Controls/GroupingFilterMobile.tsx
@@ -96,13 +96,13 @@ class GroupingFilterMobile extends Component<IProps, IState> {
             key={filter.label}
           >
             <Flex sx={{ alignItems: 'center' }}>
-              <Image width="30px" src={filter.icon} />
+              <Image loading="lazy" width="30px" src={filter.icon} />
               <Text sx={{ fontSize: 2 }} ml="10px">
                 {filter.label} ({filter.number})
               </Text>
             </Flex>
             {selectedItems.includes(filter.value) && (
-              <Image src={checkmarkIcon} width="20px" />
+              <Image loading="lazy" src={checkmarkIcon} width="20px" />
             )}
           </Flex>
         ))}

--- a/src/pages/Maps/Content/Controls/index.tsx
+++ b/src/pages/Maps/Content/Controls/index.tsx
@@ -169,6 +169,7 @@ class Controls extends React.Component<IProps, IState> {
             <Flex p={0} mx={-1} sx={{ justifyContent: 'space-between' }}>
               <Text sx={{ fontWeight: 'bold' }}>Select filters</Text>
               <Image
+                loading="lazy"
                 width="25px"
                 src={crossClose}
                 alt="cross-close"

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -126,6 +126,7 @@ export class Popup extends React.Component<IProps> {
               {displayName}
               {verifiedBadge && (
                 <Image
+                  loading="lazy"
                   src={VerifiedBadgeIcon}
                   width="22px"
                   height="22px"

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -63,6 +63,7 @@ const ResearchDescription: React.FC<IProps> = ({
             >
               <Flex>
                 <Image
+                  loading="lazy"
                   sx={{
                     width: '10px',
                     marginRight: '4px',

--- a/src/pages/Settings/content/formSections/Fields/CustomCheckbox.field.tsx
+++ b/src/pages/Settings/content/formSections/Fields/CustomCheckbox.field.tsx
@@ -86,6 +86,7 @@ class CustomCheckbox extends Component<IProps, IState> {
         />
         {imageSrc && (
           <Image
+            loading="lazy"
             px={3}
             src={imageSrc}
             sx={{ width: ['70px', '70px', '100%'] }}

--- a/src/pages/Settings/content/formSections/Fields/CustomRadio.field.tsx
+++ b/src/pages/Settings/content/formSections/Fields/CustomRadio.field.tsx
@@ -111,6 +111,7 @@ class CustomRadioField extends Component<IProps, IState> {
         />
         {imageSrc && (
           <Image
+            loading="lazy"
             px={3}
             src={imageSrc}
             sx={{ width: ['100px', '100px', '100%'] }}

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -71,6 +71,7 @@ export const MemberProfile = ({ user }: IProps) => {
         <Box mr={3} style={{ flexGrow: 1, minWidth: 'initial' }}>
           <MemberPicture>
             <Image
+              loading="lazy"
               src={
                 user.coverImages[0]
                   ? (user.coverImages[0] as IUploadedFileMeta).downloadUrl

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -154,19 +154,19 @@ function renderPlasticTypes(plasticTypes: Array<PlasticTypeLabel>) {
   function renderIcon(type: string) {
     switch (type) {
       case 'hdpe':
-        return <Image src={HDPEIcon} />
+        return <Image loading="lazy" src={HDPEIcon} />
       case 'ldpe':
-        return <Image src={LDPEIcon} />
+        return <Image loading="lazy" src={LDPEIcon} />
       case 'other':
-        return <Image src={OtherIcon} />
+        return <Image loading="lazy" src={OtherIcon} />
       case 'pet':
-        return <Image src={PETIcon} />
+        return <Image loading="lazy" src={PETIcon} />
       case 'pp':
-        return <Image src={PPIcon} />
+        return <Image loading="lazy" src={PPIcon} />
       case 'ps':
-        return <Image src={PSIcon} />
+        return <Image loading="lazy" src={PSIcon} />
       case 'pvc':
-        return <Image src={PVCIcon} />
+        return <Image loading="lazy" src={PVCIcon} />
       default:
         return null
     }

--- a/src/pages/User/content/UserStats.tsx
+++ b/src/pages/User/content/UserStats.tsx
@@ -49,7 +49,12 @@ export const UserStats = ({ user }: IProps) => {
     <UserStatsBox mt={3} p={2} pb={0}>
       {user.badges?.verified && (
         <UserStatsBoxItem>
-          <Image src={VerifiedBadgeIcon} width="22px" height="22px" />
+          <Image
+            loading="lazy"
+            src={VerifiedBadgeIcon}
+            width="22px"
+            height="22px"
+          />
           <Box ml="5px">Verified</Box>
         </UserStatsBoxItem>
       )}

--- a/src/pages/common/Header/Menu/Logo/Logo.tsx
+++ b/src/pages/common/Header/Menu/Logo/Logo.tsx
@@ -59,6 +59,7 @@ export class Logo extends Component<IProps> {
               }}
             >
               <Image
+                loading="lazy"
                 src={logo}
                 sx={{
                   width: [50, 50, 100],


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

On most pages we use image that load eagerly (the moment the page loads images try to load even when not on screen). This is expensive on bandwidth and also can result in a lot of network requests that impact on SEO (e.g. googlebot limits 25 resources and may miss out on key js/css if loading lots of images). We use a virtual scroller to limit this impact on the main howto list page, however individual howto items can also often contain 20+ images so good to have here too

This PR tries to add a `loading='lazy'` strategy for all images that could be found (including ones generated through styled components as `styled(image)`

## Review Notes
@thisislawatts - I searched for `<Image` to match all theme-ui and vanilla image tags, as well as `styled(image)`, but let me know if you think there might be any more image tags I could have missed

@davehakkens - The idea here is that the images only load just a little before they are scrolled into view, and so the user should not notice that they are not loaded. But it would be good if you could take a quick browser on the preview site in case you notice any pages where the images appear to load extra slowly

## Git Issues

Closes #

## Screenshots/Videos

**Before** - all images loaded on page load

https://user-images.githubusercontent.com/10515065/172474119-765d1f78-3129-4bd8-a5a5-ba21185d32df.mp4

**After** - images are loading on demand (while scrolling)

https://user-images.githubusercontent.com/10515065/172473799-95837434-36f5-41cb-8cc2-6232e8a417ac.mp4



---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
