### PR TITLE
feat: remove map zoom control on mobile/tablet

### DIFF
--- a/src/pages/Maps/Content/View/index.tsx
+++ b/src/pages/Maps/Content/View/index.tsx
@@ -46,7 +46,7 @@ class MapView extends React.Component<IProps> {
   }
   componentDidMount() {
     if (this.props.mapRef.current) {
-      return this.props.mapRef.current.leafletElement.zoomControl.setPosition(
+      return this.props.mapRef.current.leafletElement.zoomControl?.setPosition(
         'bottomleft',
       )
     }
@@ -73,6 +73,7 @@ class MapView extends React.Component<IProps> {
   public render() {
     const { center, zoom, pins } = this.props
     const { activePin } = this.injected.mapsStore
+    const isViewportGreaterThanTablet = window.innerWidth > 1024
 
     const mapCenter: LatLngExpression = center
       ? [center.lat, center.lng]
@@ -86,6 +87,7 @@ class MapView extends React.Component<IProps> {
         center={mapCenter}
         zoom={mapZoom}
         maxZoom={18}
+        zoomControl={isViewportGreaterThanTablet}
         style={{ height: '100%', zIndex: 0 }}
         onmove={this.handleMove}
         onclick={() => {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR adds a verification to hide map zoom controls on mobile/tablets devices, due to its pinch mechanism

## Git Issues

Closes #1839 

## Screenshots/Videos
### Mobile
![zoom_controls_mobile](https://user-images.githubusercontent.com/48301172/183788102-ca23a7ff-f9ff-4844-a28b-b8f97d13eb1e.jpg)
### Chrome/brave
![zoom_controls_desktop](https://user-images.githubusercontent.com/48301172/183788144-2d3419fd-1b61-45ce-ae99-c370f8e54d90.png)
### Firefox
![zoom_controls_firefox](https://user-images.githubusercontent.com/48301172/183788731-71a97d38-670e-42d3-b5e9-254e33319af2.png)

