### PR TITLE
chore(ci): bump action to use latest version of node action

### DIFF
--- a/.github/workflows/reset-staging-site.yml
+++ b/.github/workflows/reset-staging-site.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
       - name: Set up Cloud SDK
         uses:
           google-github-actions/setup-gcloud@master


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

We have been seeing some flakey builds in our GitHub actions, the error is usually something like:

```
Error: The process '/opt/hostedtoolcache/node/16.15.1/x64/bin/npx' failed with exit code 127
```

Hoping that bumping to the latest version of the action may help here 🤞🏻 