### PR TITLE
chore(deps): remove unused react-linkify

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "react-lazy-load-image-component": "^1.5.1",
     "react-leaflet": "^2.5.0",
     "react-leaflet-markercluster": "^2.0.0-rc3",
-    "react-linkify": "^0.2.2",
     "react-player": "^1.15.3",
     "react-portal": "^4.2.0",
     "react-router": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25173,15 +25173,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^2.0.3":
-  version: 2.2.0
-  resolution: "linkify-it@npm:2.2.0"
-  dependencies:
-    uc.micro: ^1.0.1
-  checksum: d198871d0b3f3cfdb745dae564bfd6743474f20cd0ef1057e6ca29451834749e7f3da52b59b4de44e98f31a1e5c71bdad160490d4ae54de251cbcde57e4d7837
-  languageName: node
-  linkType: hard
-
 "linkify-it@npm:^3.0.1":
   version: 3.0.3
   resolution: "linkify-it@npm:3.0.3"
@@ -28012,7 +28003,6 @@ fsevents@^1.2.7:
     react-lazy-load-image-component: ^1.5.1
     react-leaflet: ^2.5.0
     react-leaflet-markercluster: ^2.0.0-rc3
-    react-linkify: ^0.2.2
     react-player: ^1.15.3
     react-portal: ^4.2.0
     react-router: ^5.2.0
@@ -32012,17 +32002,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-linkify@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "react-linkify@npm:0.2.2"
-  dependencies:
-    linkify-it: ^2.0.3
-    prop-types: ^15.5.8
-    tlds: ^1.57.0
-  checksum: 51f637e63176d0f96daa824bcec6ec6f28ee13228e8d8a017bdf8df748469c39daac0bfcc8c5983aab871fb939bbb4a2a4e8458f4e2ddb8342b379d23a2554ad
-  languageName: node
-  linkType: hard
-
 "react-loadable-ssr-addon-v5-slorber@npm:^1.0.1":
   version: 1.0.1
   resolution: "react-loadable-ssr-addon-v5-slorber@npm:1.0.1"
@@ -35989,15 +35968,6 @@ resolve@^2.0.0-next.3:
   version: 1.4.2
   resolution: "tinycolor2@npm:1.4.2"
   checksum: 57ed262e08815a4ab0ed933edafdbc6555a17081781766149813b44a080ecbe58b3ee281e81c0e75b42e4d41679f138cfa98eabf043f829e0683c04adb12c031
-  languageName: node
-  linkType: hard
-
-"tlds@npm:^1.57.0":
-  version: 1.222.0
-  resolution: "tlds@npm:1.222.0"
-  bin:
-    tlds: bin.js
-  checksum: de0c87d7c75ab3cb7c7c7a1a40c7b4ff08d7aa0b9b3feb6fa3f6a72bcf54de2e44b5caf6f2307741f963334cc55ebcc641ff132af402ae293a52ce01fd288eb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes unused dependency, linkifying text is now handled via [the LinkifyText component](https://onearmy.github.io/community-platform/storybook-static/index.html?path=/story/components-linkifytext--default)