### PR TITLE
fix: added flex to container to prevent overflow of content

### DIFF
--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -51,7 +51,7 @@ const MobileBadge = styled.div`
 
   @media only screen and (min-width: ${theme.breakpoints[1]}) {
     align-items: center;
-  } 
+  }
 
   @media only screen and (min-width: ${theme.breakpoints[2]}) {
     margin-top: -50%;

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -44,11 +44,16 @@ interface IProps {
 
 const MobileBadge = styled.div`
   position: relative;
-  max-width: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   margin-bottom: 0;
 
+  @media only screen and (min-width: ${theme.breakpoints[1]}) {
+    align-items: center;
+  } 
+
   @media only screen and (min-width: ${theme.breakpoints[2]}) {
-    max-width: 150px;
     margin-top: -50%;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

User stats in profile can at times overflow outside of its box. This fix prevents that by removing max-width and flexing the box.

## Git Issues

Closes #1890

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/19585239/184620459-e7c51ad2-7cf9-46f1-ba40-ca4e78631868.png)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on slack in the `platform-dev` channel.
