### PR TITLE
fix: add visibility to SelectField child items when exceeding parent

### DIFF
--- a/src/pages/Settings/content/formSections/elements.tsx
+++ b/src/pages/Settings/content/formSections/elements.tsx
@@ -36,7 +36,7 @@ export const HiddenInput = styled(Field)`
 `
 
 export const FlexSectionContainer = (props) => (
-  <Card mt={4}>
+  <Card mt={4} style={{ overflow: 'visible' }}>
     <Flex p={4} sx={{ flexWrap: 'nowrap', flexDirection: 'column' }}>
       {props.children}
     </Flex>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR adds a css property that allows a SelectField to show its children when exceeding it parent

## Git Issues

Closes #1866 

## Screenshots/Videos

[Video](https://streamtape.com/v/xODO30vG1wTkKLB/2022-08-07_14-33-14.mkv)

