### PR TITLE
chore: fix spelling of CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ workflows:
               ignore:
                 - production
       - test_circular_dependency:
-          name: 'Circuar dependency test'
+          name: 'Circular dependency test'
           requires:
             - 'Lint code'
           filters:
@@ -491,7 +491,7 @@ workflows:
           requires:
             - 'Build Application'
             - 'Unit tests'
-            - 'Circuar dependency test'
+            - 'Circular dependency test'
             - 'Cloud Function tests'
             - 'Build Storybook'
           context:


### PR DESCRIPTION
Circular dependency test was incorrectly spelt

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Minor spelling mistake fixed