### PR TITLE
fix: docker emulator build triggers

### DIFF
--- a/.github/workflows/docker-emulator-build.yml
+++ b/.github/workflows/docker-emulator-build.yml
@@ -7,20 +7,24 @@
 
 name: Docker Emulator Build
 on:
-  push:
+  # Run only when a pr has been merged into master and contains changes to seed data (additional check below for merge instead of close)
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges-1
+  pull_request_target:
+    types:
+      - closed
     branches:
       - master
-    # Allow manual trigger of build in case of broken/minor updates
-    workflow_dispatch:
-    # Only create new build when seed data or functions update
     paths:
       - 'packages/emulators-docker/seed_data/**'
+  # Allow manual trigger of build in case of broken/minor updates
+  workflow_dispatch:
 
 env:
   # Image name that will be added as suffix to either github repo owner or dockerhub username
   IMAGE_NAME: community-platform-emulator
 jobs:
   build_and_preview:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       # Setup


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

It looks like some of the recent robot release PRs are failing e.g. #2022.

The release pr is rebuilding the docker seed data image when it shouldn't be (should only build when changed). It appears there is an issue with the indentation on the file that specifies the build triggers (introduced in bc68f6ae7605eace885b27b5e1293a8aa29d0b87). 
https://github.com/ONEARMY/community-platform/actions/runs/3671170395/jobs/6206188896

This pr should fix that and add better rules to try ensure the docker builds only happen on merge into master when seed data changed. Likely follow-up will be needed when next running emulator build to see if there has been a breaking change  within our own code somewhere or just a temporary glitch in the build process (e.g. github/docker error).

## Testing notes
After merge check the next robot release PR to see if the docker build action is run or skipped 

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
