### PR TITLE
fix: address button inconsistency

### DIFF
--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -1,4 +1,5 @@
 import type { ComponentStory, ComponentMeta } from '@storybook/react'
+import { glyphs } from '../Icon/Icon'
 import { Button } from './Button'
 
 export default {
@@ -10,32 +11,125 @@ export default {
   component: Button,
 } as ComponentMeta<typeof Button>
 
+const sizeOptions = [
+  {
+    small: true,
+    label: 'Small',
+  },
+  {
+    label: 'Default',
+  },
+  {
+    large: true,
+    label: 'Large',
+  },
+]
+
 export const Basic: ComponentStory<typeof Button> = () => (
   <Button>Button Text</Button>
 )
 
 export const Disabled: ComponentStory<typeof Button> = () => (
-  <Button disabled>Disabled</Button>
+  <>
+    <Button disabled>Disabled</Button>
+    <Button icon="delete" disabled>
+      Disabled
+    </Button>
+  </>
 )
 
 export const Primary: ComponentStory<typeof Button> = () => (
-  <Button variant={'primary'}>Primary</Button>
+  <>
+    <Button variant={'primary'}>Primary</Button>
+    <Button icon="delete" variant={'primary'}>
+      Primary
+    </Button>
+    {sizeOptions.map((v, k) => (
+      <Button key={k} variant={'primary'} {...v}>
+        {v.label}
+      </Button>
+    ))}
+  </>
 )
 
 export const Secondary: ComponentStory<typeof Button> = () => (
-  <Button variant={'secondary'}>Secondary</Button>
+  <>
+    <Button variant={'secondary'}>Secondary</Button>
+    <Button icon="delete" variant={'secondary'}>
+      Secondary
+    </Button>
+    {sizeOptions.map((v, k) => (
+      <Button key={k} variant={'secondary'} {...v}>
+        {v.label}
+      </Button>
+    ))}
+  </>
+)
+
+export const Subtle: ComponentStory<typeof Button> = () => (
+  <>
+    <Button variant={'subtle'}>Subtle</Button>
+    <Button variant={'subtle'} icon="account-circle">
+      Subtle
+    </Button>
+    {sizeOptions.map((v, k) => (
+      <Button key={k} variant={'subtle'} {...v}>
+        {v.label}
+      </Button>
+    ))}
+  </>
 )
 
 export const Outline: ComponentStory<typeof Button> = () => (
-  <Button variant={'outline'}>Outline</Button>
+  <>
+    <Button variant={'outline'}>Outline</Button>
+    <Button variant={'outline'} icon="account-circle">
+      Outline
+    </Button>
+    {sizeOptions.map((v, k) => (
+      <Button key={k} variant={'outline'} {...v}>
+        {v.label}
+      </Button>
+    ))}
+  </>
 )
 
 export const Small: ComponentStory<typeof Button> = () => (
-  <Button small={true}>Small Button</Button>
+  <>
+    <Button small={true}>Small Button</Button>
+    <Button small={true} icon="delete">
+      Small Button with Icon
+    </Button>
+  </>
 )
-export const Medium: ComponentStory<typeof Button> = () => (
-  <Button medium={true}>Medium Button</Button>
-)
+
 export const Large: ComponentStory<typeof Button> = () => (
-  <Button large={true}>Large Button</Button>
+  <>
+    <Button large={true}>Large Button</Button>
+    <Button large={true} icon="delete">
+      Large Button with Icon
+    </Button>
+  </>
+)
+
+export const IconOnly: ComponentStory<typeof Button> = () => (
+  <>
+    <Button large={true} icon="delete" showIconOnly={true}>
+      Icon Button with hidden text
+    </Button>
+  </>
+)
+
+export const Icons: ComponentStory<typeof Button> = () => (
+  <>
+    {sizeOptions.map((size) =>
+      ['primary', 'secondary', 'outline'].map((variant) =>
+        Object.keys(glyphs).map((glyph: any, key) => (
+          <Button icon={glyph} key={key} {...size} variant={variant}>
+            {size.label} with Icon
+          </Button>
+        )),
+      ),
+    )}
+  </>
 )

--- a/packages/components/src/CommentList/CommentList.tsx
+++ b/packages/components/src/CommentList/CommentList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import ReactGA from 'react-ga4'
-import { Box } from 'theme-ui'
+import { Box, Flex } from 'theme-ui'
 import { Button, CommentItem } from '../'
 import type { CommentItemProps as Comment } from '../CommentItem/CommentItem'
 const MAX_COMMENTS = 5
@@ -76,20 +76,24 @@ export const CommentList: React.FC<{
           </Box>
         ))}
       {comments && comments.length > shownComments && (
-        <Button
-          sx={{ width: 'max-content', margin: '0 auto' }}
-          variant="outline"
-          onClick={() => {
-            ReactGA.event({
-              category: 'Comments',
-              action: 'Show more',
-              label: articleTitle,
-            })
-            return setMoreComments(moreComments + 1)
-          }}
-        >
-          show more comments
-        </Button>
+        <Flex>
+          <Button
+            sx={{
+              margin: '0 auto',
+            }}
+            variant="outline"
+            onClick={() => {
+              ReactGA.event({
+                category: 'Comments',
+                action: 'Show more',
+                label: articleTitle,
+              })
+              return setMoreComments(moreComments + 1)
+            }}
+          >
+            show more comments
+          </Button>
+        </Flex>
       )}
     </Box>
   )

--- a/packages/components/src/MapMemberCard/MapMemberCard.tsx
+++ b/packages/components/src/MapMemberCard/MapMemberCard.tsx
@@ -146,7 +146,7 @@ export const MapMemberCard = (props: Props) => {
           <Button
             small
             data-cy="MapMemberCard: reject"
-            variant={'tertiary'}
+            variant={'outline'}
             icon="delete"
             onClick={() => onPinModerated && onPinModerated(false)}
           >

--- a/src/pages/Events/Content/EventsCreate/EventsCreate.tsx
+++ b/src/pages/Events/Content/EventsCreate/EventsCreate.tsx
@@ -308,6 +308,7 @@ export class EventsCreate extends React.Component<IProps, IState> {
                   <PostingGuidelines />
                 </Box>
                 <Button
+                  large
                   onClick={() => {
                     if (isDigitalEvent || isLocationSelected) {
                       handleSubmit()
@@ -319,7 +320,11 @@ export class EventsCreate extends React.Component<IProps, IState> {
                   variant={'primary'}
                   disabled={submitting}
                   data-cy="submit"
-                  sx={{ mb: ['40px', '40px', 0], width: '100%' }}
+                  sx={{
+                    mb: ['40px', '40px', 0],
+                    width: '100%',
+                    justifyContent: 'center',
+                  }}
                 >
                   Publish
                 </Button>

--- a/src/pages/Events/EventCard/EventCard.tsx
+++ b/src/pages/Events/EventCard/EventCard.tsx
@@ -162,7 +162,7 @@ export const EventCard = (props: IProps) => {
               flexWrap: 'nowrap',
               order: [5, 5, 5],
             }}
-            ml={2}
+            mx={2}
           >
             <Button
               small
@@ -171,16 +171,22 @@ export const EventCard = (props: IProps) => {
               icon="check"
               mr={1}
               sx={{ height: '30px' }}
+              showIconOnly={true}
               onClick={() => props.moderateEvent(props.event, true)}
-            />
+            >
+              Approve
+            </Button>
             <Button
               small
               data-cy="reject-pin"
-              variant={'tertiary'}
+              variant={'outline'}
+              showIconOnly={true}
               icon="delete"
               sx={{ height: '30px' }}
               onClick={() => props.moderateEvent(props.event, false)}
-            />
+            >
+              Reject
+            </Button>
           </Flex>
         )}
         <Flex

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -354,7 +354,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                 sx={{ flexDirection: 'column' }}
                                 mb={[4, 4, 0]}
                               >
-                                {formValues.files.length !== 0 &&
+                                {formValues.files?.length &&
                                 parentType === 'edit' &&
                                 !fileEditMode ? (
                                   <Flex
@@ -371,7 +371,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                       />
                                     ))}
                                     <Button
-                                      variant={'tertiary'}
+                                      variant={'outline'}
                                       icon="delete"
                                       onClick={() =>
                                         this.setState({
@@ -490,7 +490,6 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                 mt={[10, 10, 20]}
                                 mb={[5, 5, 20]}
                                 variant="secondary"
-                                medium
                                 onClick={() => {
                                   fields.push({
                                     title: '',
@@ -546,18 +545,23 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                         <span>Save to draft</span>
                       ) : (
                         <span>Revert to draft</span>
-                      )}{' '}
+                      )}
                     </Button>
                     <Button
+                      large
                       data-cy={'submit'}
                       onClick={() => this.trySubmitForm(false)}
                       mt={3}
                       variant="primary"
                       type="submit"
                       disabled={submitting}
-                      sx={{ width: '100%', mb: ['40px', '40px', 0] }}
+                      sx={{
+                        width: '100%',
+                        display: 'block',
+                        mb: ['40px', '40px', 0],
+                      }}
                     >
-                      <span>Publish</span>
+                      Publish
                     </Button>
                   </Box>
                 </Flex>

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -82,6 +82,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 data-cy="move-step"
                 variant={'secondary'}
                 icon="arrow-full-up"
+                showIconOnly={true}
                 sx={{ mx: '5px' }}
                 onClick={() => this.props.moveStep(index, index - 1)}
               />
@@ -91,12 +92,14 @@ class HowtoStep extends PureComponent<IProps, IState> {
               variant={'secondary'}
               icon="arrow-full-down"
               sx={{ mx: '5px' }}
+              showIconOnly={true}
               onClick={() => this.props.moveStep(index, index + 1)}
             />
             {index >= 1 && (
               <Button
                 data-cy="delete-step"
-                variant={'tertiary'}
+                variant={'outline'}
+                showIconOnly={true}
                 icon="delete"
                 onClick={() => this.toggleDeleteModal()}
               />
@@ -119,7 +122,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 <Flex px={1}>
                   <Button
                     data-cy="confirm"
-                    variant={'tertiary'}
+                    variant={'outline'}
                     onClick={() => this.confirmDelete()}
                   >
                     Delete

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -178,7 +178,7 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
                 />
                 <Button
                   data-cy="reject-howto"
-                  variant={'tertiary'}
+                  variant={'outline'}
                   icon="delete"
                   onClick={() => this.props.moderateHowto(false)}
                 />

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -232,7 +232,6 @@ export class HowtoList extends React.Component<any, IState> {
                 <Button
                   sx={{ width: '100%' }}
                   variant={'primary'}
-                  translateY
                   data-cy="create"
                 >
                   Create a How-to

--- a/src/pages/Password/ForgotPassword.tsx
+++ b/src/pages/Password/ForgotPassword.tsx
@@ -105,7 +105,7 @@ class ForgotPasswordPage extends React.Component<IProps, IState> {
                   </Flex>
                 </Card>
                 <Flex mt={3} sx={{ justifyContent: 'flex-end' }}>
-                  <Button variant="tertiary">Close</Button>
+                  <Button variant={'outline'}>Close</Button>
                 </Flex>
               </Flex>
             </Flex>

--- a/src/pages/Password/ForgotPasswordMessage.tsx
+++ b/src/pages/Password/ForgotPasswordMessage.tsx
@@ -45,7 +45,7 @@ class ForgotPasswordMessagePage extends React.Component {
             </Flex>
           </Card>
           <Flex mt={3} sx={{ justifyContent: 'flex-end' }}>
-            <Button variant="tertiary">Close</Button>
+            <Button variant={'outline'}>Close</Button>
           </Flex>
         </Flex>
       </Flex>

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -276,6 +276,7 @@ const ResearchForm = observer((props: IProps) => {
                     )}{' '}
                   </Button>
                   <Button
+                    large
                     data-cy={'submit'}
                     onClick={() =>
                       setSubmissionHandler({ shouldSubmit: true, draft: false })
@@ -284,7 +285,11 @@ const ResearchForm = observer((props: IProps) => {
                     variant="primary"
                     type="submit"
                     disabled={submitting}
-                    sx={{ width: '100%', mb: ['40px', '40px', 0] }}
+                    sx={{
+                      width: '100%',
+                      mb: ['40px', '40px', 0],
+                      display: 'block',
+                    }}
                   >
                     <span>Publish</span>
                   </Button>

--- a/src/pages/Research/Content/Common/Update.form.tsx
+++ b/src/pages/Research/Content/Common/Update.form.tsx
@@ -304,13 +304,17 @@ const UpdateForm = observer((props: IProps) => {
                   }}
                 >
                   <Button
+                    large
                     data-cy={'submit'}
                     onClick={trySubmitForm}
-                    mt={3}
                     variant="primary"
                     type="submit"
                     disabled={submitting}
-                    sx={{ mb: ['40px', '40px', 0], width: '100%' }}
+                    sx={{
+                      mb: ['40px', '40px', 0],
+                      width: '100%',
+                      justifyContent: 'center',
+                    }}
                   >
                     <span>
                       {props.parentType === 'edit' ? 'Save' : 'Add update'}

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -101,7 +101,7 @@ const ResearchDescription: React.FC<IProps> = ({
               />
               <Button
                 data-cy="reject-research"
-                variant={'tertiary'}
+                variant={'outline'}
                 icon="delete"
                 onClick={() => props.moderateResearch(false)}
               />

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -293,6 +293,7 @@ export class UserSettings extends React.Component<IProps, IState> {
                     </Box>
                   )}
                   <Button
+                    large
                     data-cy="save"
                     title={
                       rest.invalid
@@ -316,7 +317,7 @@ export class UserSettings extends React.Component<IProps, IState> {
                       }
                     }}
                     mb={3}
-                    sx={{ width: '100%' }}
+                    sx={{ width: '100%', justifyContent: 'center' }}
                     variant={'primary'}
                     type="submit"
                     // disable button when form invalid or during submit.

--- a/src/pages/Settings/content/ProfileDelete.tsx
+++ b/src/pages/Settings/content/ProfileDelete.tsx
@@ -36,7 +36,7 @@ export class ProfileDelete extends React.Component<IProps, IState> {
       <>
         <Button
           icon="delete"
-          variant="tertiary"
+          variant={'outline'}
           my={3}
           onClick={() => this.setState({ showDeleteDialog: true })}
         >
@@ -71,7 +71,7 @@ export class ProfileDelete extends React.Component<IProps, IState> {
                     </Button>
                     <Button
                       type="submit"
-                      variant="tertiary"
+                      variant={'outline'}
                       ml={1}
                       disabled={values.password ? false : true}
                     >

--- a/src/pages/Settings/content/formSections/ChangeEmail.form.tsx
+++ b/src/pages/Settings/content/formSections/ChangeEmail.form.tsx
@@ -62,6 +62,7 @@ export class ChangeEmailForm extends React.Component<IProps, IState> {
       <>
         <Button
           my={3}
+          mr={2}
           variant={'secondary'}
           onClick={() =>
             this.setState({

--- a/src/pages/Settings/content/formSections/ChangePassword.form.tsx
+++ b/src/pages/Settings/content/formSections/ChangePassword.form.tsx
@@ -55,6 +55,7 @@ export class ChangePasswordForm extends React.Component<IProps, IState> {
       <>
         <Button
           my={3}
+          mr={2}
           variant={'secondary'}
           onClick={() =>
             this.setState({

--- a/src/pages/Settings/content/formSections/Fields/Link.field.tsx
+++ b/src/pages/Settings/content/formSections/Fields/Link.field.tsx
@@ -61,9 +61,10 @@ export class ProfileLinkField extends Component<IProps, IState> {
       <Button
         data-cy={`delete-link-${index}`}
         icon={'delete'}
-        variant={'tertiary'}
+        variant={'outline'}
+        showIconOnly={true}
         onClick={() => this.toggleDeleteModal()}
-        ml={'10px'}
+        ml={2}
         {...props}
       />
     )
@@ -142,7 +143,7 @@ export class ProfileLinkField extends Component<IProps, IState> {
               </Flex>
               <Flex px={1}>
                 <Button
-                  variant={'tertiary'}
+                  variant={'outline'}
                   onClick={() => this.confirmDelete()}
                 >
                   Delete

--- a/src/pages/Settings/content/formSections/Fields/OpeningHoursPicker.field.tsx
+++ b/src/pages/Settings/content/formSections/Fields/OpeningHoursPicker.field.tsx
@@ -58,7 +58,7 @@ export class OpeningHoursPicker extends Component<IProps, IState> {
           />
           <Button
             icon={'delete'}
-            variant={'tertiary'}
+            variant={'outline'}
             sx={{ height: '40px', display: ['block', 'block', 'none'] }}
             onClick={() => this.toggleDeleteModal()}
           />
@@ -89,7 +89,7 @@ export class OpeningHoursPicker extends Component<IProps, IState> {
         </Flex>
         <Button
           icon={'delete'}
-          variant={'tertiary'}
+          variant={'outline'}
           data-cy={`delete-opening-time-${index}-desk`}
           sx={{ height: '40px', display: ['none', 'none', 'block'] }}
           onClick={() => this.toggleDeleteModal()}
@@ -112,7 +112,7 @@ export class OpeningHoursPicker extends Component<IProps, IState> {
             <Flex px={1}>
               <Button
                 data-cy={'confirm-delete'}
-                variant={'tertiary'}
+                variant={'outline'}
                 onClick={() => this.confirmDelete()}
               >
                 Delete

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -227,8 +227,9 @@ class SignInPage extends React.Component<IProps, IState> {
 
                             <Flex>
                               <Button
+                                large
                                 data-cy="submit"
-                                sx={{ width: '100%' }}
+                                sx={{ width: '100%', justifyContent: 'center' }}
                                 variant={'primary'}
                                 disabled={submitting || invalid}
                                 type="submit"

--- a/src/pages/SignUp/ResendSignUpMessage.tsx
+++ b/src/pages/SignUp/ResendSignUpMessage.tsx
@@ -105,7 +105,7 @@ class ResendSignUpMessagePage extends React.Component<IProps, IState> {
                 </Card>
 
                 <Flex mt={3} sx={{ justifyContent: 'flex-end' }}>
-                  <Button variant="tertiary">Home</Button>
+                  <Button variant={'outline'}>Home</Button>
                 </Flex>
               </Flex>
             </Flex>

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -263,8 +263,9 @@ class SignUpPage extends React.Component<IProps, IState> {
 
                       <Flex>
                         <Button
+                          large
                           data-cy="submit"
-                          sx={{ width: '100%' }}
+                          sx={{ width: '100%', justifyContent: 'center' }}
                           variant={'primary'}
                           disabled={disabled}
                           type="submit"

--- a/src/pages/common/Header/Menu/Profile/ProfileButtonItem.tsx
+++ b/src/pages/common/Header/Menu/Profile/ProfileButtonItem.tsx
@@ -46,7 +46,7 @@ export class ProfileButtonItem extends React.Component<IProps> {
           <ButtonSign
             onClick={() => this.props.isMobile && menu.toggleMobilePanel()}
             variant={this.props.variant}
-            {...(this.props.isMobile ? { large: true } : { medium: true })}
+            {...(this.props.isMobile ? { large: true } : {})}
             data-cy={this.props.text.toLowerCase()}
             sx={{
               ...this.props.sx,

--- a/src/pages/common/Header/Menu/Profile/ProfileButtons.tsx
+++ b/src/pages/common/Header/Menu/Profile/ProfileButtons.tsx
@@ -45,7 +45,7 @@ export class ProfileButtons extends Component<IProps> {
               <ProfileButtonItem
                 link={'/sign-up'}
                 text="Join"
-                variant="colorful"
+                variant="outline"
                 isMobile={true}
                 sx={{
                   fontSize: '12px',
@@ -71,7 +71,7 @@ export class ProfileButtons extends Component<IProps> {
             <ProfileButtonItem
               link={'/sign-up'}
               text="Join"
-              variant="colorful"
+              variant="outline"
               sx={{ fontSize: 2 }}
             />
           </>

--- a/src/themes/common/button.ts
+++ b/src/themes/common/button.ts
@@ -1,0 +1,87 @@
+const BASE_BUTTON = {
+  fontFamily: '"Varela Round", Arial, sans-serif',
+  fontSize: 3,
+  display: 'inline-flex',
+  alignItems: 'center',
+  position: 'relative',
+  transition: '.2s ease-in-out',
+  borderRadius: 1,
+  width: 'auto',
+  border: '2px solid',
+}
+
+export function getButtons(colors) {
+  return {
+    primary: {
+      ...BASE_BUTTON,
+      color: colors.black,
+      bg: colors.yellow.base,
+      '&:hover': {
+        bg: colors.yellow.hover,
+        cursor: 'pointer',
+      },
+      '&[disabled]': {
+        opacity: 0.5,
+        cursor: 'not-allowed',
+      },
+      '&[disabled]:hover': {
+        bg: colors.yellow.base,
+      },
+    },
+    secondary: {
+      ...BASE_BUTTON,
+      border: '2px solid ' + colors.black,
+      color: colors.black,
+      bg: colors.softblue,
+      '&:hover': {
+        bg: colors.white,
+        cursor: 'pointer',
+      },
+      '&[disabled]': {
+        opacity: 0.5,
+      },
+      '&[disabled]:hover': {
+        bg: colors.softblue,
+      },
+    },
+    outline: {
+      ...BASE_BUTTON,
+      border: '2px solid ' + colors.black,
+      color: colors.black,
+      backgroundColor: 'transparent',
+      '&:hover': {
+        backgroundColor: colors.softblue,
+        cursor: 'pointer',
+      },
+    },
+    imageInput: {
+      border: '2px dashed #e0e0e0',
+      color: '#e0e0e0',
+      backgroundColor: 'transparent',
+    },
+    subtle: {
+      ...BASE_BUTTON,
+      borderColor: colors.softblue,
+      color: colors.black,
+      bg: colors.softblue,
+      '&:hover': {
+        borderColor: colors.white,
+        bg: colors.white,
+        cursor: 'pointer',
+      },
+      '&[disabled]': {
+        opacity: 0.5,
+      },
+      '&[disabled]:hover': {
+        bg: colors.softblue,
+      },
+    },
+  }
+}
+
+export type ButtonVariants =
+  | 'primary'
+  | 'secondary'
+  | 'outline'
+  | 'disabled'
+  | 'subtle'

--- a/src/themes/fixing-fashion/styles.ts
+++ b/src/themes/fixing-fashion/styles.ts
@@ -3,6 +3,8 @@ import spaceBadge from 'src/assets/images/themes/fixing-fashion/avatar_space_lg.
 import memberBadgeLowDetail from 'src/assets/images/themes/fixing-fashion/avatar_member_sm.svg'
 import memberBadgeHighDetail from 'src/assets/images/themes/fixing-fashion/avatar_member_lg.svg'
 import logo from 'src/assets/images/themes/fixing-fashion/fixing-fashion-header.png'
+import { getButtons } from '../common/button'
+export type { ButtonVariants } from '../common/button'
 
 const fonts = {
   body: `'Inter', Arial, sans-serif`,
@@ -42,15 +44,6 @@ export const zIndex = {
   header: 3000,
 }
 
-export type ButtonVariants =
-  | 'primary'
-  | 'secondary'
-  | 'outline'
-  | 'disabled'
-  | 'dark'
-  | 'light'
-  | 'subtle'
-
 const space = [
   0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
   100, 105, 110, 115, 120, 125, 130, 135, 140,
@@ -80,127 +73,6 @@ const alerts = {
     backgroundColor: colors.red2,
     textAlign: 'center',
     fontWeight: 'normal',
-  },
-}
-
-const buttons = {
-  primary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    bg: colors.yellow.base,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.hover,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  secondary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  tertiary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.red,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.white,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-
-  outline: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    backgroundColor: colors.white,
-    transition: '.2s ease-in-out',
-    display: 'flex',
-    alignItems: 'center',
-    width: 'fit-content',
-    height: 'fit-content',
-    '&:hover': {
-      backgroundColor: colors.softblue,
-      cursor: 'pointer',
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  imageInput: {
-    border: '2px dashed #e0e0e0',
-    color: '#e0e0e0',
-    backgroundColor: 'transparent',
-  },
-  colorful: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.base,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  subtle: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: 'none',
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
   },
 }
 
@@ -244,7 +116,7 @@ const StyledComponentTheme: ThemeWithName = {
     },
   },
   colors,
-  buttons,
+  buttons: getButtons(colors),
   breakpoints,
   space,
   radii,

--- a/src/themes/precious-plastic/styles.ts
+++ b/src/themes/precious-plastic/styles.ts
@@ -11,6 +11,8 @@ import LocalComBadgeLowDetail from 'src/assets/icons/map-community.svg'
 import logo from 'src/assets/images/precious-plastic-logo-official.svg'
 
 import type { ThemeWithName } from '../types'
+import { getButtons } from '../common/button'
+export type { ButtonVariants } from '../common/button'
 
 const fonts = {
   body: `'Inter', Arial, sans-serif`,
@@ -50,15 +52,6 @@ export const zIndex = {
   header: 3000,
 }
 
-export type ButtonVariants =
-  | 'primary'
-  | 'secondary'
-  | 'outline'
-  | 'disabled'
-  | 'dark'
-  | 'light'
-  | 'subtle'
-
 const space = [
   0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
   100, 105, 110, 115, 120, 125, 130, 135, 140,
@@ -97,127 +90,6 @@ const alerts = {
     backgroundColor: colors.red2,
     textAlign: 'center',
     fontWeight: 'normal',
-  },
-}
-
-const buttons = {
-  primary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    bg: colors.yellow.base,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.hover,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  secondary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  tertiary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.red,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.white,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-
-  outline: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    backgroundColor: colors.white,
-    transition: '.2s ease-in-out',
-    display: 'flex',
-    alignItems: 'center',
-    width: 'fit-content',
-    height: 'fit-content',
-    '&:hover': {
-      backgroundColor: colors.softblue,
-      cursor: 'pointer',
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  imageInput: {
-    border: '2px dashed #e0e0e0',
-    color: '#e0e0e0',
-    backgroundColor: 'transparent',
-  },
-  colorful: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.base,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  subtle: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: 'none',
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
   },
 }
 
@@ -266,7 +138,7 @@ const StyledComponentTheme: ThemeWithName = {
   },
   bold,
   breakpoints,
-  buttons,
+  buttons: getButtons(colors),
   cards: {
     primary: {
       background: 'white',

--- a/src/themes/project-kamp/styles.ts
+++ b/src/themes/project-kamp/styles.ts
@@ -2,6 +2,8 @@ import memberBadgeLowDetail from 'src/assets/images/themes/project-kamp/avatar_m
 import memberBadgeHighDetail from 'src/assets/images/themes/project-kamp/avatar_member_lg.svg'
 import logo from 'src/assets/images/themes/project-kamp/project-kamp-header.png'
 import type { ThemeWithName } from '../types'
+import { getButtons } from '../common/button'
+export type { ButtonVariants } from '../common/button'
 
 // use enum to specify list of possible colors for typing
 export const colors = {
@@ -41,15 +43,6 @@ const fonts = {
   body: `'Inter', Arial, sans-serif`,
 }
 
-export type ButtonVariants =
-  | 'primary'
-  | 'secondary'
-  | 'outline'
-  | 'disabled'
-  | 'dark'
-  | 'light'
-  | 'subtle'
-
 const space = [
   0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
   100, 105, 110, 115, 120, 125, 130, 135, 140,
@@ -79,127 +72,6 @@ const alerts = {
     backgroundColor: colors.red2,
     textAlign: 'center',
     fontWeight: 'normal',
-  },
-}
-
-const buttons = {
-  primary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    bg: colors.yellow.base,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.hover,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  secondary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  tertiary: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.red,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.white,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-
-  outline: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    backgroundColor: colors.white,
-    transition: '.2s ease-in-out',
-    display: 'flex',
-    alignItems: 'center',
-    width: 'fit-content',
-    height: 'fit-content',
-    '&:hover': {
-      backgroundColor: colors.softblue,
-      cursor: 'pointer',
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  imageInput: {
-    border: '2px dashed #e0e0e0',
-    color: '#e0e0e0',
-    backgroundColor: 'transparent',
-  },
-  colorful: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: '2px solid ' + colors.black,
-    color: colors.black,
-    display: 'flex',
-    bg: colors.white,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.yellow.base,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-      cursor: 'not-allowed',
-    },
-    '&[disabled]:hover': {
-      bg: colors.yellow.base,
-    },
-    borderRadius: radii[1] + 'px',
-  },
-  subtle: {
-    fontFamily: '"Varela Round", Arial, sans-serif',
-    border: 'none',
-    color: colors.black,
-    display: 'flex',
-    bg: colors.softblue,
-    transition: '.2s ease-in-out',
-    '&:hover': {
-      bg: colors.white,
-      cursor: 'pointer',
-    },
-    '&[disabled]': {
-      opacity: 0.5,
-    },
-    '&[disabled]:hover': {
-      bg: colors.softblue,
-    },
-    borderRadius: radii[1] + 'px',
   },
 }
 
@@ -239,7 +111,7 @@ const StyledComponentTheme: ThemeWithName = {
     },
   },
   colors,
-  buttons,
+  buttons: getButtons(colors),
   breakpoints,
   space,
   radii,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

It was the misalignment of text and icons in the folllowing screengrab that started me down this path. 

![Screenshot 2022-12-21 at 11 40 00](https://user-images.githubusercontent.com/472589/208898455-69852c20-ac54-44d7-b900-26b4251a9eb4.jpg)

* Remove unused `medium` variant in favour of a sensible default complimented by a small and large variant.
* Remove snowflake transform effect from `Create new How-to` button.
* Introduced documentation for all variants within Storybook

Questions:
* Large is not currently being used anywhere, should we just remove it?
* Inconsistent cases, some buttons are lowercased `action` and others are capitalized `Action`. Do we have a clear preference here? 


## Git Issues

Closes #

## Screenshots/Videos



![Screen Shot 2022-12-21 at 11 41 17](https://user-images.githubusercontent.com/472589/208898416-0413e805-9bc8-467b-abf1-aa668e8633c6.png)
