### PR TITLE
fix(AdminTags.tsx): change categories separator

### DIFF
--- a/src/pages/admin/content/AdminTags.tsx
+++ b/src/pages/admin/content/AdminTags.tsx
@@ -7,6 +7,7 @@ import type { ITag, TagCategory } from 'src/models/tags.model'
 // Import React Table
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
+import type { Column } from 'react-table'
 import { Form, Field } from 'react-final-form'
 
 // we include props from react-final-form fields so it can be used as a custom field component
@@ -159,7 +160,7 @@ export class AdminTags extends React.Component<IProps, IState> {
   }
 }
 
-const TAG_TABLE_COLUMNS: { [key: string]: keyof ITag }[] = [
+const TAG_TABLE_COLUMNS: Array<Column<ITag>> = [
   {
     Header: '_id',
     accessor: '_id',
@@ -170,7 +171,8 @@ const TAG_TABLE_COLUMNS: { [key: string]: keyof ITag }[] = [
   },
   {
     Header: 'categories',
-    accessor: 'categories',
+    id: 'categories',
+    accessor: (tag: ITag) => tag.categories.join(', '),
   },
 ]
 // TODO - currently all hard-coded, would be good to allow custom categories and organisation


### PR DESCRIPTION
in order to visually distinguish the categories tag I am introducing the separator between the tags

fix #2181

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
