### PR TITLE
fix: return sitemap as file

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,7 +16,7 @@
         "function": "seoRender"
       },
       {
-        "source": "/sitemap",
+        "source": "/sitemap.xml",
         "function": "seo-sitemapProxy"
       },
       {

--- a/functions/src/seo/sitemap/sitemapProxy.ts
+++ b/functions/src/seo/sitemap/sitemapProxy.ts
@@ -1,4 +1,7 @@
 import * as functions from 'firebase-functions'
+import { writeFileSync } from 'fs-extra'
+import { tmpdir } from 'os'
+import path from 'path'
 import { bucket } from '../../Firebase/storage'
 import { generateSitemap } from './sitemapGenerate'
 
@@ -12,20 +15,24 @@ export const handleSitemapProxy = async (
   req: functions.https.Request,
   res: functions.Response,
 ) => {
+  let sitemapString: string
   const ref = bucket.file('sitemap.xml')
   const [exists] = await ref.exists()
+  // If sitemap already exists read from storage
+  if (exists) {
+    const data = await ref.download()
+    sitemapString = Buffer.from(...data).toString()
+  }
   // If sitemap does not exist (e.g. new site) try to generate
-  if (!exists) {
-    const sitemapString = await generateSitemap()
-    if (sitemapString) {
-      res.send(sitemapString)
-    } else {
-      res.status(404).send()
-    }
+  else {
+    sitemapString = await generateSitemap()
+  }
+  if (!sitemapString) {
+    res.status(404).send()
     return
   }
-  // Otherwise read the sitemap from storage and return
-  const data = await ref.download()
-  const sitemapString = Buffer.from(...data).toString()
-  res.send(sitemapString)
+  // Write to disk and return as a file
+  const sitemapPath = path.resolve(tmpdir(), 'sitemap.xml')
+  writeFileSync(sitemapPath, sitemapString)
+  res.status(200).sendFile(sitemapPath)
 }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Small update to the sitemap generator to run via `/sitemap.xml` instead of `/sitemap` and return as a file instead of a string. Previously it was assumed not possible (static files should take priority over rewrites), however reading around and testing in local emulators suggests this should actually work.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
