### PR TITLE
feat: move map card to component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -114,6 +114,7 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/no-unused-vars": ["error"],
     "no-restricted-imports": [
       "error",
       {

--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -7,7 +7,6 @@
       "error",
       { "namedComponents": "arrow-function" }
     ],
-    "@typescript-eslint/no-unused-vars": ["error"],
     "import/no-unresolved": "off",
     "import/no-default-export": "error"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,7 +18,9 @@
   "dependencies": {
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
+    "@faker-js/faker": "^7.6.0",
     "@react-icons/all-files": "^4.1.0",
+    "date-fns": "^2.29.3",
     "linkify-plugin-mention": "^3.0.4",
     "linkify-react": "^3.0.4",
     "linkifyjs": "^3.0.5",

--- a/packages/components/src/MapMemberCard/MapMemberCard.stories.tsx
+++ b/packages/components/src/MapMemberCard/MapMemberCard.stories.tsx
@@ -1,0 +1,35 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
+import { MapMemberCard } from './MapMemberCard'
+import { faker } from '@faker-js/faker'
+
+export default {
+  title: 'Components/MapMemberCard',
+  component: MapMemberCard,
+} as ComponentMeta<typeof MapMemberCard>
+
+export const Default: ComponentStory<typeof MapMemberCard> = () => (
+  <MapMemberCard
+    imageUrl="https://placekitten.com/450/450"
+    description={`${faker.lorem.sentence()}`}
+    lastActive={`${faker.date.past().toString()}`}
+    user={{
+      username: faker.internet.userName(),
+      isVerified: faker.datatype.boolean(),
+    }}
+    heading={`${faker.lorem.word()}`}
+  />
+)
+
+export const LoadingState: ComponentStory<typeof MapMemberCard> = () => (
+  <MapMemberCard
+    loading
+    imageUrl="https://placekitten.com/450/450"
+    description={`${faker.lorem.sentence()}`}
+    lastActive={`${faker.date.past()}`}
+    user={{
+      username: faker.internet.userName(),
+      isVerified: faker.datatype.boolean(),
+    }}
+    heading={`${faker.lorem.word()}`}
+  />
+)

--- a/packages/components/src/MapMemberCard/MapMemberCard.tsx
+++ b/packages/components/src/MapMemberCard/MapMemberCard.tsx
@@ -1,0 +1,123 @@
+import { Box, Card, Text, Image, AspectRatio } from 'theme-ui'
+import { formatDistanceToNow } from 'date-fns'
+
+import { InternalLink } from '../InternalLink/InternalLink'
+import { Username } from '../Username/Username'
+
+export interface Props {
+  loading?: boolean
+  imageUrl: string
+  lastActive: string
+  description: string
+  user: {
+    isVerified: boolean
+    username: string
+  }
+  heading: string
+}
+
+import { keyframes } from '@emotion/react'
+
+const wave = keyframes`
+  from {
+    background: lightgrey;
+  }
+  to {
+    background: grey;
+  }
+`
+
+export const MapMemberCard = (props: Props) => {
+  const { imageUrl, lastActive, description, user, heading } = props
+  const pin = {
+    type: 'member',
+    moderation: 'accepted',
+  }
+  const moderationStatus = 'fish'
+
+  return (
+    <Card sx={{ maxWidth: '230px' }}>
+      <InternalLink to={`/u/${user.username}`}>
+        {props.loading && (
+          <>
+            <AspectRatio
+              ratio={230 / 120}
+              sx={{
+                background: 'lightgrey',
+                animation: `${wave} 800ms ease infinite`,
+              }}
+            />
+            <Box sx={{ p: 2, height: '109px' }} />
+          </>
+        )}
+        {!props.loading && (
+          <>
+            <AspectRatio
+              ratio={230 / 120}
+              sx={{
+                background: 'lightgrey',
+              }}
+            >
+              <Image
+                src={imageUrl}
+                sx={{ objectFit: 'cover', width: '100%', height: '100%' }}
+              />
+            </AspectRatio>
+            <Box sx={{ p: 2 }}>
+              <Text mb={2} sx={{ fontSize: '12px', color: 'blue' }}>
+                {heading}
+              </Text>
+              <div>
+                <Username
+                  isVerified={!!user.isVerified}
+                  user={{
+                    userName: user.username,
+                  }}
+                />
+              </div>
+              <Text
+                mb={2}
+                sx={{
+                  wordBreak: 'break-word',
+                  fontSize: 1,
+                  display: 'block',
+                  color: 'black',
+                }}
+              >
+                {description}
+              </Text>
+              <Text
+                sx={{
+                  fontSize: 0,
+                  color: 'grey',
+                }}
+              >
+                Last active{' '}
+                {lastActive
+                  ? `${formatDistanceToNow(new Date(lastActive))}`
+                  : 'a long time'}{' '}
+                ago
+              </Text>
+              {pin.moderation !== 'accepted' && (
+                <Text
+                  mb={2}
+                  sx={{
+                    fontWeight: 'bold',
+                    fontSize: 1,
+                    background: 'yellow.base',
+                    padding: '7px',
+                    borderRadius: '5px',
+                    border: '1px dashed',
+                    color: pin.moderation === 'rejected' ? 'red' : null,
+                  }}
+                >
+                  {moderationStatus}
+                </Text>
+              )}
+            </Box>
+          </>
+        )}
+      </InternalLink>
+    </Card>
+  )
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -32,3 +32,4 @@ export type { Props as TextNotificationProps } from './TextNotification/TextNoti
 export { Select } from './Select/Select'
 export { Username } from './Username/Username'
 export { InternalLink } from './InternalLink/InternalLink'
+export { MapMemberCard } from './MapMemberCard/MapMemberCard'

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -83,111 +83,13 @@ export class Popup extends React.Component<IProps> {
     return 'loading'
   }
 
-  private getHeading(pin): string {
+  private getHeading(pin: IMapPinWithDetail): string {
     const group = MAP_GROUPINGS.find((g) => {
       return pin.subType
         ? g.subType === pin.subType && g.type === pin.type
         : g.type === pin.type
     })
     return group ? group.displayName : pin.type
-  }
-
-  private renderContent(pin: IMapPinWithDetail) {
-    const {
-      lastActive,
-      heroImageUrl,
-      shortDescription,
-      name,
-      displayName,
-      verifiedBadge,
-    } = pin.detail
-    const description =
-      shortDescription.length > 70
-        ? shortDescription.substr(0, 70) + '...'
-        : shortDescription
-    const lastActiveText = lastActive
-      ? distanceInWords(lastActive, new Date())
-      : 'a long time'
-    const moderationStatus =
-      pin.moderation !== 'rejected'
-        ? 'This pin is awaiting moderation, will be shown on general map once accepted'
-        : 'This pin has been rejected, wont show on general map'
-
-    function addFallbackSrc(ev: any) {
-      const icon = Workspace.findWorkspaceBadge(pin.type, true)
-      ev.target.src = icon
-    }
-
-    return (
-      <>
-        <Link to={'/u/' + name} data-cy="map-pin-popup">
-          <HeroImage src={heroImageUrl} onError={addFallbackSrc} />
-          <Flex sx={{ flexDirection: 'column' }} px={2} py={2}>
-            <Text mb={2} sx={{ fontSize: '12px', color: theme.colors.blue }}>
-              {this.getHeading(pin)}
-            </Text>
-            <Text mb={1} sx={{ display: 'flex', fontSize: 2 }}>
-              {displayName}
-              {verifiedBadge && (
-                <Image
-                  loading="lazy"
-                  src={VerifiedBadgeIcon}
-                  width="22px"
-                  height="22px"
-                  style={{ marginLeft: '5px' }}
-                />
-              )}
-            </Text>
-            <Text mb={2} sx={{ wordBreak: 'break-word', fontSize: 1 }}>
-              {description}
-            </Text>
-            <LastOnline>Last active {lastActiveText} ago</LastOnline>
-            {pin.moderation !== 'accepted' && (
-              <Text
-                mb={2}
-                sx={{
-                  ...theme.typography.auxiliary,
-                  fontWeight: 'bold',
-                  fontSize: 1,
-                  background: theme.colors.yellow.base,
-                  padding: '7px',
-                  borderRadius: '5px',
-                  border: '1px dashed',
-                  color:
-                    pin.moderation === 'rejected' ? theme.colors.red : null,
-                }}
-              >
-                {moderationStatus}
-              </Text>
-            )}
-          </Flex>
-        </Link>
-        {this.store.needsModeration(pin) && (
-          <Flex
-            px={10}
-            py={1}
-            sx={{ flexDirection: 'row', justifyContent: 'space-around' }}
-          >
-            <Button
-              small
-              data-cy={'accept'}
-              variant={'primary'}
-              icon="check"
-              onClick={() => this.moderatePin(pin, true)}
-              sx={{ height: '30px' }}
-            />
-            <Button
-              small
-              data-cy="reject-pin"
-              variant={'tertiary'}
-              icon="delete"
-              onClick={() => this.moderatePin(pin, false)}
-              sx={{ height: '30px' }}
-            />
-          </Flex>
-        )}
-      </>
-    )
   }
 
   public render() {

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
 import L from 'leaflet'
-import { Image, Text, Flex } from 'theme-ui'
-import { Button, MapMemberCard } from 'oa-components'
+import { MapMemberCard } from 'oa-components'
 import type { Map } from 'react-leaflet'
 import { Popup as LeafletPopup } from 'react-leaflet'
-import styled from '@emotion/styled'
-import { distanceInWords } from 'date-fns'
 
 import type { IMapPin, IMapPinWithDetail } from 'src/models/maps.models'
 
@@ -13,10 +10,6 @@ import './popup.css'
 import { inject } from 'mobx-react'
 import type { MapsStore } from 'src/stores/Maps/maps.store'
 import { MAP_GROUPINGS } from 'src/stores/Maps/maps.groupings'
-import Workspace from 'src/pages/User/workspace/Workspace'
-import VerifiedBadgeIcon from 'src/assets/icons/icon-verified-badge.svg'
-import theme from 'src/themes/styled.theme'
-import { Link } from 'react-router-dom'
 
 interface IProps {
   activePin: IMapPin | IMapPinWithDetail
@@ -26,31 +19,9 @@ interface IInjectedProps extends IProps {
   mapsStore: MapsStore
 }
 
-const HeroImage = styled.img`
-  width: 100%;
-  background-color: lightgrey;
-  height: 120px;
-  object-fit: cover;
-`
-
-const LastOnline = styled.div`
-  margin: 7px 2px;
-  color: grey;
-  font-size: 0.6rem;
-`
-
 @inject('mapsStore')
 export class Popup extends React.Component<IProps> {
   leafletRef: React.RefObject<LeafletPopup> = React.createRef()
-  private moderatePin = async (pin: IMapPin, accepted: boolean) => {
-    await this.store.moderatePin({
-      ...pin,
-      moderation: accepted ? 'accepted' : 'rejected',
-    })
-    if (!accepted) {
-      this.injected.mapsStore.setActivePin(undefined)
-    }
-  }
   // eslint-disable-next-line
   constructor(props: IProps) {
     super(props)
@@ -77,10 +48,6 @@ export class Popup extends React.Component<IProps> {
         this.props.map.current!.leafletElement,
       )
     }
-  }
-
-  private renderLoading() {
-    return 'loading'
   }
 
   private getHeading(pin: IMapPinWithDetail): string {

--- a/src/pages/Maps/Content/View/Popup.tsx
+++ b/src/pages/Maps/Content/View/Popup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import L from 'leaflet'
 import { Image, Text, Flex } from 'theme-ui'
-import { Button } from 'oa-components'
+import { Button, MapMemberCard } from 'oa-components'
 import type { Map } from 'react-leaflet'
 import { Popup as LeafletPopup } from 'react-leaflet'
 import styled from '@emotion/styled'
@@ -83,12 +83,16 @@ export class Popup extends React.Component<IProps> {
     return 'loading'
   }
 
-  private renderContent(pin: IMapPinWithDetail) {
+  private getHeading(pin): string {
     const group = MAP_GROUPINGS.find((g) => {
       return pin.subType
         ? g.subType === pin.subType && g.type === pin.type
         : g.type === pin.type
     })
+    return group ? group.displayName : pin.type
+  }
+
+  private renderContent(pin: IMapPinWithDetail) {
     const {
       lastActive,
       heroImageUrl,
@@ -120,7 +124,7 @@ export class Popup extends React.Component<IProps> {
           <HeroImage src={heroImageUrl} onError={addFallbackSrc} />
           <Flex sx={{ flexDirection: 'column' }} px={2} py={2}>
             <Text mb={2} sx={{ fontSize: '12px', color: theme.colors.blue }}>
-              {group ? group.displayName : pin.type}
+              {this.getHeading(pin)}
             </Text>
             <Text mb={1} sx={{ display: 'flex', fontSize: 2 }}>
               {displayName}
@@ -188,9 +192,6 @@ export class Popup extends React.Component<IProps> {
 
   public render() {
     const activePin = this.props.activePin as IMapPinWithDetail
-    const content = activePin.detail
-      ? this.renderContent(activePin)
-      : this.renderLoading()
 
     return (
       activePin.location && (
@@ -203,7 +204,17 @@ export class Popup extends React.Component<IProps> {
           minWidth={230}
           maxWidth={230}
         >
-          {content}
+          <MapMemberCard
+            loading={!activePin.detail}
+            imageUrl={activePin.detail?.heroImageUrl}
+            lastActive={activePin.detail?.lastActive || ''}
+            description={activePin.detail?.shortDescription}
+            user={{
+              isVerified: !!activePin.detail?.verifiedBadge,
+              username: activePin.detail?.name,
+            }}
+            heading={this.getHeading(activePin)}
+          />
         </LeafletPopup>
       )
     )

--- a/src/pages/Maps/Content/View/popup.css
+++ b/src/pages/Maps/Content/View/popup.css
@@ -1,10 +1,6 @@
 .markercluster-map .leaflet-popup-content {
   margin: 0;
-  font-family: 'Varela Round', 'Inter', Helvetica Neue, Arial, sans-serif;
   z-index: 99991;
-  border: 2px solid black;
-  border-radius: 5px;
-  max-width: 230px;
 }
 
 .markercluster-map .leaflet-popup-content p {
@@ -12,8 +8,10 @@
 }
 
 .markercluster-map .leaflet-popup-content-wrapper {
-  border-radius: 5px;
-  box-shadow: 0px 0px 2px grey;
+  background: none;
+
+  border-radius: 0;
+  box-shadow: none;
   padding: 0;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16449,6 +16449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^2.29.3":
+  version: 2.29.3
+  resolution: "date-fns@npm:2.29.3"
+  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+  languageName: node
+  linkType: hard
+
 "date-now@npm:^0.1.4":
   version: 0.1.4
   resolution: "date-now@npm:0.1.4"
@@ -27599,6 +27606,7 @@ fsevents@^1.2.7:
     "@babel/core": ^7.14.3
     "@emotion/react": ^11.8.2
     "@emotion/styled": ^11.8.1
+    "@faker-js/faker": ^7.6.0
     "@react-icons/all-files": ^4.1.0
     "@react-theming/storybook-addon": ^1.1.5
     "@storybook/addon-actions": ^6.4.22
@@ -27612,6 +27620,7 @@ fsevents@^1.2.7:
     "@types/react-flag-icon-css": ^1.0.5
     "@types/react-portal": ^4.0.4
     babel-loader: 8.1.0
+    date-fns: ^2.29.3
     eslint: ^7.32.0
     eslint-plugin-import: ^2.25.4
     linkify-plugin-mention: ^3.0.4


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

* Refactors the Map Card out to a stateless component `MapMemberCard`
* Adds a loading state which better the dimensions for the loaded state

## Screenshots/Videos

This first screen recording demonstrates the current behaviour. The card displays a small block containing "loading" before the user data is fetched and displayed. This results in the card being resized which feels a bit janky.

https://user-images.githubusercontent.com/472589/204007419-36eb0cfb-29e5-4e70-8ba6-ba79da3cb497.mov

The second screen recording demonstrates the proposed behaviour. Instead the card's loading state better matches the expected size _after_ the content has loaded. This creates a gentler transition from the loading to loaded state.

https://user-images.githubusercontent.com/472589/204007443-5126e881-20e5-45fc-9cb9-2a9cabc93e48.mov

