### PR TITLE
chore(ci): generate releases on master(default) branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["production"],
+  "branches": ["master"],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Originally the releases were generated _after_ the code
had been deployed to a production environment. However
as the number of deployed instances has increased past one,
the question is if code is partially deployed has been released?

Not wishing to get lost down that rabbit hole we opted to declare
code released _before_ it is then deployed to the instances.