### PR TITLE
feat(Howto.form): added current character count indicator

### DIFF
--- a/packages/components/src/FieldInput/FieldInput.tsx
+++ b/packages/components/src/FieldInput/FieldInput.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { FieldRenderProps } from 'react-final-form'
 import { Text, Input } from 'theme-ui'
 
@@ -7,6 +8,7 @@ export interface Props extends FieldProps {
   // additional fields intending to pass down
   disabled?: boolean
   children?: React.ReactNode
+  showCharacterCount?: boolean
   'data-cy'?: string
   customOnBlur?: (event: any) => void
 }
@@ -26,14 +28,38 @@ const processInputModifiers = (value: any, modifiers: InputModifiers = {}) => {
   return value
 }
 
+const TextLimitIndicator = ({
+  curSize,
+  maxSize,
+}: {
+  curSize: number
+  maxSize: number
+}) => {
+  const percMax = curSize / maxSize
+  const colorVec = [
+    { value: 1.0, color: 'red' },
+    { value: 0.75, color: 'red2' },
+    { value: 0.6, color: 'yellow.base' },
+  ]
+  const color = colorVec.find((cur) => cur.value <= percMax)?.color ?? 'black'
+  return (
+    <Text color={color} ml="auto" mr={2} mt={2} sx={{ fontSize: 1 }}>
+      {curSize} / {maxSize}
+    </Text>
+  )
+}
+
 export const FieldInput = ({
   input,
   meta,
   disabled,
   modifiers,
   customOnBlur,
+  showCharacterCount,
+  maxLength,
   ...rest
 }: Props) => {
+  const [curLength, setLength] = useState<number>(input?.value?.length ?? 0)
   return (
     <>
       <Input
@@ -41,6 +67,7 @@ export const FieldInput = ({
         variant={meta?.error && meta?.touched ? 'textareaError' : 'textarea'}
         {...input}
         {...rest}
+        maxLength={maxLength}
         onBlur={(e) => {
           if (modifiers) {
             e.target.value = processInputModifiers(e.target.value, modifiers)
@@ -51,11 +78,18 @@ export const FieldInput = ({
           }
           input.onBlur()
         }}
+        onChange={(ev) => {
+          showCharacterCount && setLength(ev.target.value.length)
+          input.onChange(ev)
+        }}
       />
       {meta.error && meta.touched && (
         <Text sx={{ fontSize: 0, margin: 1, color: 'error' }}>
           {meta.error}
         </Text>
+      )}
+      {showCharacterCount && maxLength && (
+        <TextLimitIndicator maxSize={maxLength} curSize={curLength} />
       )}
     </>
   )

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -263,6 +263,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   component={FieldInput}
                                   maxLength={HOWTO_TITLE_MAX_LENGTH}
                                   placeholder={`Make a chair from... (max ${HOWTO_TITLE_MAX_LENGTH} characters)`}
+                                  showCharacterCount
                                 />
                               </Flex>
                               <Flex sx={{ flexDirection: 'column' }} mb={3}>


### PR DESCRIPTION
In order to easier see what the limit of characters in the howto creation for the title is, show current and maximum number of characters next to the text area widget.

PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Introduced the better character length indicator on the title input ui for event

## Git Issues

Closes #2015 

## Screenshots/Videos


https://user-images.githubusercontent.com/4504330/228482191-3b00edd0-66c8-4c90-9dd0-09c8d91cee0a.mp4



---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
