### PR TITLE
fix: research update, do not show identical created/edited timestamps

### DIFF
--- a/src/pages/Research/Content/ResearchUpdate.test.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.test.tsx
@@ -1,0 +1,81 @@
+import { format } from 'date-fns'
+import { ThemeProvider } from '@theme-ui/core'
+import { render } from '@testing-library/react'
+import Theme from 'src/themes/styled.theme'
+import ResearchUpdate from './ResearchUpdate'
+import { faker } from '@faker-js/faker'
+
+jest.mock('src/index', () => {
+  return {
+    useCommonStores: jest.fn().mockReturnValue({
+      stores: { userStore: { fetchAllVerifiedUsers: jest.fn() } },
+    }),
+  }
+})
+
+jest.mock('./ResearchComments/ResearchComments', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  ResearchComments: () => <>Mocked Research Comments</>,
+}))
+
+describe('ResearchUpdate', () => {
+  it('does not show edit timestamp, when create displays the same value', () => {
+    const created = faker.date.past()
+    const modified = new Date(created)
+    modified.setHours(15)
+
+    const wrapper = render(
+      <ThemeProvider theme={Theme}>
+        <ResearchUpdate
+          update={{
+            _id: faker.database.mongodbObjectId(),
+            _deleted: false,
+            _created: created.toString(),
+            _modified: modified.toString(),
+            title: 'A title',
+            description: 'A description',
+            images: [],
+            comments: [],
+          }}
+          updateIndex={1}
+          slug={'slug'}
+          comments={[]}
+          isEditable={false}
+        />
+      </ThemeProvider>,
+    )
+
+    expect(() =>
+      wrapper.getAllByText(`edited ${format(modified, 'DD-MM-YYYY')}`),
+    ).toThrow()
+  })
+
+  it('does show both created and edit timestamp, when different', () => {
+    const modified = faker.date.past()
+    const wrapper = render(
+      <ThemeProvider theme={Theme}>
+        <ResearchUpdate
+          update={{
+            _id: faker.database.mongodbObjectId(),
+            _deleted: false,
+            _created: faker.date.past().toString(),
+            _modified: modified.toString(),
+            title: 'A title',
+            description: 'A description',
+            images: [],
+            comments: [],
+          }}
+          updateIndex={1}
+          slug={'slug'}
+          comments={[]}
+          isEditable={false}
+        />
+      </ThemeProvider>,
+    )
+
+    expect(() =>
+      wrapper.getAllByText(`edited ${format(modified, 'DD-MM-YYYY')}`),
+    ).not.toThrow()
+  })
+})

--- a/src/pages/Research/Content/ResearchUpdate.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.tsx
@@ -31,6 +31,14 @@ const ResearchUpdate: React.FC<IProps> = ({
   comments,
 }) => {
   const theme = useTheme()
+  const formattedCreateDatestamp = format(
+    new Date(update._created),
+    'DD-MM-YYYY',
+  )
+  const formattedModifiedDatestamp = format(
+    new Date(update._modified),
+    'DD-MM-YYYY',
+  )
   return (
     <>
       <Flex
@@ -79,18 +87,18 @@ const ResearchUpdate: React.FC<IProps> = ({
                         ...theme.typography.auxiliary,
                       }}
                     >
-                      {'created ' +
-                        format(new Date(update._created), 'DD-MM-YYYY')}
+                      {'created ' + formattedCreateDatestamp}
                     </Text>
-                    {update._created !== update._modified && (
+
+                    {formattedCreateDatestamp !==
+                      formattedModifiedDatestamp && (
                       <Text
                         sx={{
                           textAlign: ['left', 'right', 'right'],
                           ...theme.typography.auxiliary,
                         }}
                       >
-                        {'edited ' +
-                          format(new Date(update._modified), 'DD-MM-YYYY')}
+                        {'edited ' + formattedModifiedDatestamp}
                       </Text>
                     )}
                   </Flex>


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Do not show create and edited datestamps if they show the same value. 

## Screenshots/Videos

**Before:**  
![Screenshot 2022-11-24 at 22 22 36](https://user-images.githubusercontent.com/472589/203867272-70db138e-8954-4327-9561-044dd82940b7.jpg)

**After:**
![Screenshot 2022-11-24 at 22 22 50](https://user-images.githubusercontent.com/472589/203867274-5c6d9d0a-ecb3-43fb-8b5e-b747a7fd5d38.jpg)


