### PR TITLE
fix: update hosting-preview action

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,9 +13,9 @@ on:
   #     - '.github/workflows/pr-preview.yml'
   #     - 'package.json'
   #     - 'yarn.lock'
-  push:
-    branches:
-      - fix/hosting-preview
+  pull_request:
+    types: [labeled, synchronize]
+
 jobs:
   build_and_preview:
     # NOTE - as we are going to check out and build from forks we also need to add manual
@@ -72,5 +72,5 @@ jobs:
           projectId: onearmy-next
           # The action usually generates based on PR title, but easier to just provide our
           # own channelId from the PR number (could also include hash if wanting to support multiple)
-          channelId: 'pr-${{ github.event.number }}'
+          channelId: 'pr-${{ github.event.issue.number }}'
           # channelId: 'pr-${{ github.event.number }}'-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/pr-preview.yml'
       - 'package.json'
       - 'yarn.lock'
-   push:
+  push:
     branches:
       - fix/hosting-preview
 jobs:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,10 +7,12 @@ on:
     types: [labeled, synchronize]
     # Only create a preview if changes have been made to the main src code or backend functions
     paths:
-      - "src/**"
-      - "functions/**"
-      - "package.json"
-      - "yarn.lock"
+      - 'src/**'
+      - 'functions/**'
+      - 'packages/components/**'
+      - '.github/workflows/pr-preview.yml'
+      - 'package.json'
+      - 'yarn.lock'
 jobs:
   build_and_preview:
     # NOTE - as we are going to check out and build from forks we also need to add manual
@@ -53,11 +55,15 @@ jobs:
           CI: false
           # specify the 'preview' site variant to populate the relevant firebase config
           REACT_APP_SITE_VARIANT: preview
+        # The hosting-deploy action calls firebase tools via npx, however installing globally
+        # gives us control over what version will be made available
+      - name: Install firebase-tools globally
+        run: npm i -g firebase-tools
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
           # the details of the service account need to be populated to github secrets
           # these must match the target projectId account
-          firebaseServiceAccount: "${{ secrets.ONEARMY_NEXT_FIREBASE_SERVICE_ACCOUNT }}"
+          firebaseServiceAccount: '${{ secrets.ONEARMY_NEXT_FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           projectId: onearmy-next

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -19,7 +19,7 @@ jobs:
     # NOTE - as we are going to check out and build from forks we also need to add manual
     # check that malicious code has not been inserted. This is handled by manually labelling the PR
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
-    # if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
+    if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,7 +1,7 @@
 # Create and deploy a build on all pull requests
 name: PR Preview
 on:
-  use pull_request_target so that secrets accessible from fork
+  # use pull_request_target so that secrets accessible from fork
   pull_request_target:
     # Trigger when labels are changed or more commits added to a PR that contains labels
     types: [labeled, synchronize]

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,20 +1,18 @@
 # Create and deploy a build on all pull requests
 name: PR Preview
 on:
-  # use pull_request_target so that secrets accessible from fork
-  # pull_request_target:
-  #   # Trigger when labels are changed or more commits added to a PR that contains labels
-  #   types: [labeled, synchronize]
-  #   # Only create a preview if changes have been made to the main src code or backend functions
-  #   paths:
-  #     - 'src/**'
-  #     - 'functions/**'
-  #     - 'packages/components/**'
-  #     - '.github/workflows/pr-preview.yml'
-  #     - 'package.json'
-  #     - 'yarn.lock'
-  pull_request:
+  use pull_request_target so that secrets accessible from fork
+  pull_request_target:
+    # Trigger when labels are changed or more commits added to a PR that contains labels
     types: [labeled, synchronize]
+    # Only create a preview if changes have been made to the main src code or backend functions
+    paths:
+      - 'src/**'
+      - 'functions/**'
+      - 'packages/components/**'
+      - '.github/workflows/pr-preview.yml'
+      - 'package.json'
+      - 'yarn.lock'
 
 jobs:
   build_and_preview:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -70,7 +70,3 @@ jobs:
           firebaseServiceAccount: '${{ secrets.ONEARMY_NEXT_FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           projectId: onearmy-next
-          # The action usually generates based on PR title, but easier to just provide our
-          # own channelId from the PR number (could also include hash if wanting to support multiple)
-          channelId: 'pr-${{ github.event.issue.number }}'
-          # channelId: 'pr-${{ github.event.number }}'-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/pr-preview.yml'
       - 'package.json'
       - 'yarn.lock'
+   push:
+    branches:
+      - fix/hosting-preview
 jobs:
   build_and_preview:
     # NOTE - as we are going to check out and build from forks we also need to add manual

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -70,5 +70,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.ONEARMY_NEXT_FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           projectId: onearmy-next
+          # The action usually generates based on PR title, but easier to just provide our
+          # own channelId from the PR number (could also include hash if wanting to support multiple)
           channelId: 'pr-${{ github.event.number }}'
           # channelId: 'pr-${{ github.event.number }}'-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -70,3 +70,5 @@ jobs:
           firebaseServiceAccount: '${{ secrets.ONEARMY_NEXT_FIREBASE_SERVICE_ACCOUNT }}'
           expires: 30d
           projectId: onearmy-next
+          channelId: 'pr-${{ github.event.number }}'
+          # channelId: 'pr-${{ github.event.number }}'-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,17 +2,17 @@
 name: PR Preview
 on:
   # use pull_request_target so that secrets accessible from fork
-  pull_request_target:
-    # Trigger when labels are changed or more commits added to a PR that contains labels
-    types: [labeled, synchronize]
-    # Only create a preview if changes have been made to the main src code or backend functions
-    paths:
-      - 'src/**'
-      - 'functions/**'
-      - 'packages/components/**'
-      - '.github/workflows/pr-preview.yml'
-      - 'package.json'
-      - 'yarn.lock'
+  # pull_request_target:
+  #   # Trigger when labels are changed or more commits added to a PR that contains labels
+  #   types: [labeled, synchronize]
+  #   # Only create a preview if changes have been made to the main src code or backend functions
+  #   paths:
+  #     - 'src/**'
+  #     - 'functions/**'
+  #     - 'packages/components/**'
+  #     - '.github/workflows/pr-preview.yml'
+  #     - 'package.json'
+  #     - 'yarn.lock'
   push:
     branches:
       - fix/hosting-preview
@@ -21,7 +21,7 @@ jobs:
     # NOTE - as we are going to check out and build from forks we also need to add manual
     # check that malicious code has not been inserted. This is handled by manually labelling the PR
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
-    if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
+    # if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Our automation action to deploy previews to firebase seems to be failing, e.g.
https://github.com/ONEARMY/community-platform/runs/6974256199?check_suite_focus=true

The error suggests an issue with how the 3rd-party firebase-hosting-deploy action calls the firebase cli (`firebase-tools`) using npx.
This installs the firebase cli globally instead so that it should be available when the action calls also.

Should be working now, although as the default action relies on pull_request_target it will only use the code from this function after merge into master (I manually forced the action to run for the demo below by changing the trigger to pull_request):
https://github.com/ONEARMY/community-platform/runs/6975113104?check_suite_focus=true

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
