### PR TITLE
fix: adjust margin and width of elements in HowToComments

### DIFF
--- a/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
+++ b/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
@@ -98,7 +98,6 @@ export const HowToComments = ({ comments }: IProps) => {
 
   return (
     <Flex
-      ml={[0, 0, 6]}
       mt={5}
       sx={{ flexDirection: 'column', alignItems: 'center' }}
       data-cy="howto-comments"
@@ -122,7 +121,7 @@ export const HowToComments = ({ comments }: IProps) => {
       </Flex>
       <Box
         sx={{
-          width: ['100%', `calc(${(2 / 3) * 100}%)`],
+          width: ['100%', `${(4 / 5) * 100}%`, `${(2 / 3) * 100}%`],
         }}
       >
         <CreateComment


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Adjust the margin and width of elements in the HowToComments component so they are consistent 

## Git Issues 

Closes #2118

## Screenshots/Videos
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/95109313/221025125-fb7deae2-d6e6-4bbc-bdd8-545ab20cb775.gif)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
