### PR TITLE
fix: populate users_verified as boolean

### DIFF
--- a/functions/src/aggregations/user.aggregations.ts
+++ b/functions/src/aggregations/user.aggregations.ts
@@ -22,8 +22,9 @@ const userAggregations: IUserAggregation[] = [
     process: ({ dbChange }) => {
       const user: IUserDB = dbChange.after.data() as any
       // return user doc id and verified status (removing entry if not verified)
+      const value = user.badges?.verified ? true : VALUE_MODIFIERS.delete()
       return {
-        [dbChange.after.id]: user.badges?.verified || VALUE_MODIFIERS.delete(),
+        [dbChange.after.id]: value,
       }
     },
   },


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

User verified aggregation populates the value from the saved badge field, however some of these are populates as string `"true"` instead of boolean `true`, which then doesn't show up in some filters. See example from screenshots in #1782

This forces a boolean value on the aggregation.

Note - it will only apply to users changed after the fix has been deployed (existing users manually migrated)

## Git Issues

Closes #

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/10515065/174203237-df02cd6e-896b-4baa-ae34-bd9b682dc6e5.png)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
