### PR TITLE
fix: do not show map filters if there are no items

### DIFF
--- a/src/pages/Maps/Content/Controls/transformAvailableFiltersToGroups.tsx
+++ b/src/pages/Maps/Content/Controls/transformAvailableFiltersToGroups.tsx
@@ -38,6 +38,7 @@ function asOptions(mapStore, items: Array<IMapGrouping>): FilterGroupOption[] {
           ),
       }
     })
+    .filter(({ number }) => !!number)
 }
 
 type FilterGroupOption = {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Will not show filters in the map dropdown if there are no items belonging to that group.

## Git Issues

Closes [#1775](https://github.com/ONEARMY/community-platform/issues/1775)

## Screenshots/Videos

**Before**

![Screenshot 2022-06-27 at 21 08 58](https://user-images.githubusercontent.com/472589/176020700-08174268-ab51-4bd6-a829-2ea14cd3e0f9.jpg)

**After**

![Screenshot 2022-06-27 at 21 09 51](https://user-images.githubusercontent.com/472589/176020705-ee12198c-bf43-45f1-8c3e-bde0a3bf3a1f.jpg)


