### PR TITLE
chore: refactor to remove use of prototype built ins

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -80,7 +80,7 @@ function sanitizedProps(obj: BtnProps, keysToRemove: AvailableButtonProps) {
 
 export const Button = (props: BtnProps) => {
   const [size] = Object.keys(props).filter((prop) =>
-    buttonSizeProps.hasOwnProperty(prop),
+    Object.prototype.hasOwnProperty.call(buttonSizeProps, prop),
   )
 
   return (

--- a/packages/components/src/CreateComment/CreateComment.tsx
+++ b/packages/components/src/CreateComment/CreateComment.tsx
@@ -98,7 +98,7 @@ export const CreateComment = (props: Props) => {
       </Flex>
       <Button
         data-cy="comment-submit"
-        disabled={!Boolean(comment.trim()) || !isLoggedIn}
+        disabled={!comment.trim() || !isLoggedIn}
         variant="primary"
         onClick={() => onSubmit(comment)}
         mt={3}

--- a/packages/emulators-docker/src/common.ts
+++ b/packages/emulators-docker/src/common.ts
@@ -75,7 +75,7 @@ function extractArgs() {
     const [selector, value] = arg
       .split('=')
       .map((v) => v.trim().replace('--', ''))
-    if (args.hasOwnProperty(selector)) {
+    if (Object.prototype.hasOwnProperty.call(args, selector)) {
       args[selector] = value
     } else {
       console.warn('Arg not recognised', selector)

--- a/shared/messages.ts
+++ b/shared/messages.ts
@@ -24,7 +24,7 @@ export const FRIENDLY_MESSAGES = {
  */
 export const getFriendlyMessage = (systemMessage = '') => {
   const messageKey = systemMessage.toLowerCase()
-  if (FRIENDLY_MESSAGES.hasOwnProperty(messageKey)) {
+  if (Object.prototype.hasOwnProperty.call(FRIENDLY_MESSAGES, messageKey)) {
     return FRIENDLY_MESSAGES[messageKey]
   } else {
     console.log(

--- a/src/common/Form/ImageInput/ImageInput.tsx
+++ b/src/common/Form/ImageInput/ImageInput.tsx
@@ -192,7 +192,7 @@ export class ImageInput extends React.Component<IProps, IState> {
   private _getUploadedFiles(value: IProps['value'] = []) {
     const valArray = Array.isArray(value) ? value : [value]
     return valArray.filter((v) =>
-      v.hasOwnProperty('downloadUrl'),
+      Object.prototype.hasOwnProperty.call(v, 'downloadUrl'),
     ) as IUploadedFileMeta[]
   }
 }

--- a/src/pages/Howto/Content/EditHowto/EditHowto.tsx
+++ b/src/pages/Howto/Content/EditHowto/EditHowto.tsx
@@ -40,7 +40,7 @@ class EditHowto extends React.Component<IProps, IState> {
   /* eslint-disable @typescript-eslint/naming-convention */
   public async UNSAFE_componentWillMount() {
     const loggedInUser = this.injected.howtoStore.activeUser
-    if (!!this.injected.howtoStore.activeHowto) {
+    if (this.injected.howtoStore.activeHowto) {
       this.setState({
         formValues: toJS(this.injected.howtoStore.activeHowto) as IHowtoDB,
         isLoading: false,

--- a/src/pages/User/content/UserContactAndLinks.tsx
+++ b/src/pages/User/content/UserContactAndLinks.tsx
@@ -18,7 +18,7 @@ const UserContactInfo = styled.div`
 `
 
 export const UserContactAndLinks = ({ links }) =>
-  !!links.length ? (
+  links.length ? (
     <UserContactInfo>
       <span>Contact & Links</span>
       {links.map((link, i) => (

--- a/src/stores/Aggregations/aggregations.store.tsx
+++ b/src/stores/Aggregations/aggregations.store.tsx
@@ -57,7 +57,9 @@ export class AggregationsStore {
     aggregationId: IAggregationId,
     timeoutDuration = DEFAULT_TIMEOUT,
   ) {
-    if (!this.subscriptions$.hasOwnProperty(aggregationId)) {
+    if (
+      !Object.prototype.hasOwnProperty.call(this.subscriptions$, aggregationId)
+    ) {
       const subscription = this.db
         .collection('aggregations')
         .doc(aggregationId)
@@ -94,7 +96,7 @@ export class AggregationsStore {
     timeoutDuration: number,
   ) {
     // remove any existing timeout
-    if (this.timeouts$.hasOwnProperty(aggregationId)) {
+    if (Object.prototype.hasOwnProperty.call(this.timeouts$, aggregationId)) {
       clearTimeout(this.timeouts$[aggregationId])
     }
     // add timeout to unsubscribe
@@ -104,7 +106,9 @@ export class AggregationsStore {
   }
 
   private clearSubscription(aggregationId: IAggregationId) {
-    if (this.subscriptions$.hasOwnProperty(aggregationId)) {
+    if (
+      Object.prototype.hasOwnProperty.call(this.subscriptions$, aggregationId)
+    ) {
       this.subscriptions$[aggregationId].unsubscribe()
       delete this.subscriptions$[aggregationId]
     }

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -470,7 +470,9 @@ export class HowtoStore extends ModuleStore {
       // if cover already uploaded stored as object not array
       // file and step image re-uploads handled in uploadFile script
       let processedCover
-      if (!values.cover_image.hasOwnProperty('downloadUrl')) {
+      if (
+        !Object.prototype.hasOwnProperty.call(values.cover_image, 'downloadUrl')
+      ) {
         processedCover = await this.uploadFileToCollection(
           values.cover_image,
           COLLECTION_NAME,

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -125,7 +125,7 @@ export class MapsStore extends ModuleStore {
   public async setActivePin(pin?: IMapPin | IMapPinWithDetail) {
     // HACK - CC - 2021-07-14 ignore hardcoded pin details, should be retrieved
     // from profile on open instead (needs cleaning from DB)
-    if (pin && pin.hasOwnProperty('detail')) {
+    if (pin && Object.prototype.hasOwnProperty.call(pin, 'detail')) {
       delete pin['detail']
     }
     this.activePin = pin

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -157,13 +157,13 @@ export class ModuleStore {
   ) {
     logger.debug('uploading file', file)
     // if already uploaded (e.g. editing but not replaced), skip
-    if (file.hasOwnProperty('downloadUrl')) {
+    if (Object.prototype.hasOwnProperty.call(file, 'downloadUrl')) {
       logger.debug('file already uploaded, skipping')
       return file as IUploadedFileMeta
     }
     // switch between converted file meta or standard file input
     let data: File | Blob = file as File
-    if (file.hasOwnProperty('photoData')) {
+    if (Object.prototype.hasOwnProperty.call(file, 'photoData')) {
       file = file as IConvertedFileMeta
       data = file.photoData
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -29,7 +29,7 @@ export const replaceDashesWithSpaces = (str: string) => {
 export const arrayToJson = (arr: any[], keyField: string) => {
   const json = {}
   arr.forEach((el) => {
-    if (el.hasOwnProperty(keyField)) {
+    if (Object.prototype.hasOwnProperty.call(el, keyField)) {
       const key = el[keyField]
       json[key] = el
     }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

It’s better to always call built in methods from Object.prototype.
For example, foo.hasOwnProperty("bar") should be replaced
with Object.prototype.hasOwnProperty.call(foo, "bar").

Further information:
https://eslint.org/docs/latest/rules/no-irregular-whitespace