### PR TITLE
fix: #2109-Change the discord link in Join our Chat

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -104,7 +104,7 @@ export class Routes extends React.Component<
           }}
         >
           <ExternalLink
-            href="https://discordapp.com/invite/cGZ5hKP"
+            href="https://discord.gg/gJ7Yyk4"
             data-cy="feedback"
           >
             <Button variant="primary" icon="comment">


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_
Fixes the expired Discord Link in the  Join our Chat. It was replaced with an updated link.
## Git Issues

Closes #2109

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
