### PR TITLE
fix: override blue border of subtle button variant

### DIFF
--- a/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
+++ b/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
@@ -52,7 +52,12 @@ export const UsefulStatsButton = (props: IProps) => {
         data-cy="vote-useful"
         variant="subtle"
         onClick={handleUsefulClick}
-        sx={{ fontSize: 2, ml: 1, background: theme.colors.softyellow }}
+        sx={{
+          fontSize: 2,
+          ml: 1,
+          background: 'softyellow',
+          borderColor: 'softyellow',
+        }}
         icon={hasUserVotedUseful ? 'star-active' : 'star'}
       >
         <Text ml={1}>Useful {votedUsefulCount ? votedUsefulCount : ''}</Text>
@@ -66,7 +71,8 @@ export const UsefulStatsButton = (props: IProps) => {
         data-tip={'Login to add your vote'}
         sx={{
           ...theme.buttons.subtle,
-          background: theme.colors.softyellow,
+          borderColor: 'softyellow',
+          background: 'softyellow',
           display: 'inline-flex',
           fontSize: 2,
           paddingY: 2,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Overrides border colour for subtle button variant when used within Useful stats

**Before:** 

![Screenshot 2022-12-30 at 11 33 15](https://user-images.githubusercontent.com/472589/210065977-01dd5611-ee46-4027-92c0-204bd110626d.jpg)

**After:**

![Screenshot 2022-12-30 at 11 33 07](https://user-images.githubusercontent.com/472589/210065985-7d7d6bc7-5830-488e-8daf-a5e3a90239ec.jpg)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
