### PR TITLE
feat: lock research to multiple editor access

### DIFF
--- a/functions/src/aggregations/research.aggregations.ts
+++ b/functions/src/aggregations/research.aggregations.ts
@@ -10,7 +10,7 @@ interface IResearchAggregation extends IAggregation {
 const researchAggregations: IResearchAggregation[] = [
   {
     sourceCollection: 'research',
-    sourceFields: ['votedUsefulBy', 'collaborators', 'moderation'],
+    sourceFields: ['collaborators', 'moderation'],
     changeType: 'updated',
     targetCollection: 'aggregations',
     targetDocId: 'users_totalUseful',

--- a/packages/components/src/BlockedRoute/BlockedRoute.stories.tsx
+++ b/packages/components/src/BlockedRoute/BlockedRoute.stories.tsx
@@ -1,0 +1,21 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
+import { BlockedRoute } from './BlockedRoute'
+import { faker } from '@faker-js/faker'
+
+export default {
+  title: 'Components/BlockedRoute',
+  component: BlockedRoute,
+} as ComponentMeta<typeof BlockedRoute>
+
+export const Default: ComponentStory<typeof BlockedRoute> = () => (
+  <BlockedRoute>{faker.lorem.sentences(2)}</BlockedRoute>
+)
+
+export const OverrideButton: ComponentStory<typeof BlockedRoute> = () => (
+  <BlockedRoute
+    redirectLabel="A custom call to action"
+    redirectUrl="/another-url"
+  >
+    {faker.lorem.sentences(2)}
+  </BlockedRoute>
+)

--- a/packages/components/src/BlockedRoute/BlockedRoute.tsx
+++ b/packages/components/src/BlockedRoute/BlockedRoute.tsx
@@ -1,0 +1,29 @@
+import { Flex, Box, Text } from 'theme-ui'
+import { Button } from '../Button/Button'
+import { InternalLink } from '../InternalLink/InternalLink'
+
+export interface BlockedRouteProps {
+  children: React.ReactNode
+  redirectUrl?: string
+  redirectLabel?: string
+}
+
+export const BlockedRoute = (props: BlockedRouteProps) => {
+  const redirectLabel = props.redirectLabel || 'Back to home'
+  const redirectUrl = props.redirectUrl || '/'
+  return (
+    <Flex
+      sx={{ justifyContent: 'center', flexDirection: 'column', mt: 8 }}
+      data-cy="BlockedRoute"
+    >
+      <Text sx={{ width: '100%', textAlign: 'center' }}>{props.children}</Text>
+      <Box sx={{ textAlign: 'center', mt: 2 }}>
+        <InternalLink to={redirectUrl}>
+          <Button variant={'subtle'} small>
+            {redirectLabel}
+          </Button>
+        </InternalLink>
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -46,3 +46,4 @@ export type { Props as TextNotificationProps } from './TextNotification/TextNoti
 export type { ResearchEditorOverviewUpdate } from './ResearchEditorOverview/ResearchEditorOverview'
 export type { User } from './types/common'
 export type { UserNotificationList } from './NotificationList/NotificationList'
+export { BlockedRoute } from './BlockedRoute/BlockedRoute'

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -433,7 +433,7 @@ describe('[How To]', () => {
     it('[By Anonymous]', () => {
       cy.step('Prevent anonymous access to edit howto')
       cy.visit(editHowtoUrl)
-      cy.get('[data-cy=auth-route-deny]').should('be.exist')
+      cy.get('[data-cy=BlockedRoute]').should('be.exist')
     })
 
     it('[By Authenticated]', () => {

--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -39,7 +39,7 @@ describe('[Profile]', () => {
       cy.get('[data-cy="Username"]').should('contain.text', admin.userName)
       cy.get('[data-cy=adminEdit]').should('not.exist')
       cy.visit(`/u/${admin.userName}/edit`)
-      cy.get('[data-cy=auth-route-deny]').should('exist')
+      cy.get('[data-cy=BlockedRoute]').should('exist')
     })
   })
 

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -140,7 +140,7 @@ describe('[Research]', () => {
     it('[By Anonymous]', () => {
       cy.step('Prevent anonymous access to edit research article')
       cy.visit(editResearchUrl)
-      cy.get('[data-cy=auth-route-deny]').should('be.exist')
+      cy.get('[data-cy=BlockedRoute]').should('be.exist')
     })
 
     it('[By Authenticated]', () => {
@@ -166,6 +166,13 @@ describe('[Research]', () => {
 
       cy.step('Update the intro')
       cy.get('[data-cy=intro-title]').clear().type(expected.title)
+
+      cy.step('Enter research article details')
+      cy.get('[data-cy="intro-description"]')
+        .clear()
+        .type(expected.description)
+        .blur({ force: true })
+
       cy.get('[data-cy=submit]').click()
 
       cy.step('Open the updated research article')

--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -1,12 +1,4 @@
-import type {
-  DBDoc,
-  IComment,
-  IModerable,
-  IModerationStatus,
-  ISelectedTags,
-  ISharedFeatures,
-  UserMention,
-} from '.'
+import type { DBDoc, IComment, IModerable, ISelectedTags, UserMention } from '.'
 import type { IUploadedFileMeta } from '../stores/storage'
 import type { IConvertedFileMeta } from '../types'
 import type { IResearchCategory } from './researchCategories.model'
@@ -16,8 +8,21 @@ import type { IResearchCategory } from './researchCategories.model'
  */
 export type IResearchDB = DBDoc & IResearch.ItemDB
 
-/** All typings related to the Research Module can be found here */
-type UserIdList = string[]
+export type IResearchStats = {
+  votedUsefulCount: number
+}
+
+type UserId = string
+type DateString = string
+
+type ResearchDocumentLockInformation = {
+  by: UserId
+  at: DateString
+}
+
+type ResearchDocumentLock = ResearchDocumentLockInformation | null
+
+type UserIdList = UserId[]
 
 export namespace IResearch {
   /** The main research item, as created by a user */
@@ -28,9 +33,8 @@ export namespace IResearch {
     _deleted: boolean
     collaborators: string[]
     subscribers?: UserIdList
-    moderation: IModerationStatus
-  } & Omit<FormInput, 'collaborators'> &
-    ISharedFeatures
+    locked?: ResearchDocumentLock
+  } & Omit<FormInput, 'collaborators'>
 
   /** A research item update */
   export interface Update {
@@ -44,6 +48,7 @@ export namespace IResearch {
     comments?: IComment[]
     collaborators?: string[]
     status: 'draft' | 'published'
+    locked?: ResearchDocumentLock
   }
 
   export interface FormInput extends IModerable {

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -88,6 +88,15 @@ const ResearchForm = observer((props: IProps) => {
     shouldSubmit: false,
   })
 
+  // Managing locked state
+  React.useEffect(() => {
+    if (store.activeUser) store.lockResearchItem(store.activeUser.userName)
+
+    return () => {
+      store.unlockResearchItem()
+    }
+  }, [store.activeUser])
+
   React.useEffect(() => {
     if (store.researchUploadStatus.Complete) {
       window.removeEventListener('beforeunload', beforeUnload, false)

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
@@ -89,6 +89,16 @@ export const ResearchUpdateForm = observer((props: IProps) => {
     }
   }, [store.updateUploadStatus?.Complete])
 
+  // Managing locked state
+  React.useEffect(() => {
+    if (store.activeUser)
+      store.lockResearchUpdate(store.activeUser.userName, props.formValues._id)
+
+    return () => {
+      store.unlockResearchUpdate(props.formValues._id)
+    }
+  }, [store.activeUser])
+
   const trySubmitForm = (isDraft: boolean) => {
     const form = document.getElementById('updateForm')
     setIsDraft(isDraft)

--- a/src/pages/Research/Content/EditResearch/index.tsx
+++ b/src/pages/Research/Content/EditResearch/index.tsx
@@ -1,15 +1,15 @@
 import { toJS } from 'mobx'
 import { observer } from 'mobx-react'
-import { Loader } from 'oa-components'
 import * as React from 'react'
 import type { RouteComponentProps } from 'react-router'
 import { Redirect } from 'react-router'
+import { Loader, BlockedRoute } from 'oa-components'
+import { Text } from 'theme-ui'
 import type { IResearch } from 'src/models/research.models'
 import type { IUser } from 'src/models/user.models'
 import ResearchForm from 'src/pages/Research/Content/Common/Research.form'
 import { useResearchStore } from 'src/stores/Research/research.store'
 import { isAllowedToEditContent } from 'src/utils/helpers'
-import { Text } from 'theme-ui'
 import { logger } from '../../../../logger'
 
 interface IState {
@@ -68,6 +68,19 @@ const EditResearch = observer((props: IProps) => {
 
   if (formValues && !isLoading) {
     if (loggedInUser && isAllowedToEditContent(formValues, loggedInUser)) {
+      if (
+        formValues.locked &&
+        formValues.locked.by !== loggedInUser?.userName
+      ) {
+        logger.info('Research is locked', formValues.locked)
+        return (
+          <BlockedRoute>
+            The research description is currently being edited by another
+            editor.
+          </BlockedRoute>
+        )
+      }
+
       return (
         <ResearchForm
           data-testid="EditResearch"

--- a/src/pages/Research/Content/EditUpdate/index.tsx
+++ b/src/pages/Research/Content/EditUpdate/index.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react'
 import * as React from 'react'
 import type { RouteComponentProps } from 'react-router'
 import { Redirect } from 'react-router'
-import { Loader } from 'oa-components'
+import { Loader, BlockedRoute } from 'oa-components'
 import { Text } from 'theme-ui'
 import type { IResearch } from 'src/models/research.models'
 import type { IUser } from 'src/models/user.models'
@@ -86,6 +86,20 @@ const EditUpdate = observer((props: IProps) => {
       loggedInUser &&
       isAllowedToEditContent(store.activeResearchItem!, loggedInUser)
     ) {
+      if (
+        formValues.locked &&
+        formValues.locked.by !== loggedInUser?.userName
+      ) {
+        return (
+          <BlockedRoute
+            redirectLabel="Back to research"
+            redirectUrl={`/research/${props.match.params.slug}`}
+          >
+            This research update is currently being edited by another editor.
+          </BlockedRoute>
+        )
+      }
+
       return (
         <ResearchUpdateForm
           formValues={formValues}

--- a/src/pages/common/AuthRoute.tsx
+++ b/src/pages/common/AuthRoute.tsx
@@ -1,8 +1,8 @@
 import { Redirect, Route } from 'react-router'
 import { observer } from 'mobx-react'
-import { Flex, Text } from 'theme-ui'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import type { UserRole } from 'src/models/user.models'
+import { BlockedRoute } from 'oa-components'
 
 /*
     This provides a <AuthRoute /> component that can be used in place of <Route /> components
@@ -27,17 +27,11 @@ export const AuthRoute = observer(
           redirect ? (
             <Redirect to={redirect} />
           ) : (
-            <Flex
-              sx={{ justifyContent: 'center' }}
-              mt="40px"
-              data-cy="auth-route-deny"
-            >
-              <Text>
-                {roleRequired
-                  ? `${roleRequired} role required to access this page. Please contact an admin.`
-                  : 'Please login to access this page.'}
-              </Text>
-            </Flex>
+            <BlockedRoute>
+              {roleRequired
+                ? `${roleRequired} role required to access this page. Please contact an admin.`
+                : 'Please login to access this page'}
+            </BlockedRoute>
           )
         }
       >

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -844,6 +844,90 @@ export class ResearchStore extends ModuleStore {
     return (this.activeResearchItem?.votedUsefulBy || []).length
   }
 
+  @action
+  public async lockResearchItem(username: string) {
+    const item = this.activeResearchItem
+    if (item) {
+      const dbRef = this.db
+        .collection<IResearch.Item>(COLLECTION_NAME)
+        .doc(item._id)
+      const newItem = {
+        ...item,
+        locked: {
+          by: username,
+          at: new Date().toISOString(),
+        },
+      }
+      await this._updateResearchItem(dbRef, newItem)
+      runInAction(() => {
+        this.activeResearchItem = newItem
+      })
+    }
+  }
+  @action
+  public async unlockResearchItem() {
+    const item = this.activeResearchItem
+    if (item) {
+      const dbRef = this.db
+        .collection<IResearch.Item>(COLLECTION_NAME)
+        .doc(item._id)
+      const newItem = {
+        ...item,
+        locked: null,
+      }
+      await this._updateResearchItem(dbRef, newItem)
+      runInAction(() => {
+        this.activeResearchItem = newItem
+      })
+    }
+  }
+  @action
+  public async lockResearchUpdate(username: string, updateId: string) {
+    const item = this.activeResearchItem
+    if (item) {
+      const dbRef = this.db
+        .collection<IResearch.Item>(COLLECTION_NAME)
+        .doc(item._id)
+      const updateIndex = item.updates.findIndex((upd) => upd._id === updateId)
+      const newItem = {
+        ...item,
+        updates: [...item.updates],
+      }
+
+      if (updateIndex && newItem.updates[updateIndex]) {
+        newItem.updates[updateIndex].locked = {
+          by: username,
+          at: new Date().toISOString(),
+        }
+      }
+      await this._updateResearchItem(dbRef, newItem)
+      runInAction(() => {
+        this.activeResearchItem = newItem
+      })
+    }
+  }
+  @action
+  public async unlockResearchUpdate(updateId: string) {
+    const item = this.activeResearchItem
+    if (item) {
+      const dbRef = this.db
+        .collection<IResearch.Item>(COLLECTION_NAME)
+        .doc(item._id)
+      const updateIndex = item.updates.findIndex((upd) => upd._id === updateId)
+      const newItem = {
+        ...item,
+        updates: [...item.updates],
+      }
+
+      if (newItem.updates[updateIndex]) {
+        newItem.updates[updateIndex].locked = null
+      }
+      await this._updateResearchItem(dbRef, newItem)
+      runInAction(() => {
+        this.activeResearchItem = newItem
+      })
+    }
+  }
   /**
    * Updates supplied dbRef after
    * converting @mentions to user references


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Introduces the concept of `locking` for Research editors. It is now possible for multiple users to be able to access a Research article or Research Update. This is great but introduces the potential for multiple users to overwrite each others changes. 

This PR attempts to minimise this risk by introducing the concept of locking a document. A document is marked as locked when the edit form is locked. The document is then marked as unlocked when the edit form is unloaded.



## Git Issues

Closes #2144

## Screenshots/Videos

Locked screen when attempting to access Research if another user is working on it. 

![Screenshot 2023-04-10 at 16 00 56](https://user-images.githubusercontent.com/472589/230916390-17906704-e977-4d65-89d6-039172bcb478.jpg)

**How to validate**

1. You will need two users (A + B) with edit access to the same Research Article. 
2. User A opens the Research article in edit mode
3. User B attempts to edit the Research article
4. Expectation: User B is unable to access the Research article and will be shown a useful error message.

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
