### PR TITLE
fix: reduced how-to heading padding for mobile

### DIFF
--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -112,7 +112,7 @@ export class HowtoList extends React.Component<any, IState> {
 
     return (
       <Box>
-        <Flex py={26}>
+        <Flex sx={{ paddingTop: [10, 26], paddingBottom: [10, 26] }}>
           {referrerSource ? (
             <Box sx={{ width: '100%' }}>
               <Heading


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Fixes padding for heading within how-to.

## Git Issues

Closes #1849 

## Screenshots/Videos

<img width="368" alt="image" src="https://user-images.githubusercontent.com/17976252/181904779-e16e7771-2b3f-45d2-bc5f-8fdd40a7b983.png">

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
