### PR TITLE
chore: address cypress lint warnings

### DIFF
--- a/packages/cypress/.eslintrc.json
+++ b/packages/cypress/.eslintrc.json
@@ -4,7 +4,7 @@
     "cypress/no-assigning-return-values": "error",
     "cypress/no-unnecessary-waiting": "warn",
     "cypress/assertion-before-screenshot": "warn",
-    "cypress/no-force": "warn",
+    "cypress/no-force": "error",
     "cypress/no-async-tests": "warn",
     "cypress/no-pause": "warn",
     "mocha/no-skipped-tests": "error"

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -115,18 +115,13 @@ describe('[How To]', () => {
       cy.step('Access the create-how-to')
       cy.get('[data-cy=create]').click()
       cy.step('Warn if title is identical with the existing ones')
-      cy.get('[data-cy=intro-title]')
-        .type('Make glass-like beams')
-        .blur({ force: true })
+      cy.get('[data-cy=intro-title]').type('Make glass-like beams').blur()
       cy.contains(
         'Titles must be unique, please try being more specific',
       ).should('exist')
 
       cy.step('Fill up the intro')
-      cy.get('[data-cy=intro-title')
-        .clear()
-        .type('Create a how-to test')
-        .blur({ force: true })
+      cy.get('[data-cy=intro-title').clear().type('Create a how-to test').blur()
       cy.selectTag('howto_testing')
       selectTimeDuration(expected.time as Duration)
       selectDifficultLevel(expected.difficulty_level as Difficulty)
@@ -189,10 +184,7 @@ describe('[How To]', () => {
       cy.wait(2000)
       cy.step('Access the create-how-to')
       cy.get('[data-cy=create]').click()
-      cy.get('[data-cy=intro-title')
-        .clear()
-        .type('Create a how-to test')
-        .blur({ force: true })
+      cy.get('[data-cy=intro-title').clear().type('Create a how-to test').blur()
       cy.get('[data-cy=page-link][href*="/how-to"]')
         .click()
         .then(() => {
@@ -202,7 +194,7 @@ describe('[How To]', () => {
       cy.url().should('match', /\/how-to\/create$/)
 
       cy.step('Clear title input')
-      cy.get('[data-cy=intro-title').clear().blur({ force: true })
+      cy.get('[data-cy=intro-title').clear().blur()
       cy.get('[data-cy=page-link][href*="/how-to"]')
         .click()
         .then(() => {
@@ -304,7 +296,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=edit]').click()
 
       cy.step('Warn if title is identical with the existing ones')
-      cy.get('[data-cy=intro-title]').focus().blur({ force: true })
+      cy.get('[data-cy=intro-title]').focus().blur()
       cy.wait(1000)
       cy.contains(
         'Titles must be unique, please try being more specific',
@@ -313,7 +305,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=intro-title]')
         .clear()
         .type('Make glass-like beams')
-        .blur({ force: true })
+        .blur()
       cy.contains(
         'Titles must be unique, please try being more specific',
       ).should('exist')
@@ -327,9 +319,7 @@ describe('[How To]', () => {
 
       cy.step('Update a new cover for the intro')
 
-      cy.get('[data-cy="intro-cover"]')
-        .find('[data-cy="delete-image"]')
-        .click({ force: true })
+      cy.get('[data-cy="intro-cover"]').find('[data-cy="delete-image"]').click()
 
       cy.get('[data-cy="intro-cover"]')
         .find(':file')

--- a/packages/cypress/src/support/commands.ts
+++ b/packages/cypress/src/support/commands.ts
@@ -206,7 +206,7 @@ const attachCustomCommands = (Cypress: Cypress.Cypress) => {
 
   Cypress.Commands.add('toggleUserMenuOff', () => {
     Cypress.log({ displayName: 'CLOSE_USER_MENU' })
-    cy.get('[data-cy=header]').click({ force: true })
+    cy.get('[data-cy=header]').click()
   })
 
   Cypress.Commands.add('clickMenuItem', (menuItem: UserMenuItem) => {
@@ -221,7 +221,7 @@ const attachCustomCommands = (Cypress: Cypress.Cypress) => {
   })
 
   Cypress.Commands.add('screenClick', () => {
-    cy.get('[data-cy=header]').click({ force: true })
+    cy.get('[data-cy=header]').click()
   })
 
   Cypress.Commands.add(
@@ -229,8 +229,8 @@ const attachCustomCommands = (Cypress: Cypress.Cypress) => {
     (tagName: string, selector = '[data-cy=tag-select]') => {
       cy.log('select tag', tagName)
       cy.get(`${selector} input`)
-        .click({ force: true })
-        .type(tagName, { force: true })
+        .click()
+        .type(tagName)
         .get(`${selector} .data-cy__menu-list`)
         .contains(tagName)
         .click()


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Aims to remove `cypress/no-force` class of warnings.

```
~/community-platform/packages/cypress/src/support/commands.ts
  209:5  warning  Do not use force on click and type calls  cypress/no-force
  224:5  warning  Do not use force on click and type calls  cypress/no-force
  231:7  warning  Do not use force on click and type calls  cypress/no-force
```