### PR TITLE
chore: only print output in failure scenario

### DIFF
--- a/scripts/envCheck.js
+++ b/scripts/envCheck.js
@@ -3,41 +3,32 @@ function envCheck() {
   const tests = [
     {
       message: 'Use Yarn (not npm)',
-      severity: 'failure',
       exec: () => /yarn/.test(process.env.npm_execpath),
     },
     {
       message: 'Use Node v18',
-      severity: 'failure',
       exec: () => process.versions.node.split('.')[0] === '18',
     },
   ]
 
   let failures = 0
+  let output = '\n'
 
-  console.log('\n')
   for (const test of tests) {
-    let icon = '✅'
-    let message = test.message
-    const passed = test.exec()
-    if (!passed) {
-      if (test.severity === 'failure') {
-        icon = '❌'
-        failures = failures + 1
-      } else {
-        icon = '⚠️'
-        message = '(Recommended) ' + message
-      }
+    if (!test.exec()) {
+      failures = failures + 1
+      output += `❌ ${test.message}\n`
+    } else {
+      output += `✅ ${test.message}\n`
     }
-    console.log(icon, '', message)
   }
-  console.log('\n')
 
   if (failures > 0) {
+    console.log(output)
     console.log(
-      '💻 Please setup your dev environment to meet requirements\n\nFor more info see:\n\n',
-      'https://onearmy.github.io/community-platform/\n\n',
+      '💻 Please setup your dev environment to meet requirements\n\nFor more info see:',
     )
+    console.log('https://onearmy.github.io/community-platform/\n\n')
     process.exit(1)
   }
 }


### PR DESCRIPTION
The envcheck was generating output when all
tests pass. Whilst reassuring, this is a distraction
when kicking off new tasks. We should aim for
actionable output and reduce noise where possible.

🕊️

Additional changes:

* Refactor to remove unused `severity` property
* Reduce logic branches within for loop
* Remove indent of documentation URL

PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
