### PR TITLE
fix: adds accessible labels to moderation buttons

### DIFF
--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -173,21 +173,27 @@ export default class HowtoDescription extends PureComponent<IProps, IState> {
                   data-cy={'accept'}
                   variant={'primary'}
                   icon="check"
-                  mr={1}
                   onClick={() => this.props.moderateHowto(true)}
-                />
+                  showIconOnly={true}
+                >
+                  Accept
+                </Button>
                 <Button
                   data-cy="reject-howto"
                   variant={'outline'}
                   icon="delete"
                   onClick={() => this.props.moderateHowto(false)}
-                />
+                  showIconOnly={true}
+                  sx={{ ml: 1 }}
+                >
+                  Reject
+                </Button>
               </Flex>
             )}
             {/* Check if logged in user is the creator of the how-to OR a super-admin */}
             {loggedInUser && isAllowToEditContent(howto, loggedInUser) && (
               <Link to={'/how-to/' + this.props.howto.slug + '/edit'}>
-                <Button variant={'primary'} data-cy={'edit'}>
+                <Button variant={'primary'} data-cy={'edit'} sx={{ ml: 1 }}>
                   Edit
                 </Button>
               </Link>


### PR DESCRIPTION
Use new `showIconOnly` property and use margin-left for consistent layout.

(cherry picked from commit 9ddc1c6f624f31fd0d9a388afb2e3f3fa0f068fa)

PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Rebase of #2065 to fix commitlint issue

## Git Issues

Closes #2065

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
