### PR TITLE
fix: add border between image and content

### DIFF
--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -91,12 +91,6 @@ const PlasticType = styled.div`
   }
 `
 
-const ProfileContentWrapper = styled(Flex)`
-  background-color: ${theme.colors.white};
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
-`
-
 const SliderImage = styled.div`
   background-size: cover;
   background-repeat: no-repeat;
@@ -250,7 +244,14 @@ export const SpaceProfile = ({ user }: IProps) => {
       <ProfileWrapperCarousel>
         <Slider {...sliderSettings}>{coverImage}</Slider>
       </ProfileWrapperCarousel>
-      <ProfileContentWrapper px={[2, 4]} py={4}>
+      <Flex
+        sx={{
+          px: [2, 4],
+          py: 4,
+          background: 'white',
+          borderTop: '2px solid',
+        }}
+      >
         <Box sx={{ width: ['100%', '100%', '80%'] }}>
           <Box sx={{ display: ['block', 'block', 'none'] }}>
             <MobileBadge>
@@ -314,7 +315,7 @@ export const SpaceProfile = ({ user }: IProps) => {
             <UserStats user={user} />
           </MobileBadge>
         </Box>
-      </ProfileContentWrapper>
+      </Flex>
     </ProfileWrapper>
   )
 }


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Adds a 2px black border between space images and information.

**Before:** 
![Screen Shot 2023-03-25 at 23 16 48](https://user-images.githubusercontent.com/472589/227744990-43a609ad-783a-4a64-9142-c07144053ef8.png)

**After:**  
![Screen Shot 2023-03-25 at 23 19 25](https://user-images.githubusercontent.com/472589/227745059-d5b0ec11-ba8e-4cd1-88bb-36546fee346a.png)

The aim here is to address lack of definition when leading image has a white background, for example: https://community.preciousplastic.com/u/ecopazifico-
