### PR TITLE
fix: admin notifications legacy format

### DIFF
--- a/src/modules/admin/pages/adminNotifications.tsx
+++ b/src/modules/admin/pages/adminNotifications.tsx
@@ -10,7 +10,8 @@ import Table from '../components/Table/Table'
 import type { ICellRenderProps, ITableProps } from '../components/Table/Table'
 
 interface IPendingEmails {
-  _authID: 'string'
+  _authID: string
+  _userId: string
   emailFrequency?: INotificationSettings['emailFrequency']
   notifications: INotification[]
 }
@@ -18,19 +19,16 @@ type IPendingEmailsDBDoc = Record<string, IPendingEmails>
 
 const EMAILS_PENDING_COLUMNS: ITableProps<IPendingEmails>['columns'] = [
   {
-    Header: 'Auth ID',
-    accessor: '_authID',
-    minWidth: 100,
+    Header: 'User ID',
+    accessor: '_userId',
   },
   {
     Header: 'Frequency',
     accessor: 'emailFrequency',
-    minWidth: 100,
   },
   {
     Header: 'Notifications',
     accessor: 'notifications',
-    minWidth: 140,
   },
 ]
 const NotificationListContainer = styled(Box)`
@@ -53,7 +51,9 @@ const AdminNotifictions = observer(() => {
       .stream()
       .subscribe((emailsPending) => {
         if (emailsPending) {
-          const values = Object.values(emailsPending)
+          const values = Object.entries(emailsPending).map(
+            ([_userId, value]) => ({ ...value, _userId }),
+          )
           if (values.length > 0) {
             setEmailsPending(values)
           }

--- a/src/pages/common/Header/getFormattedNotifications.tsx
+++ b/src/pages/common/Header/getFormattedNotifications.tsx
@@ -4,17 +4,21 @@ import type { INotification } from 'src/models'
 import { Box } from 'theme-ui'
 
 export function getFormattedNotificationMessage(notification: INotification) {
+  // Some legacy notifications to not have trigger, workaround until data cleaned and caches updated
+  const triggeredBy = notification.triggeredBy || {
+    displayName: 'Anonymous',
+    userId: '',
+  }
+  const relevantUrl = notification.relevantUrl || ''
   switch (notification.type) {
     case 'new_comment':
       return (
         <Box>
           New comment on your
-          <InternalLink to={notification.relevantUrl || ''}>
-            how-to
-          </InternalLink>
+          <InternalLink to={relevantUrl}>how-to</InternalLink>
           by
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
         </Box>
       )
@@ -22,12 +26,10 @@ export function getFormattedNotificationMessage(notification: INotification) {
       return (
         <Box>
           You were mentioned in a
-          <InternalLink to={notification.relevantUrl || ''}>
-            how-to
-          </InternalLink>
+          <InternalLink to={relevantUrl}>how-to</InternalLink>
           by
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
         </Box>
       )
@@ -35,13 +37,11 @@ export function getFormattedNotificationMessage(notification: INotification) {
       return (
         <Box>
           Yay,
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
           found your
-          <InternalLink to={notification.relevantUrl || ''}>
-            how-to
-          </InternalLink>
+          <InternalLink to={relevantUrl}>how-to</InternalLink>
           useful
         </Box>
       )
@@ -49,13 +49,11 @@ export function getFormattedNotificationMessage(notification: INotification) {
       return (
         <Box>
           Yay,
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
           found your
-          <InternalLink to={notification.relevantUrl || ''}>
-            research
-          </InternalLink>
+          <InternalLink to={relevantUrl}>research</InternalLink>
           useful
         </Box>
       )
@@ -63,12 +61,10 @@ export function getFormattedNotificationMessage(notification: INotification) {
       return (
         <Box>
           You were mentioned in a
-          <InternalLink to={notification.relevantUrl || ''}>
-            research article
-          </InternalLink>
+          <InternalLink to={relevantUrl}>research article</InternalLink>
           by
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
         </Box>
       )
@@ -76,12 +72,10 @@ export function getFormattedNotificationMessage(notification: INotification) {
       return (
         <Box>
           New comment on your
-          <InternalLink to={notification.relevantUrl || ''}>
-            research
-          </InternalLink>
+          <InternalLink to={relevantUrl}>research</InternalLink>
           by
-          <InternalLink to={'/u/' + notification.triggeredBy.userId}>
-            {notification.triggeredBy.displayName}
+          <InternalLink to={'/u/' + triggeredBy.userId}>
+            {triggeredBy.displayName}
           </InternalLink>
         </Box>
       )

--- a/src/stores/databaseV2/DocReference.tsx
+++ b/src/stores/databaseV2/DocReference.tsx
@@ -38,12 +38,12 @@ export class DocReference<T> {
    *  Stream live updates from a server (where supported)
    *  Just returns the doc when not supported
    */
-  stream(): Observable<DBDoc> {
+  stream(): Observable<T & DBDoc> {
     const { serverDB } = this.clients
     if (serverDB.streamDoc) {
       return serverDB.streamDoc<T>(`${this.endpoint}/${this.id}`)
     } else {
-      return new Observable<DBDoc>((subscriber) => {
+      return new Observable<T & DBDoc>((subscriber) => {
         this.get('server').then((res) => {
           subscriber.next(res)
           subscriber.complete()


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Fix admin panel to display notifications stored in legacy format. They didn't track the `triggeredBy` user in the same way, so for now just marking as "Anonymous". Unclear if any of these notifications exist in production, so for now mostly just to keep the dev site working until we have a better way to clean-up legacy data.

## Git Issues

Closes #

## Screenshots/Videos
**Admin panel now lists pending emails in table**
![image](https://user-images.githubusercontent.com/10515065/219985479-edf1b10c-96ce-45d7-8bf7-8165010245e4.png)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
