### PR TITLE
fix: pin firebase tools ci version to fix  regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,8 @@ commands:
     steps:
       - run:
           name: Install Firebase Tools
-          command: yarn add -D firebase-tools
+          # Pinned to 11.1.0 pending fix of https://github.com/firebase/firebase-tools/issues/4697
+          command: yarn add -D firebase-tools@11.1.0
       - when:
           condition: <<parameters.use_application_credentials>>
           steps:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Pin CI version of firebase tools to unblock build due to regression seen in firebase tools:
`https://github.com/firebase/firebase-tools/issues/4697`

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
