### PR TITLE
fix: avoid calling sessionStorage from non-browser env

### DIFF
--- a/shared/models/db.ts
+++ b/shared/models/db.ts
@@ -33,13 +33,17 @@ export const dbEndpointSubollections = {
 // (e.g. cypress will instead use it's own env to populate a prefix)
 const e = process ? process.env : ({} as any)
 
+// Check if window exists (running in browser environment), use window sessionStorage available
+const storage =
+  typeof window === 'undefined' ? ({} as any) : window.sessionStorage
+
 /**
  * A prefix can be used to simplify large-scale schema changes or multisite hosting
  * and allow multiple sites to use one DB (used for parallel test seed DBs)
  * e.g. oa_
  * SessionStorage prefixes are used to allow test ci environments to dynamically set a db endpoint
  */
-const DB_PREFIX = sessionStorage.DB_PREFIX || e.REACT_APP_DB_PREFIX || ''
+const DB_PREFIX = storage.DB_PREFIX || e.REACT_APP_DB_PREFIX || ''
 
 /**
  * Mapping of generic database endpoints to specific prefixed and revisioned versions for the

--- a/shared/models/db.ts
+++ b/shared/models/db.ts
@@ -33,9 +33,9 @@ export const dbEndpointSubollections = {
 // (e.g. cypress will instead use it's own env to populate a prefix)
 const e = process ? process.env : ({} as any)
 
-// Check if window exists (running in browser environment), use window sessionStorage available
+// Check if sessionStorage exists (e.g. running in browser environment), and use if available
 const storage =
-  typeof window === 'undefined' ? ({} as any) : window.sessionStorage
+  typeof sessionStorage === 'undefined' ? ({} as any) : sessionStorage
 
 /**
  * A prefix can be used to simplify large-scale schema changes or multisite hosting


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
The shared db endpoint generator method which includes a check for any prefix stored in sessionStorage (as used by cypress tests), however when running on backend functions the sessionStorage object is not available, so this throws an error. It seems a recent update might have started to check and catch these things, instead of previously running unnoticed.

This pr adds a check for to see if sessionStorage is available before trying to use (via `typeof sessionStorage === 'undefined'`)

Seen in:
https://app.circleci.com/pipelines/github/ONEARMY/community-platform/2669/workflows/afbed966-55a3-4015-a6a3-ed8722699414/jobs/15743

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
