### PR TITLE
fix(useful-button): use local update instead of optimistic update

### DIFF
--- a/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
+++ b/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
@@ -33,18 +33,29 @@ export interface IProps {
 export const UsefulStatsButton = (props: IProps) => {
   const theme: any = useTheme()
 
-  const [votedUsefulCount, setVotedUsefulCount] = useState<number>()
-  const [hasUserVotedUseful, setHasUserVotedUseful] = useState<boolean>()
+  const [votedUsefulCount, setVotedUsefulCount] = useState<number>(
+    props.votedUsefulCount,
+  )
+  const [hasUserVotedUseful, setHasUserVotedUseful] = useState<boolean>(
+    props.hasUserVotedUseful,
+  )
 
   useEffect(
     () => setHasUserVotedUseful(props.hasUserVotedUseful),
     [props.hasUserVotedUseful],
   )
+
   useEffect(
     () => setVotedUsefulCount(props.votedUsefulCount),
     [props.votedUsefulCount],
   )
-  const handleUsefulClick = () => {
+
+  const handleUsefulClick = async () => {
+    // Optimistically update state locally to refresh UI
+    setVotedUsefulCount(
+      hasUserVotedUseful ? votedUsefulCount - 1 : votedUsefulCount + 1,
+    )
+    setHasUserVotedUseful(!hasUserVotedUseful)
     props.onUsefulClick()
   }
 

--- a/src/pages/Howto/Content/Howto/Howto.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.tsx
@@ -96,23 +96,21 @@ export class Howto extends React.Component<
       await this.store.moderateHowto(_howto)
     }
   }
-  private onUsefulClick = async (
+  private onUsefulClick = (
     howtoId: string,
     howtoCreatedBy: string,
     howToSlug: string,
+    votedUsefulCount: number,
+    hasUserVotedUseful: boolean,
   ) => {
-    // Trigger update without waiting
-    const { userStore } = this.injected
+    const { userStore, aggregationsStore } = this.injected
     userStore.updateUsefulHowTos(howtoId, howtoCreatedBy, howToSlug)
-    // Make an optimistic update of current aggregation to update UI
-    const { aggregationsStore } = this.injected
-    const votedUsefulCount =
-      aggregationsStore.aggregations.users_votedUsefulHowtos![howtoId] || 0
-    const hasUserVotedUseful = this.store.userVotedActiveHowToUseful
+    // Optimistically update aggregation to keep useful buttons in sync
     aggregationsStore.overrideAggregationValue('users_votedUsefulHowtos', {
       [howtoId]: votedUsefulCount + (hasUserVotedUseful ? -1 : 1),
     })
   }
+
   //TODO: Typing Props
   constructor(props: any) {
     super(props)
@@ -158,6 +156,15 @@ export class Howto extends React.Component<
       const votedUsefulCount = aggregations.users_votedUsefulHowtos
         ? aggregations.users_votedUsefulHowtos[activeHowto._id] || 0
         : undefined
+      const hasUserVotedUseful = this.store.userVotedActiveHowToUseful
+      const onUsefulClick = () =>
+        this.onUsefulClick(
+          activeHowto._id,
+          activeHowto._createdBy,
+          activeHowto.slug,
+          votedUsefulCount,
+          hasUserVotedUseful,
+        )
 
       const activeHowToComments: UserComment[] = this.store
         .getActiveHowToComments()
@@ -180,14 +187,6 @@ export class Howto extends React.Component<
             .map((t) => allTagsByKey[t])
             .filter(Boolean),
       }
-
-      const onUsefulClick = () =>
-        this.onUsefulClick(
-          activeHowto._id,
-          activeHowto._createdBy,
-          activeHowto.slug,
-        )
-      const hasUserVotedUseful = this.store.userVotedActiveHowToUseful
 
       return (
         <>

--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -58,13 +58,11 @@ const ResearchArticle = observer((props: IProps) => {
     researchId: string,
     researchAuthor: string,
     researchSlug: string,
+    votedUsefulCount: number,
+    hasUserVotedUseful: boolean,
   ) => {
-    // Trigger update without waiting
     userStore.updateUsefulResearch(researchId, researchAuthor, researchSlug)
-    // Make an optimistic update of current aggregation to update UI
-    const votedUsefulCount =
-      aggregationsStore.aggregations.users_votedUsefulResearch![researchId] || 0
-    const hasUserVotedUseful = researchStore.userVotedActiveResearchUseful
+    // Optimistically update aggregation to keep useful buttons in sync
     aggregationsStore.overrideAggregationValue('users_votedUsefulResearch', {
       [researchId]: votedUsefulCount + (hasUserVotedUseful ? -1 : 1),
     })
@@ -123,6 +121,8 @@ const ResearchArticle = observer((props: IProps) => {
     const votedUsefulCount = aggregations.users_votedUsefulResearch
       ? aggregations.users_votedUsefulResearch[item._id] || 0
       : undefined
+    const hasUserVotedUseful = researchStore.userVotedActiveResearchUseful
+
     const isEditable =
       !!researchStore.activeUser &&
       isAllowToEditContent(item, researchStore.activeUser)
@@ -144,10 +144,16 @@ const ResearchArticle = observer((props: IProps) => {
           loggedInUser={loggedInUser}
           isEditable={isEditable}
           needsModeration={researchStore.needsModeration(item)}
-          hasUserVotedUseful={researchStore.userVotedActiveResearchUseful}
+          hasUserVotedUseful={hasUserVotedUseful}
           moderateResearch={moderateResearch}
           onUsefulClick={() =>
-            onUsefulClick(item._id, item._createdBy, item.slug)
+            onUsefulClick(
+              item._id,
+              item._createdBy,
+              item.slug,
+              votedUsefulCount,
+              hasUserVotedUseful,
+            )
           }
         />
         <Box my={16}>
@@ -183,14 +189,20 @@ const ResearchArticle = observer((props: IProps) => {
             <UsefulStatsButton
               isLoggedIn={!!loggedInUser}
               votedUsefulCount={votedUsefulCount}
-              hasUserVotedUseful={researchStore.userVotedActiveResearchUseful}
+              hasUserVotedUseful={hasUserVotedUseful}
               onUsefulClick={() => {
                 ReactGA.event({
                   category: 'ArticleCallToAction',
                   action: 'ReseachUseful',
                   label: item.slug,
                 })
-                onUsefulClick(item._id, item._createdBy, item.slug)
+                onUsefulClick(
+                  item._id,
+                  item._createdBy,
+                  item.slug,
+                  votedUsefulCount,
+                  hasUserVotedUseful,
+                )
               }}
             />
           </ArticleCallToAction>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
we've identified two issues with the "mark as useful" button. one issue is when you smash the useful button the count gets out of sync. another issue is that users report sometimes articles they've marked as useful mysteriously disappear. 

in testing the update behavior, I could verify that the optimistic update causes the first issue. i changed this optimistic update to a local update in the useful button component. this maintains the instant update on click, but prevents aggregation updates that cause counts to get out of sync. 

i am not sure whether this will impact the second issue. i think a good next step would be to add error catching in the update step so we can track unsuccessful updates and notify users if their useful was not recorded in the DB. 

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
