### PR TITLE
fix: user references after updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
     "@commitlint/cz-commitlint": "^16.2.3",
+    "@faker-js/faker": "^7.6.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/models/comment.model.ts
+++ b/src/models/comment.model.ts
@@ -1,0 +1,17 @@
+/**
+ * Comments are currently used as documents nested
+ * underneath Howtos and Research items
+ *
+ * - Howto: Available at howto.comments
+ * - ResearchItem: Available under researchItem.updates.comments
+ */
+export interface IComment {
+  _id: string
+  _created: string
+  _edited?: string
+  _creatorId: string
+  creatorName: string
+  creatorCountry?: string | null
+  text: string
+  isUserVerified?: boolean
+}

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -3,20 +3,7 @@ import type { DBDoc, IModerable } from './common.models'
 import type { IConvertedFileMeta } from '../types'
 import type { IUploadedFileMeta } from '../stores/storage'
 import type { ICategory } from './categories.model'
-
-/**
- * Comments are currently only used in Howtos.
- */
-export interface IComment {
-  _id: string
-  _created: string
-  _edited?: string
-  _creatorId: string
-  creatorName: string
-  creatorCountry?: string | null
-  text: string
-  isUserVerified?: boolean
-}
+import type { IComment } from './'
 
 // By default all how-to form input fields come as strings
 // The IHowto interface can imposes the correct formats on fields

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,7 @@
-import type { IComment } from './howto.models'
+import type { IComment } from './comment.model'
 
 // Re-export all other files for easy access
+export type { IComment } from './comment.model'
 export * from './common.models'
 export * from './events.models'
 export * from './howto.models'

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -13,6 +13,7 @@ import type { IConvertedFileMeta } from '../types'
 export interface IUserState {
   user?: IUser
 }
+
 // IUser retains most of the fields from legacy users (omitting passwords),
 // and has a few additional fields. Note 'email' is excluded
 // _uid is unique/fixed identifier

--- a/src/stores/Howto/howto.store.test.ts
+++ b/src/stores/Howto/howto.store.test.ts
@@ -1,0 +1,247 @@
+jest.mock('../common/module.store')
+import type { IHowtoDB } from 'src/models'
+import { FactoryComment } from 'src/test/factories/Comment'
+import { FactoryHowto } from 'src/test/factories/Howto'
+import { FactoryUser } from 'src/test/factories/User'
+import type { RootStore } from '..'
+import { HowtoStore } from './howto.store'
+
+async function factory(howtoOverloads: Partial<IHowtoDB> = {}) {
+  const store = new HowtoStore({} as RootStore)
+  const howToItem = FactoryHowto(howtoOverloads)
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.setActiveUser(
+    FactoryUser({
+      _id: 'fake-user',
+    }),
+  )
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.db.get.mockResolvedValue(howToItem)
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.db.getWhere.mockReturnValue([howToItem])
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.userStore = {
+    getUserProfile: jest.fn().mockResolvedValue(
+      FactoryUser({
+        _authID: 'userId',
+        userName: 'username',
+      }),
+    ),
+  }
+
+  await store.setActiveHowtoBySlug('howto')
+
+  return {
+    store,
+    howToItem,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    setFn: store.db.set,
+  }
+}
+
+describe('howto.store', () => {
+  describe('uploadHowTo', () => {
+    it.todo('updates an existing item')
+    it('preserves @mention on existing comments', async () => {
+      const comments = [
+        FactoryComment({
+          _creatorId: 'fake-user',
+        }),
+        FactoryComment({
+          text: '@username',
+        }),
+      ]
+      const { store, howToItem, setFn } = await factory({
+        comments,
+        description: '@username',
+      })
+
+      // Act
+      await store.uploadHowTo(howToItem)
+
+      const [newHowto] = setFn.mock.calls[0]
+      expect(setFn).toHaveBeenCalledTimes(1)
+      expect(newHowto.comments[1].text).toBe('@@{userId:username}')
+    })
+  })
+
+  describe('Comments', () => {
+    describe('addComment', () => {
+      it('adds comment to howto', async () => {
+        const { store, setFn } = await factory()
+
+        // Act
+        await store.addComment('short comment including @username')
+
+        // Assert
+        const [newHowto] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newHowto.comments).toHaveLength(1)
+        expect(newHowto.comments[0]).toEqual(
+          expect.objectContaining({
+            text: 'short comment including @@{userId:username}',
+          }),
+        )
+      })
+
+      it('preserves @mentions in description', async () => {
+        const { store, setFn } = await factory({
+          description: '@username',
+        })
+
+        // Act
+        await store.addComment('fish')
+
+        // Assert
+        const [newHowto] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newHowto.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mentions in existing comments', async () => {
+        const { store, setFn } = await factory({
+          description: '@username',
+          comments: [
+            FactoryComment({
+              text: 'Existing comment @username',
+            }),
+          ],
+        })
+
+        // Act
+        await store.addComment('fish')
+
+        // Assert
+        const [newHowto] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newHowto.comments).toHaveLength(2)
+        expect(newHowto.comments[0].text).toBe(
+          'Existing comment @@{userId:username}',
+        )
+      })
+    })
+
+    describe('editComment', () => {
+      it('updates comment', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, setFn } = await factory({
+          comments: [comment],
+        })
+
+        // Act
+        await store.editComment(comment._id, 'New text')
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(newHowto.comments[0]).toEqual(
+          expect.objectContaining({
+            text: 'New text',
+          }),
+        )
+      })
+      it('preserves @mentions in description', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, setFn } = await factory({
+          comments: [comment],
+          description: '@username',
+        })
+
+        // Act
+        await store.editComment(comment._id, 'New text')
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(newHowto.description).toBe('@@{userId:username}')
+      })
+      it('preserves @mentions in existing comments', async () => {
+        const comments = [
+          FactoryComment({
+            _creatorId: 'fake-user',
+          }),
+          FactoryComment({
+            text: '@username',
+          }),
+        ]
+        const { store, setFn } = await factory({
+          comments,
+          description: '@username',
+        })
+
+        // Act
+        await store.editComment(comments[0]._id, 'An updated message')
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newHowto.comments).toHaveLength(comments.length)
+        expect(newHowto.comments[1].text).toBe('@@{userId:username}')
+      })
+    })
+
+    describe('deleteComment', () => {
+      it('removes comment', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, setFn } = await factory({
+          comments: [comment],
+        })
+
+        // Act
+        await store.deleteComment(comment._id)
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(newHowto.comments).toHaveLength(0)
+      })
+
+      it('preserves @mentions in description', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, setFn } = await factory({
+          comments: [comment],
+          description: '@username',
+        })
+
+        // Act
+        await store.deleteComment(comment._id)
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(newHowto.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mentions in existing comments', async () => {
+        const comments = [
+          FactoryComment({
+            _creatorId: 'fake-user',
+          }),
+          FactoryComment({
+            text: '@username',
+          }),
+        ]
+        const { store, setFn } = await factory({
+          comments,
+          description: '@username',
+        })
+
+        // Act
+        await store.deleteComment(comments[0]._id)
+
+        const [newHowto] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newHowto.comments).toHaveLength(1)
+        expect(newHowto.comments[0].text).toBe('@@{userId:username}')
+      })
+    })
+  })
+})

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -8,9 +8,8 @@ import type {
   IHowtoFormInput,
   IHowtoStep,
   IHowToStepFormInput,
-  IComment,
 } from 'src/models/howto.models'
-import type { IUser } from 'src/models/user.models'
+import type { IComment, IUser } from 'src/models'
 import {
   filterModerableItems,
   hasAdminRights,
@@ -227,9 +226,13 @@ export class HowtoStore extends ModuleStore {
 
         const updatedHowto: IHowto = {
           ...toJS(howto),
-          comments: howto.comments
-            ? [...toJS(howto.comments), newComment]
-            : [newComment],
+          description: await this.addUserReference(howto.description),
+          comments: await Promise.all(
+            [...toJS(howto.comments || []), newComment].map(async (comment) => {
+              comment.text = await this.addUserReference(comment.text)
+              return comment
+            }),
+          ),
         }
 
         const dbRef = this.db
@@ -265,7 +268,13 @@ export class HowtoStore extends ModuleStore {
 
           const updatedHowto: IHowto = {
             ...toJS(howto),
-            comments,
+            description: await this.addUserReference(howto.description),
+            comments: await Promise.all(
+              comments.map(async (comment) => ({
+                ...comment,
+                text: await this.addUserReference(comment.text),
+              })),
+            ),
           }
 
           const dbRef = this.db
@@ -290,12 +299,21 @@ export class HowtoStore extends ModuleStore {
       const howto = this.activeHowto
       const user = this.activeUser
       if (id && howto && user && howto.comments) {
-        const comments = toJS(howto.comments).filter(
-          (comment) => !(comment._creatorId === user._id && comment._id === id),
+        const comments = await Promise.all(
+          toJS(howto.comments)
+            .filter(
+              (comment) =>
+                !(comment._creatorId === user._id && comment._id === id),
+            )
+            .map(async (comment) => ({
+              ...comment,
+              text: await this.addUserReference(comment.text),
+            })),
         )
 
         const updatedHowto: IHowto = {
           ...toJS(howto),
+          description: await this.addUserReference(howto.description),
           comments,
         }
 
@@ -326,6 +344,7 @@ export class HowtoStore extends ModuleStore {
 
     // keep comments if doc existed previously
     const existingDoc = await dbRef.get()
+
     const comments =
       existingDoc && existingDoc.comments ? existingDoc.comments : []
 
@@ -363,7 +382,12 @@ export class HowtoStore extends ModuleStore {
         ...values,
         description: await this.addUserReference(values.description),
         _createdBy: values._createdBy ? values._createdBy : user.userName,
-        comments,
+        comments: await Promise.all(
+          comments.map(async (c) => ({
+            ...c,
+            text: await this.addUserReference(c.text),
+          })),
+        ),
         cover_image: processedCover,
         steps: processedSteps,
         fileLink: values.fileLink ?? '',
@@ -444,8 +468,8 @@ interface IHowToUploadStatus {
   Complete: boolean
 }
 
-function getInitialUploadStatus() {
-  const status: IHowToUploadStatus = {
+function getInitialUploadStatus(): IHowToUploadStatus {
+  return {
     Start: false,
     Cover: false,
     'Step Images': false,
@@ -453,5 +477,4 @@ function getInitialUploadStatus() {
     Database: false,
     Complete: false,
   }
-  return status
 }

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -1,0 +1,405 @@
+jest.mock('../common/module.store')
+import { toJS } from 'mobx'
+import { FactoryComment } from 'src/test/factories/Comment'
+import {
+  FactoryResearchItem,
+  FactoryResearchItemUpdate,
+} from 'src/test/factories/ResearchItem'
+import { FactoryUser } from 'src/test/factories/User'
+import { ResearchStore } from './research.store'
+
+const factory = async (researchItemOverloads: any = {}) => {
+  const researchItem = FactoryResearchItem({
+    updates: [FactoryResearchItemUpdate(), FactoryResearchItemUpdate()],
+    ...researchItemOverloads,
+  })
+  const store = new ResearchStore()
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.setActiveUser(
+    FactoryUser({
+      _id: 'fake-user',
+    }),
+  )
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.db.get.mockResolvedValue(researchItem)
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.db.getWhere.mockReturnValue([researchItem])
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  store.userStore = {
+    getUserProfile: jest.fn().mockResolvedValue(
+      FactoryUser({
+        _authID: 'userId',
+        userName: 'username',
+      }),
+    ),
+  }
+
+  await store.setActiveResearchItem('fish')
+
+  return {
+    store,
+    researchItem,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    setFn: store.db.set,
+  }
+}
+
+describe('research.store', () => {
+  describe('Comments', () => {
+    describe('addComment', () => {
+      it('adds new comment to update', async () => {
+        const { store, researchItem, setFn } = await factory()
+
+        // Act
+        await store.addComment('fish', researchItem.updates[0])
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newResearchItem.updates[0].comments[0]).toEqual(
+          expect.objectContaining({
+            text: 'fish',
+          }),
+        )
+        expect(newResearchItem.updates[1].comments).toBeUndefined()
+      })
+
+      it('adds @mention to comment text', async () => {
+        const { store, researchItem, setFn } = await factory()
+
+        // Act
+        await store.addComment(
+          'My favourite user has to be @username',
+          researchItem.updates[0],
+        )
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newResearchItem.updates[0].comments[0]).toEqual(
+          expect.objectContaining({
+            text: 'My favourite user has to be @@{userId:username}',
+          }),
+        )
+        expect(newResearchItem.updates[1].comments).toBeUndefined()
+      })
+
+      it('preserves @mention within Research description', async () => {
+        const { store, researchItem, setFn } = await factory({
+          description: '@username',
+        })
+
+        // Act
+        await store.addComment('fish', researchItem.updates[0])
+
+        // Assert
+        expect(setFn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: '@@{userId:username}',
+          }),
+        )
+      })
+
+      it('preserves @mention within an Update description', async () => {
+        const { store, researchItem, setFn } = await factory({
+          updates: [FactoryResearchItemUpdate({ description: '@username' })],
+        })
+
+        // Act
+        await store.addComment('fish', researchItem.updates[0])
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newResearchItem.updates[0]).toEqual(
+          expect.objectContaining({
+            description: '@@{userId:username}',
+          }),
+        )
+      })
+    })
+
+    describe('deleteComment', () => {
+      it('removes a comment', async () => {
+        const { store, researchItem, setFn } = await factory({
+          updates: [
+            FactoryResearchItemUpdate({
+              description: '@username',
+              comments: [
+                FactoryComment({
+                  _id: 'commentId',
+                  _creatorId: 'fake-user',
+                  text: 'text',
+                }),
+              ],
+            }),
+          ],
+        })
+
+        // Act
+        await store.deleteComment('commentId', researchItem.updates[0])
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalledTimes(1)
+        expect(newResearchItem.updates[0].comments).toHaveLength(0)
+      })
+
+      it('preserves @mention within Research description', async () => {
+        const { store, researchItem, setFn } = await factory({
+          description: '@username',
+          updates: [
+            FactoryResearchItemUpdate({
+              comments: [
+                FactoryComment({
+                  _id: 'commentId',
+                  _creatorId: 'fake-user',
+                  text: 'text',
+                }),
+              ],
+            }),
+          ],
+        })
+
+        // Act
+        await store.deleteComment('commentId', researchItem.updates[0])
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mention within an Update description', async () => {
+        const { store, researchItem, setFn } = await factory({
+          updates: [
+            FactoryResearchItemUpdate({
+              description: '@username',
+              comments: [
+                FactoryComment({
+                  _id: 'commentId',
+                  _creatorId: 'fake-user',
+                  text: 'text',
+                }),
+              ],
+            }),
+          ],
+        })
+
+        // Act
+        await store.deleteComment('commentId', researchItem.updates[0])
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates[0].description).toBe(
+          '@@{userId:username}',
+        )
+      })
+    })
+
+    describe('editComment', () => {
+      it('updates a comment', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, researchItem, setFn } = await factory({
+          updates: [
+            FactoryResearchItemUpdate({
+              comments: [comment],
+            }),
+          ],
+        })
+
+        // Act
+        await store.editComment(
+          comment._id,
+          'My favourite comment',
+          researchItem.updates[0],
+        )
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates[0].comments[0].text).toBe(
+          'My favourite comment',
+        )
+      })
+
+      it('preserves @mention within Research description', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, researchItem, setFn } = await factory({
+          description: '@username',
+          updates: [
+            FactoryResearchItemUpdate({
+              comments: [comment],
+            }),
+          ],
+        })
+
+        // Act
+        await store.editComment(
+          comment._id,
+          'My favourite comment',
+          researchItem.updates[0],
+        )
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mention within an Update description', async () => {
+        const comment = FactoryComment({
+          _creatorId: 'fake-user',
+        })
+        const { store, researchItem, setFn } = await factory({
+          updates: [
+            FactoryResearchItemUpdate({
+              description: '@username',
+              comments: [comment],
+            }),
+          ],
+        })
+
+        // Act
+        await store.editComment(
+          comment._id,
+          'My favourite comment',
+          researchItem.updates[0],
+        )
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates[0].description).toBe(
+          '@@{userId:username}',
+        )
+      })
+    })
+  })
+
+  describe('updates', () => {
+    describe('uploadUpdate', () => {
+      it('inserts a new update', async () => {
+        const { store, researchItem, setFn } = await factory()
+        const newUpdate = FactoryResearchItemUpdate()
+
+        // Act
+        await store.uploadUpdate(newUpdate)
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates.length).toBeGreaterThan(
+          researchItem.updates.length,
+        )
+        expect(
+          newResearchItem.updates.find(
+            ({ title }) => title === newUpdate.title,
+          ),
+        ).toBeTruthy()
+      })
+
+      it('updates an existing update', async () => {
+        const { store, researchItem, setFn } = await factory()
+        const editedUpdate = toJS(researchItem.updates[0])
+
+        // Act
+        await store.uploadUpdate(editedUpdate)
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates.length).toEqual(
+          researchItem.updates.length,
+        )
+        expect(
+          newResearchItem.updates.find(
+            ({ title }) => title === editedUpdate.title,
+          ),
+        ).toBeTruthy()
+      })
+
+      it('preserves @mention within Research description', async () => {
+        const { store, setFn } = await factory({
+          description: '@username',
+        })
+
+        // Act
+        await store.uploadUpdate(FactoryResearchItemUpdate())
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mention within an existing Update description', async () => {
+        const { store, setFn } = await factory({
+          description: '@username',
+          updates: [
+            FactoryResearchItemUpdate({
+              description: '@username',
+            }),
+          ],
+        })
+
+        // Act
+        await store.uploadUpdate(FactoryResearchItemUpdate())
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.updates[0].description).toBe(
+          '@@{userId:username}',
+        )
+      })
+    })
+  })
+
+  describe('item', () => {
+    describe('uploadResearch', () => {
+      it('adds @mention to Research description', async () => {
+        const { store, researchItem, setFn } = await factory()
+
+        // Act
+        await store.uploadResearch({
+          ...toJS(researchItem),
+          description: '@username',
+        })
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.description).toBe('@@{userId:username}')
+      })
+
+      it('preserves @mention on existing Update description', async () => {
+        const { store, researchItem, setFn } = await factory({
+          _createdBy: 'fake-user',
+          updates: [
+            FactoryResearchItemUpdate({
+              description: '@username',
+            }),
+          ],
+        })
+
+        // Act
+        await store.uploadResearch({
+          ...toJS(researchItem),
+          description: 'Edited description',
+        })
+
+        // Assert
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(setFn).toHaveBeenCalled()
+        expect(newResearchItem.updates[0].description).toBe(
+          '@@{userId:username}',
+        )
+      })
+    })
+  })
+})

--- a/src/stores/common/__mocks__/module.store.ts
+++ b/src/stores/common/__mocks__/module.store.ts
@@ -3,7 +3,21 @@ export class ModuleStore {
     collection: jest.fn().mockReturnThis(),
     doc: jest.fn().mockReturnThis(),
     set: jest.fn().mockReturnThis(),
+    get: jest.fn().mockReturnThis(),
+    getWhere: jest.fn().mockReturnThis(),
+  }
+  activeUser = {}
+  allDocs$ = {
+    subscribe: jest.fn(),
   }
 
   constructor() {}
+
+  public uploadCollectionBatch() {}
+
+  public init() {}
+
+  public setActiveUser(user: any) {
+    this.activeUser = user
+  }
 }

--- a/src/test/factories/Comment.ts
+++ b/src/test/factories/Comment.ts
@@ -1,0 +1,16 @@
+import { faker } from '@faker-js/faker'
+import type { IComment } from 'src/models'
+
+export const FactoryComment = (
+  commentOverloads: Partial<IComment> = {},
+): IComment => ({
+  _id: faker.datatype.uuid(),
+  _created: faker.date.past().toString(),
+  _edited: faker.date.past().toString(),
+  _creatorId: faker.internet.userName(),
+  creatorName: faker.internet.userName(),
+  creatorCountry: '',
+  text: faker.lorem.paragraph(),
+  isUserVerified: faker.datatype.boolean(),
+  ...commentOverloads,
+})

--- a/src/test/factories/Howto.ts
+++ b/src/test/factories/Howto.ts
@@ -1,0 +1,40 @@
+import type { IHowtoDB } from 'src/models'
+import { faker } from '@faker-js/faker'
+
+export const FactoryHowto = (
+  howtoOverloads: Partial<IHowtoDB> = {},
+): IHowtoDB => ({
+  files: [],
+  difficulty_level: faker.helpers.arrayElement([
+    'Easy',
+    'Medium',
+    'Hard',
+    'Very Hard',
+  ]),
+  time: '',
+  slug: faker.lorem.slug(),
+  moderation: faker.helpers.arrayElement([
+    'draft',
+    'awaiting-moderation',
+    'rejected',
+    'accepted',
+  ]),
+  title: faker.lorem.words(4),
+  description: faker.lorem.paragraph(),
+  _id: faker.datatype.uuid(),
+  _modified: faker.date.past().toString(),
+  _created: faker.date.past().toString(),
+  _deleted: faker.datatype.boolean(),
+  _createdBy: faker.internet.userName(),
+  steps: [],
+  cover_image: {
+    downloadUrl: '',
+    name: '',
+    type: '',
+    timeCreated: '',
+    fullPath: '',
+    updated: '',
+    size: 0,
+  },
+  ...howtoOverloads,
+})

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker'
+import type { IResearch, IResearchDB } from 'src/models'
+
+export const FactoryResearchItemUpdate = (
+  researchItemUpdateOverloads: Partial<IResearch.UpdateDB> = {},
+): IResearch.UpdateDB => ({
+  title: faker.lorem.words(),
+  description: faker.lorem.sentences(2),
+  images: [],
+  _id: faker.datatype.uuid(),
+  _modified: faker.date.past().toString(),
+  _created: faker.date.past().toString(),
+  _deleted: faker.datatype.boolean(),
+  ...researchItemUpdateOverloads,
+})
+
+export const FactoryResearchItem = (
+  researchItemOverloads: Partial<IResearchDB> = {},
+): IResearchDB => ({
+  _id: faker.datatype.uuid(),
+  _createdBy: faker.internet.userName(),
+  _modified: faker.date.past().toString(),
+  _created: faker.date.past().toString(),
+  _deleted: faker.datatype.boolean(),
+  description: faker.lorem.paragraphs(),
+  title: faker.lorem.words(),
+  slug: faker.lorem.slug(),
+  updates: [FactoryResearchItemUpdate()],
+  tags: {},
+  moderation: faker.helpers.arrayElement([
+    'draft',
+    'awaiting-moderation',
+    'rejected',
+    'accepted',
+  ]),
+  ...researchItemOverloads,
+})

--- a/src/test/factories/User.ts
+++ b/src/test/factories/User.ts
@@ -1,0 +1,26 @@
+import type { IUserPPDB } from 'src/models'
+import { faker } from '@faker-js/faker'
+import { ProfileType } from 'src/modules/profile/types'
+
+export const FactoryUser = (
+  userOverloads: Partial<IUserPPDB> = {},
+): IUserPPDB => ({
+  _id: faker.datatype.uuid(),
+  _created: faker.date.past().toString(),
+  _modified: faker.date.past().toString(),
+  _deleted: faker.datatype.boolean(),
+  _authID: faker.datatype.uuid(),
+  profileType: faker.helpers.arrayElement(Object.values(ProfileType)),
+  userName: faker.internet.userName(),
+  displayName: faker.name.fullName(),
+  verified: faker.datatype.boolean(),
+  links: [],
+  moderation: faker.helpers.arrayElement([
+    'draft',
+    'awaiting-moderation',
+    'rejected',
+    'accepted',
+  ]),
+  coverImages: [] as any[],
+  ...userOverloads,
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5511,6 +5511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^7.6.0":
+  version: 7.6.0
+  resolution: "@faker-js/faker@npm:7.6.0"
+  checksum: 942af6221774e8c98a0eb6bc75265e05fb81a941170377666c3439aab9495dd321d6beedc5406f07e6ad44262b3e43c20961f666d116ad150b78e7437dd1bb2b
+  languageName: node
+  linkType: hard
+
 "@fastify/busboy@npm:^1.1.0":
   version: 1.1.0
   resolution: "@fastify/busboy@npm:1.1.0"
@@ -27916,6 +27923,7 @@ fsevents@^1.2.7:
     "@commitlint/cz-commitlint": ^16.2.3
     "@emotion/react": ^11.8.2
     "@emotion/styled": ^11.8.1
+    "@faker-js/faker": ^7.6.0
     "@semantic-release/changelog": ^6.0.1
     "@semantic-release/git": ^10.0.1
     "@sentry/react": ^6.15.0


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Recently we introduced an `@mention` feature. This enables users to mention others at multiple places within a Research and Howto article; these are are main description, update description and comments.

This behaviour relies on `addUserReference` having been applied to each of those fields to convert a plain `@mention` string to a user reference ID: `@@{userId:username}`.

Every method which modifies the ResearchItem|HowtoArticle first clones and saves the ResearchItem which means the save object does _not_ have a userReferenceId available. 

I think that there is value in refactoring the internal flow of the store so that we can avoid this rework but first let's fix the immediate bug and introduce some tests to make it safer to refactor the implementation. 


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
