### PR TITLE
fix: badge icons for specialist workshops

### DIFF
--- a/src/pages/Maps/Content/Controls/GroupingFilterDesktop.tsx
+++ b/src/pages/Maps/Content/Controls/GroupingFilterDesktop.tsx
@@ -9,6 +9,7 @@ import type { MapsStore } from 'src/stores/Maps/maps.store'
 import { Box, Flex, Image, Text } from 'theme-ui'
 import { SelectStyles } from 'src/components/Form/Select.field'
 import { MemberBadge } from 'oa-components'
+import { transformSpecialistWorkspaceTypeToWorkspace } from './transformSpecialistWorkspaceTypeToWorkspace'
 
 interface IProps {
   items: Record<IPinGrouping, Array<IMapGrouping>>
@@ -84,7 +85,12 @@ class GroupingFilterDesktop extends Component<IProps, IState> {
           key={option.label}
         >
           <Flex sx={{ alignItems: 'center' }}>
-            <MemberBadge profileType={option.value} size={30} />
+            <MemberBadge
+              profileType={transformSpecialistWorkspaceTypeToWorkspace(
+                option.value,
+              )}
+              size={30}
+            />
             <Text sx={{ fontSize: 2 }} ml="10px">
               {option.label} ({option.number})
             </Text>

--- a/src/pages/Maps/Content/Controls/GroupingFilterMobile.tsx
+++ b/src/pages/Maps/Content/Controls/GroupingFilterMobile.tsx
@@ -1,9 +1,11 @@
 import { inject } from 'mobx-react'
+import { MemberBadge } from 'oa-components'
 import { Component } from 'react'
 import checkmarkIcon from 'src/assets/icons/icon-checkmark.svg'
 import type { IMapGrouping } from 'src/models/maps.models'
 import type { MapsStore } from 'src/stores/Maps/maps.store'
 import { Flex, Image, Text } from 'theme-ui'
+import { transformSpecialistWorkspaceTypeToWorkspace } from './transformSpecialistWorkspaceTypeToWorkspace'
 
 interface IProps {
   items: Array<IMapGrouping>
@@ -96,7 +98,12 @@ class GroupingFilterMobile extends Component<IProps, IState> {
             key={filter.label}
           >
             <Flex sx={{ alignItems: 'center' }}>
-              <Image loading="lazy" width="30px" src={filter.icon} />
+              <MemberBadge
+                profileType={transformSpecialistWorkspaceTypeToWorkspace(
+                  filter.value,
+                )}
+                size={30}
+              />
               <Text sx={{ fontSize: 2 }} ml="10px">
                 {filter.label} ({filter.number})
               </Text>

--- a/src/pages/Maps/Content/Controls/transformSpecialistWorkspaceTypeToWorkspace.tsx
+++ b/src/pages/Maps/Content/Controls/transformSpecialistWorkspaceTypeToWorkspace.tsx
@@ -1,0 +1,9 @@
+export function transformSpecialistWorkspaceTypeToWorkspace(
+  type: string,
+): string {
+  return ['extrusion', 'injection', 'shredder', 'sheetpress', 'mix'].includes(
+    type,
+  )
+    ? 'workspace'
+    : type
+}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Addresses an issue where specialist workspace types were being incorrectly resolved to a fallback badge.

## Screenshots/Videos

**Before:**

![image (3)](https://user-images.githubusercontent.com/472589/173567136-bd54fffb-70e3-4e17-b7bb-da934e72aac0.png)

**After**

![Screenshot 2022-06-14 at 13 35 00](https://user-images.githubusercontent.com/472589/173568184-80ea0c10-0d3b-438f-8aa0-ab9b18d534bc.jpg)
