### PR TITLE
fix: move initialization boolean inside component

### DIFF
--- a/packages/components/src/ViewsCounter/ViewsCounter.tsx
+++ b/packages/components/src/ViewsCounter/ViewsCounter.tsx
@@ -7,6 +7,7 @@ export interface IProps {
 
 export const ViewsCounter = (props: IProps) => (
   <Flex
+    data-cy={'ViewsCounter'}
     px={2}
     py={1}
     mb={1}

--- a/packages/cypress/src/integration/howto/read.spec.ts
+++ b/packages/cypress/src/integration/howto/read.spec.ts
@@ -158,6 +158,12 @@ describe('[How To]', () => {
 
         cy.get(`[data-cy="comments-form"]`).should('not.exist')
       })
+
+      it('[Views only visible for beta-testers]', () => {
+        cy.visit(specificHowtoUrl)
+        cy.step(`ViewsCounter should be visible`)
+        cy.get('[data-cy="ViewsCounter"]').should('not.exist')
+      })
     })
 
     describe('[By Authenticated]', () => {
@@ -197,6 +203,30 @@ describe('[How To]', () => {
 
           cy.get('[data-cy="CommentItem: edit button"]').should('exist')
         })
+      })
+    })
+
+    describe('[By Beta-Tester]', () => {
+      it('[Views show on multiple howtos]', () => {
+        cy.login('demo_beta_tester@example.com', 'demo_beta_tester')
+
+        cy.step('Views show on first howto')
+        cy.visit(specificHowtoUrl)
+        cy.get('[data-cy="ViewsCounter"]').should('exist')
+
+        cy.step('Go back')
+        cy.get('[data-cy="go-back"]:eq(0)').as('topBackButton').click()
+
+        cy.step('Views show on second howto')
+        cy.visit('/how-to/make-glass-like-beams')
+        cy.get('[data-cy="ViewsCounter"]').should('exist')
+
+        cy.step('Go back')
+        cy.get('[data-cy="go-back"]:eq(0)').as('topBackButton').click()
+
+        cy.step('Views show on third howto')
+        cy.visit('/how-to/set-up-devsite-to-help-coding')
+        cy.get('[data-cy="ViewsCounter"]').should('exist')
       })
     })
 

--- a/packages/cypress/src/integration/howto/read.spec.ts
+++ b/packages/cypress/src/integration/howto/read.spec.ts
@@ -161,7 +161,7 @@ describe('[How To]', () => {
 
       it('[Views only visible for beta-testers]', () => {
         cy.visit(specificHowtoUrl)
-        cy.step(`ViewsCounter should be visible`)
+        cy.step(`ViewsCounter should not be visible`)
         cy.get('[data-cy="ViewsCounter"]').should('not.exist')
       })
     })
@@ -219,13 +219,6 @@ describe('[How To]', () => {
 
         cy.step('Views show on second howto')
         cy.visit('/how-to/make-glass-like-beams')
-        cy.get('[data-cy="ViewsCounter"]').should('exist')
-
-        cy.step('Go back')
-        cy.get('[data-cy="go-back"]:eq(0)').as('topBackButton').click()
-
-        cy.step('Views show on third howto')
-        cy.visit('/how-to/set-up-devsite-to-help-coding')
         cy.get('[data-cy="ViewsCounter"]').should('exist')
       })
     })

--- a/packages/cypress/src/integration/research/read.spec.ts
+++ b/packages/cypress/src/integration/research/read.spec.ts
@@ -1,9 +1,8 @@
 describe('[Research]', () => {
   const SKIP_TIMEOUT = { timeout: 300 }
-  const totalResearchCount = 1
+  const totalResearchCount = 2
 
   describe('[List research articles]', () => {
-    const researchArticleUrl = '/research/qwerty'
     beforeEach(() => {
       cy.visit('/research')
     })
@@ -14,24 +13,59 @@ describe('[Research]', () => {
       cy.get('[data-cy="ResearchListItem"]')
         .its('length')
         .should('be.eq', totalResearchCount)
+    })
+  })
 
-      cy.step('Research cards has basic info')
-      cy.get(
-        `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
-      ).within(() => {
-        cy.contains('qwerty').should('be.exist')
-        cy.contains('event_reader').should('be.exist')
-        cy.get('[data-cy="ItemUpdateText"]').contains('1').should('be.exist')
+  describe('[Read a research article]', () => {
+    const researchArticleUrl = '/research/qwerty'
+    const researchArticleUrl2 = 'A%20test%20research'
+    beforeEach(() => {
+      cy.visit('/research')
+    })
+
+    describe('[By Everyone]', () => {
+      it('[See all info]', () => {
+        cy.step('Research cards has basic info')
+        cy.get(
+          `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
+        ).within(() => {
+          cy.contains('qwerty').should('be.exist')
+          cy.contains('event_reader').should('be.exist')
+          cy.get('[data-cy="ItemUpdateText"]').contains('1').should('be.exist')
+        })
+
+        cy.step(
+          `Open Research details when click on a Research ${researchArticleUrl}`,
+        )
+        cy.get(
+          `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
+          SKIP_TIMEOUT,
+        ).click()
+        cy.url().should('include', researchArticleUrl)
       })
 
-      cy.step(
-        `Open Research details when click on a Research ${researchArticleUrl}`,
-      )
-      cy.get(
-        `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
-        SKIP_TIMEOUT,
-      ).click()
-      cy.url().should('include', researchArticleUrl)
+      it('[Views only visible for beta-testers]', () => {
+        cy.step(`ViewsCounter should not be visible`)
+        cy.visit(researchArticleUrl)
+        cy.get('[data-cy="ViewsCounter"]').should('not.exist')
+      })
+    })
+
+    describe('[Beta-tester]', () => {
+      it('[Views show on multiple research articles]', () => {
+        cy.login('demo_beta_tester@example.com', 'demo_beta_tester')
+
+        cy.step('Views show on first research article')
+        cy.visit(researchArticleUrl)
+        cy.get('[data-cy="ViewsCounter"]').should('exist')
+
+        cy.step('Go back')
+        cy.get('[data-cy="go-back"]:eq(0)').as('topBackButton').click()
+
+        cy.step('Views show on second research article')
+        cy.visit('/research/A%20test%20research')
+        cy.get('[data-cy="ViewsCounter"]').should('exist')
+      })
     })
   })
 })

--- a/packages/cypress/src/integration/research/read.spec.ts
+++ b/packages/cypress/src/integration/research/read.spec.ts
@@ -18,7 +18,6 @@ describe('[Research]', () => {
 
   describe('[Read a research article]', () => {
     const researchArticleUrl = '/research/qwerty'
-    const researchArticleUrl2 = 'A%20test%20research'
     beforeEach(() => {
       cy.visit('/research')
     })

--- a/shared/mocks/data/research.ts
+++ b/shared/mocks/data/research.ts
@@ -388,4 +388,19 @@ export const research = {
       },
     ],
   },
+  '0up6oJCTT3M9bDYx34Et': {
+    _created: '2023-02-27T22:08:25.999Z',
+    _createdBy: 'test user',
+    _deleted: false,
+    _id: '0up6oJCTT3M9bDYx34Et',
+    _modified: '2023-03-01T19:12:11.271Z',
+    creatorCountry: 'it',
+    description: 'A test!',
+    moderation: 'accepted',
+    slug: 'A test research',
+    tags: {
+      h1wCs0o9j60lkw3AYPB1: true,
+    },
+    title: 'A test research',
+  },
 }

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -57,9 +57,9 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
   const [fileDownloadCount, setFileDownloadCount] = useState(
     howto.total_downloads,
   )
+  let didInit = false
   const [viewCount, setViewCount] = useState<number | undefined>()
   const { stores } = useCommonStores()
-  let didInit = false
 
   const incrementDownloadCount = async () => {
     const updatedDownloadCount = await stores.howtoStore.incrementDownloadCount(

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -108,7 +108,6 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
   }
 
   useEffect(() => {
-    console.log(didInit)
     if (!didInit) {
       didInit = true
       incrementViewCount()

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -53,14 +53,13 @@ interface IProps {
   onUsefulClick: () => void
 }
 
-let didInit = false
-
 const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
   const [fileDownloadCount, setFileDownloadCount] = useState(
     howto.total_downloads,
   )
   const [viewCount, setViewCount] = useState<number | undefined>()
   const { stores } = useCommonStores()
+  let didInit = false
 
   const incrementDownloadCount = async () => {
     const updatedDownloadCount = await stores.howtoStore.incrementDownloadCount(
@@ -109,6 +108,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
   }
 
   useEffect(() => {
+    console.log(didInit)
     if (!didInit) {
       didInit = true
       incrementViewCount()

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -33,8 +33,6 @@ interface IProps {
   onUsefulClick: () => void
 }
 
-let didInit = false
-
 const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
   const dateLastUpdateText = (research: IResearch.ItemDB): string => {
     const lastModifiedDate = format(new Date(research._modified), 'DD-MM-YYYY')
@@ -45,6 +43,8 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
       return ''
     }
   }
+  let didInit = false
+
   const store = useResearchStore()
 
   const [viewCount, setViewCount] = useState<number | undefined>()

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -44,9 +44,7 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
     }
   }
   let didInit = false
-
   const store = useResearchStore()
-
   const [viewCount, setViewCount] = useState<number | undefined>()
 
   const incrementViewCount = async () => {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

I noticed that this [line](https://github.com/ONEARMY/community-platform/blob/e2727c9ea7ec9c3e149ce9885fc66f9caf138c45/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx#L56) was added, the issue is that now it will set `didInit` to true after a single howto or research is viewed and then the `useEffect` won't run again for other pages until page refresh.  This fixes the issue.

