### PR TITLE
chore: change slack fail notification mention

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
       - setup_repo
       - run:
           command: yarn lint
-      - run: 
+      - run:
           command: yarn workspace oa-components lint
   # Prepare node module caches so that future tasks run more quickly
   # NOTE - not currently used as we only have one workflow
@@ -324,7 +324,7 @@ jobs:
           steps:
             - slack/notify:
                 event: fail
-                mentions: '@Chris Clarke'
+                mentions: '@channel'
                 template: basic_fail_1
             - slack/notify:
                 event: pass


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

When builds fail a message is posted to slack. The message tries to tag me but
a) I'm super unresponsive
b) It doesn't tag me correctly

This makes fail notifications try to tag `@channel` instead. Hopefully we will never see this...

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/174181102-7e91acaf-5881-46d1-98ab-1dd82113a6fc.png)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
