### PR TITLE
chore: switch to using icon within button component

### DIFF
--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -22,7 +22,6 @@ import {
   capitalizeFirstLetter,
 } from 'src/utils/helpers'
 import theme from 'src/themes/styled.theme'
-import ArrowIcon from 'src/assets/icons/icon-arrow-select.svg'
 import { DownloadExternal } from 'src/pages/Howto/DownloadExternal/DownloadExternal'
 import { Link } from 'react-router-dom'
 import { useCommonStores } from 'src/index'
@@ -144,19 +143,9 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
               variant="subtle"
               sx={{ fontSize: '14px' }}
               data-cy="go-back"
+              icon="arrow-back"
             >
-              <Flex>
-                <Image
-                  loading="lazy"
-                  sx={{
-                    width: '10px',
-                    marginRight: '4px',
-                    transform: 'rotate(90deg)',
-                  }}
-                  src={ArrowIcon}
-                />
-                <Text>Back</Text>
-              </Flex>
+              Back
             </Button>
           </Link>
           {props.votedUsefulCount !== undefined && (

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -9,7 +9,6 @@ import {
 } from 'oa-components'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import ArrowIcon from 'src/assets/icons/icon-arrow-select.svg'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { isUserVerified } from 'src/common/isUserVerified'
 import type { IResearch } from 'src/models/research.models'
@@ -20,7 +19,7 @@ import {
   addIDToSessionStorageArray,
   retrieveSessionStorageArray,
 } from 'src/utils/sessionStorage'
-import { Box, Flex, Heading, Image, Text } from 'theme-ui'
+import { Box, Flex, Heading, Text } from 'theme-ui'
 
 interface IProps {
   research: IResearch.ItemDB
@@ -89,19 +88,9 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
               variant="subtle"
               sx={{ fontSize: '14px' }}
               data-cy="go-back"
+              icon="arrow-back"
             >
-              <Flex>
-                <Image
-                  loading="lazy"
-                  sx={{
-                    width: '10px',
-                    marginRight: '4px',
-                    transform: 'rotate(90deg)',
-                  }}
-                  src={ArrowIcon}
-                />
-                <Text>Back</Text>
-              </Flex>
+              Back
             </Button>
           </Link>
           {props.votedUsefulCount !== undefined && (


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Use standard Button with icon variant for `Back` button on Research and How-to Description. Introduces standard `arrow-back` icon and spacing. 

## Screenshots/Videos

**Before:**   

![Screenshot 2023-03-26 at 20 22 44](https://user-images.githubusercontent.com/472589/227796126-c982029e-1d27-490b-bb45-d19e555cb943.jpg)

**After:**. 

![Screenshot 2023-03-26 at 20 20 49](https://user-images.githubusercontent.com/472589/227796122-116597f3-98e7-42d6-893b-623a051e3c54.jpg)

