### PR TITLE
fix: use standard button icon for Discord link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,13 +14,13 @@ import {
   POLICY_PAGES,
   getAvailablePageList,
 } from './PageList'
-import { Flex, Box, Button } from 'theme-ui'
+import { Flex, Box } from 'theme-ui'
 import DevSiteHeader from 'src/pages/common/DevSiteHeader/DevSiteHeader'
 import { getSupportedModules } from 'src/modules'
 import GlobalSiteFooter from './common/GlobalSiteFooter/GlobalSiteFooter'
 import { AlertIncompleteProfile } from 'src/common/AlertIncompleteProfile'
 import { SeoTagsUpdateComponent } from 'src/utils/seo'
-import { ExternalLink } from 'oa-components'
+import { ExternalLink, Button } from 'oa-components'
 
 export class Routes extends React.Component<
   any,
@@ -107,11 +107,8 @@ export class Routes extends React.Component<
             href="https://discordapp.com/invite/cGZ5hKP"
             data-cy="feedback"
           >
-            <Button variant="primary">
-              Join our chat{' '}
-              <span role="img" aria-label="talk-bubble">
-                💬
-              </span>
+            <Button variant="primary" icon="comment">
+              Join our chat
             </Button>
           </ExternalLink>
         </Box>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Drop use of emoji within a button in favour of standard icon followed by text pattern used across the entire platform. 

## Screenshots/Videos

Before:  

![Screenshot 2022-12-29 at 21 34 42](https://user-images.githubusercontent.com/472589/210013296-199e73f5-226b-4a35-92ac-d27c701a17e5.jpg)

After:  

![Screenshot 2022-12-29 at 21 31 00](https://user-images.githubusercontent.com/472589/210013294-41e20b74-a06b-4476-9d25-c2f9283a7848.jpg)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
