### PR TITLE
fix: aggregations limit

### DIFF
--- a/functions/src/aggregations/common.aggregations.ts
+++ b/functions/src/aggregations/common.aggregations.ts
@@ -112,8 +112,9 @@ class AggregationHandler {
         updates.push({ ref: this.targetDocRef, entry: aggregationEntry })
       }
     }
-    // split updates into batches of 500 with 1s pause between
-    const chunks = splitArrayToChunks(updates, 500)
+    // firebase supports up to 500 requests every second
+    // as each update uses 2 ops (set + update) run in batches of 250
+    const chunks = splitArrayToChunks(updates, 250)
     for (const [index, chunk] of chunks.entries()) {
       const batch = db.batch()
       if (index === 0) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
The user badges aggregation keeps failing to seed due to max write issues
![image](https://user-images.githubusercontent.com/10515065/174170152-2923fed7-fe9a-42d3-b9da-b8eec05b1145.png)

The code already batches requests to limit to 500 updates per second, however it may be the case that some updates are counted twice so limiting to 250 instead

Once merged it can be tested by toggling the badge status for any of the users

In the emulator everything already worked before so hard to test, example output below

![image](https://user-images.githubusercontent.com/10515065/174170433-9d9b48f2-5c4a-4e7e-8470-c0f65ca23aef.png)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
