### PR TITLE
feat: adds option to delete ResearchUpdate

### DIFF
--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -64,6 +64,20 @@ export const Secondary: StoryFn<typeof Button> = () => (
   </>
 )
 
+export const Destructive: StoryFn<typeof Button> = () => (
+  <>
+    <Button variant={'destructive'}>Destructive</Button>
+    <Button icon="delete" variant={'destructive'}>
+      Destructive
+    </Button>
+    {sizeOptions.map((v, k) => (
+      <Button key={k} variant={'destructive'} {...v}>
+        {v.label}
+      </Button>
+    ))}
+  </>
+)
+
 export const Subtle: StoryFn<typeof Button> = () => (
   <>
     <Button variant={'subtle'}>Subtle</Button>

--- a/packages/themes/src/common/button.ts
+++ b/packages/themes/src/common/button.ts
@@ -45,6 +45,13 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
       bg: colors.softblue,
     },
   },
+  destructive: {
+    ...BASE_BUTTON,
+    border: '2px solid ' + colors.black,
+    backgroundColor: colors.red2,
+    color: colors.black,
+    cursor: 'pointer',
+  },
   outline: {
     ...BASE_BUTTON,
     border: '2px solid ' + colors.black,

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -334,12 +334,14 @@ const ResearchForm = observer((props: IProps) => {
                 {props.formValues.updates ? (
                   <ResearchEditorOverview
                     sx={{ mt: 4 }}
-                    updates={props.formValues?.updates.map((u) => ({
-                      isActive: false,
-                      status: u.status,
-                      title: u.title,
-                      slug: u._id,
-                    }))}
+                    updates={props.formValues?.updates
+                      .filter((u) => !u._deleted)
+                      .map((u) => ({
+                        isActive: false,
+                        status: u.status,
+                        title: u.title,
+                        slug: u._id,
+                      }))}
                     researchSlug={props.formValues.slug}
                     showCreateUpdateButton={true}
                   />

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
@@ -409,12 +409,14 @@ const getResearchUpdates = (
   researchTitle: string,
 ): ResearchEditorOverviewUpdate[] =>
   [
-    ...updates.map((u) => ({
-      isActive: u._id === activeResearchId,
-      title: u.title,
-      status: u.status,
-      slug: u._id,
-    })),
+    ...updates
+      .filter((u) => !u._deleted)
+      .map((u) => ({
+        isActive: u._id === activeResearchId,
+        title: u.title,
+        status: u.status,
+        slug: u._id,
+      })),
     isCreating
       ? {
           isActive: false,

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
@@ -12,6 +12,7 @@ import {
   FieldTextarea,
   ElWithBeforeIcon,
   ResearchEditorOverview,
+  ConfirmModal,
 } from 'oa-components'
 import type { ResearchEditorOverviewUpdate } from 'oa-components'
 import { ImageInputField } from 'src/common/Form/ImageInput.field'
@@ -35,6 +36,7 @@ const CONFIRM_DIALOG_MSG =
 interface IProps extends RouteComponentProps<any> {
   formValues: any
   parentType: 'create' | 'edit'
+  redirectUrl?: string
 }
 
 const FormContainer = styled.form`
@@ -48,6 +50,7 @@ const beforeUnload = (e) => {
 
 export const ResearchUpdateForm = observer((props: IProps) => {
   const store = useResearchStore()
+  const [showDeleteModal, setShowDeleteModal] = React.useState(false)
   const [showSubmitModal, setShowSubmitModal] = React.useState<boolean>(false)
   const [isDraft, setIsDraft] = React.useState<boolean>(
     props.formValues.status === 'draft',
@@ -85,6 +88,14 @@ export const ResearchUpdateForm = observer((props: IProps) => {
       ),
       status: isDraft ? 'draft' : 'published',
     })
+  }
+
+  const handleDelete = async (_updateId: string) => {
+    setShowDeleteModal(false)
+    await store.deleteUpdate(_updateId)
+    if (props.redirectUrl) {
+      window.location.assign(props.redirectUrl)
+    }
   }
 
   // Display a confirmation dialog when leaving the page outside the React Router
@@ -321,6 +332,21 @@ export const ResearchUpdateForm = observer((props: IProps) => {
                       <span>Revert to draft</span>
                     )}
                   </Button>
+                  {props.parentType === 'edit' ? (
+                    <Button
+                      data-cy={'delete'}
+                      onClick={(evt) => {
+                        setShowDeleteModal(true)
+                        evt.preventDefault()
+                      }}
+                      variant="destructive"
+                      type="submit"
+                      disabled={submitting}
+                      sx={{ width: '100%', display: 'block', mt: 3 }}
+                    >
+                      Delete this update
+                    </Button>
+                  ) : null}
                   <Button
                     large
                     data-cy={'submit'}
@@ -359,6 +385,15 @@ export const ResearchUpdateForm = observer((props: IProps) => {
                   ) : null}
                 </Box>
               </Flex>
+              <ConfirmModal
+                isOpen={showDeleteModal}
+                message="Are you sure you want to delete this update?"
+                confirmButtonText="Delete"
+                handleCancel={() => setShowDeleteModal(false)}
+                handleConfirm={() =>
+                  handleDelete && handleDelete(props.formValues._id)
+                }
+              />
             </Flex>
           )
         }}

--- a/src/pages/Research/Content/EditUpdate/index.tsx
+++ b/src/pages/Research/Content/EditUpdate/index.tsx
@@ -89,6 +89,7 @@ const EditUpdate = observer((props: IProps) => {
       return (
         <ResearchUpdateForm
           formValues={formValues}
+          redirectUrl={'/research/' + store.activeResearchItem!.slug + '/edit'}
           parentType="edit"
           {...props}
         />

--- a/src/pages/Research/Content/ResearchArticle.test.tsx
+++ b/src/pages/Research/Content/ResearchArticle.test.tsx
@@ -162,20 +162,7 @@ describe('Research Article', () => {
       })
 
       // Act
-      const wrapper = render(
-        <Provider userStore={{}}>
-          <ThemeProvider theme={Theme}>
-            <MemoryRouter initialEntries={['/research/article']}>
-              <Route
-                path="/research/:slug"
-                exact
-                key={1}
-                component={ResearchArticle}
-              />
-            </MemoryRouter>
-          </ThemeProvider>
-        </Provider>,
-      )
+      const wrapper = getWrapper()
 
       // Assert
       expect(() => {
@@ -206,20 +193,7 @@ describe('Research Article', () => {
       })
 
       // Act
-      const wrapper = render(
-        <Provider userStore={{}}>
-          <ThemeProvider theme={Theme}>
-            <MemoryRouter initialEntries={['/research/article']}>
-              <Route
-                path="/research/:slug"
-                exact
-                key={1}
-                component={ResearchArticle}
-              />
-            </MemoryRouter>
-          </ThemeProvider>
-        </Provider>,
-      )
+      const wrapper = getWrapper()
 
       // Assert
       expect(() => {
@@ -247,20 +221,7 @@ describe('Research Article', () => {
     })
 
     // Act
-    const wrapper = render(
-      <Provider userStore={{}}>
-        <ThemeProvider theme={Theme}>
-          <MemoryRouter initialEntries={['/research/article']}>
-            <Route
-              path="/research/:slug"
-              exact
-              key={1}
-              component={ResearchArticle}
-            />
-          </MemoryRouter>
-        </ThemeProvider>
-      </Provider>,
-    )
+    const wrapper = getWrapper()
 
     // Assert
     expect(() => {

--- a/src/pages/Research/Content/ResearchArticle.test.tsx
+++ b/src/pages/Research/Content/ResearchArticle.test.tsx
@@ -143,6 +143,89 @@ describe('Research Article', () => {
       expect(wrapper.getAllByText('example-username')).toHaveLength(1)
       expect(wrapper.getAllByText('another-example-username')).toHaveLength(1)
     })
+    it('shows only published updates', async () => {
+      // Arrange
+      ;(useResearchStore as jest.Mock).mockReturnValue({
+        ...mockResearchStore,
+        activeResearchItem: FactoryResearchItem({
+          collaborators: ['example-username', 'another-example-username'],
+          updates: [
+            FactoryResearchItemUpdate({
+              title: 'Research Update #1',
+            }),
+            FactoryResearchItemUpdate({
+              title: 'Research Update #2',
+              status: 'draft',
+            }),
+          ],
+        }),
+      })
+
+      // Act
+      const wrapper = render(
+        <Provider userStore={{}}>
+          <ThemeProvider theme={Theme}>
+            <MemoryRouter initialEntries={['/research/article']}>
+              <Route
+                path="/research/:slug"
+                exact
+                key={1}
+                component={ResearchArticle}
+              />
+            </MemoryRouter>
+          </ThemeProvider>
+        </Provider>,
+      )
+
+      // Assert
+      expect(() => {
+        wrapper.getByText('Research Update #2')
+      }).toThrow()
+    })
+
+    it('does not show deleted updates', async () => {
+      // Arrange
+      ;(useResearchStore as jest.Mock).mockReturnValue({
+        ...mockResearchStore,
+        activeResearchItem: FactoryResearchItem({
+          collaborators: ['example-username', 'another-example-username'],
+          updates: [
+            FactoryResearchItemUpdate({
+              title: 'Research Update #1',
+            }),
+            FactoryResearchItemUpdate({
+              title: 'Research Update #2',
+              status: 'draft',
+            }),
+            FactoryResearchItemUpdate({
+              title: 'Research Update #3',
+              _deleted: true,
+            }),
+          ],
+        }),
+      })
+
+      // Act
+      const wrapper = render(
+        <Provider userStore={{}}>
+          <ThemeProvider theme={Theme}>
+            <MemoryRouter initialEntries={['/research/article']}>
+              <Route
+                path="/research/:slug"
+                exact
+                key={1}
+                component={ResearchArticle}
+              />
+            </MemoryRouter>
+          </ThemeProvider>
+        </Provider>,
+      )
+
+      // Assert
+      expect(() => {
+        wrapper.getByText('Research Update #3')
+      }).toThrow()
+    })
   })
 
   it('shows only published updates', async () => {

--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -10,7 +10,7 @@ import type { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
 import { trackEvent } from 'src/common/Analytics'
 import { isUserVerified } from 'src/common/isUserVerified'
-import type { IComment, UserComment } from 'src/models'
+import type { IComment, IResearch, UserComment } from 'src/models'
 import { NotFoundPage } from 'src/pages/NotFound/NotFound'
 import { useResearchStore } from 'src/stores/Research/research.store'
 import type { IUploadedFileMeta } from 'src/stores/storage'
@@ -174,7 +174,7 @@ const ResearchArticle = observer((props: IProps) => {
         <Box my={16}>
           {item &&
             item?.updates
-              ?.filter((update) => update.status !== 'draft')
+              ?.filter(isUpdateVisible)
               .map((update, index) => (
                 <ResearchUpdate
                   update={update}
@@ -233,6 +233,10 @@ const ResearchArticle = observer((props: IProps) => {
     return isLoading ? <Loader /> : <NotFoundPage />
   }
 })
+
+const isUpdateVisible = (update: IResearch.UpdateDB) => {
+  return update.status !== 'draft' && update._deleted === false
+}
 
 const transformToUserComment = (
   comments: IComment[],

--- a/src/pages/Research/Content/ResearchUpdate.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.tsx
@@ -1,5 +1,4 @@
 import { format } from 'date-fns'
-import * as React from 'react'
 import ReactPlayer from 'react-player'
 import { Box, Card, Text, Flex, Heading } from 'theme-ui'
 import { Button, ImageGallery, LinkifyText, Username } from 'oa-components'

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -462,6 +462,34 @@ describe('research.store', () => {
         )
       })
     })
+
+    describe('deleteUpdate', () => {
+      it('removes an update', async () => {
+        const { store, researchItem, setFn } = await factoryResearchItem()
+
+        // Act
+        await store.deleteUpdate(researchItem.updates[0]._id)
+
+        // Assert
+        expect(setFn).toBeCalledTimes(1)
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(
+          newResearchItem.updates.find(
+            ({ title }) => title === researchItem.updates[0].title,
+          )._deleted,
+        ).toBe(true)
+      })
+
+      it('handles malformed update id', async () => {
+        const { store, setFn } = await factoryResearchItem()
+
+        // Act
+        await store.deleteUpdate('malformed-id')
+
+        // Assert
+        expect(setFn).not.toBeCalled()
+      })
+    })
   })
 
   describe('Item', () => {


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Building on the work in #2206 (please review that one first), this change introduces the ability to "Delete" a Research update.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
