### PR TITLE
fix: download counter not resetting to 0 on howto edit

### DIFF
--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -70,6 +70,7 @@ describe('[How To]', () => {
       slug: 'create-a-how-to-test',
       fileLink: 'http://google.com/',
       files: [],
+      total_downloads: 0,
       tags: {
         EOVeOZaKKw1UJkDIf3c3: true,
       },
@@ -159,6 +160,9 @@ describe('[How To]', () => {
         .should('include', `/how-to/create-a-how-to-test`)
 
       cy.step('Howto was created correctly')
+      cy.get('[data-cy=file-download-counter]')
+        .contains(expected.total_downloads)
+        .should('exist')
       cy.queryDocuments('howtos', 'title', '==', expected.title).then(
         (docs) => {
           cy.log('queryDocs', docs)
@@ -218,6 +222,8 @@ describe('[How To]', () => {
       description: 'After editing, all changes are reverted',
       difficulty_level: 'Hard',
       files: [],
+      fileLink: 'http://google.com/',
+      total_downloads: 10,
       slug: 'this-is-an-edit-test',
       tags: { EOVeOZaKKw1UJkDIf3c3: true },
       time: '3-4 weeks',
@@ -351,6 +357,9 @@ describe('[How To]', () => {
         .url()
         .should('include', '/how-to/this-is-an-edit-test')
       cy.get('[data-cy=how-to-basis]').contains('This is an edit test')
+      cy.get('[data-cy=file-download-counter]')
+        .contains(expected.total_downloads)
+        .should('exist')
       cy.queryDocuments('howtos', 'title', '==', 'This is an edit test').then(
         (docs) => {
           cy.log('queryDocs', docs)

--- a/shared/mocks/data/howtos.ts
+++ b/shared/mocks/data/howtos.ts
@@ -19,6 +19,8 @@ export const howtos = {
     _id: '0EwdD1IMrwXcOncqVwOl',
     difficulty_level: 'Easy',
     files: [],
+    fileLink: 'http://google.com/',
+    total_downloads: 10,
     steps: [
       {
         title: 'Get the code',

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -311,6 +311,7 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
               ))}
               {typeof this.state.fileDownloadCount === 'number' && (
                 <Text
+                  data-cy="file-download-counter"
                   sx={{
                     fontSize: '12px',
                     color: '#61646B',

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -362,7 +362,8 @@ export class HowtoStore extends ModuleStore {
             ? values.creatorCountry
             : '',
       }
-      if (processedFiles) howTo['total_downloads'] = 0
+      if (processedFiles && !howTo['total_downloads'])
+        howTo['total_downloads'] = 0
 
       logger.debug('populating database', howTo)
       // set the database document


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

I realized that I had forgot to implement a check to stop the counter from being reset when the howto is edited.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
