### PR TITLE
feat(email-notifs): send emails from admin panel for testing

### DIFF
--- a/functions/src/emailNotifications/createEmail.ts
+++ b/functions/src/emailNotifications/createEmail.ts
@@ -13,6 +13,7 @@ const getResourceLabelFromNotificationType = (type: NotificationType) => {
       return 'research'
     case 'howto_useful':
     case 'howto_mention':
+    case 'new_comment':
       return 'how-to'
   }
 }

--- a/functions/src/emailNotifications/index.ts
+++ b/functions/src/emailNotifications/index.ts
@@ -1,8 +1,41 @@
 import * as functions from 'firebase-functions'
 import { createNotificationEmails } from './createEmail'
+import { db } from '../Firebase/firestoreDB'
+import { DB_ENDPOINTS, IUserDB } from '../models'
 
 /** Trigger daily process to send any pending email notifications */
 exports.sendDaily = functions.pubsub
   // Trigger daily at 5pm (https://crontab.guru/#0_17_*_*_*)
   .schedule('0 17 * * *')
   .onRun(async () => createNotificationEmails())
+
+exports.sendOnce = functions.https.onCall(async (_, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'The function must be called while authenticated.',
+    )
+  }
+  // Validate user exists and has admin status before triggering function.
+  const { uid } = context.auth
+  const user = await db.collection(DB_ENDPOINTS.users).doc(uid).get()
+  if (user.exists) {
+    const { userRoles } = user.data() as IUserDB
+    if (userRoles?.some((role) => ['admin', 'super-admin'].includes(role))) {
+      try {
+        await createNotificationEmails()
+        return 'OK'
+      } catch (error) {
+        console.error(error)
+        throw new functions.https.HttpsError(
+          'internal',
+          'There was an error creating emails.',
+        )
+      }
+    }
+  }
+  throw new functions.https.HttpsError(
+    'permission-denied',
+    'Emails can be triggered by admins only.',
+  )
+})


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
this PR creates a button in the admin notifications page that will trigger the create email function to run. this will enable email testing in the development environment.

to do this, i created another firebase function `emailNotifications-sendOnce` that triggers the `createEmail` function through an HTTP call. it requires that the caller be an authorized user with admin permissions.  

we can see emails getting populated in the emails collection locally, but our local emulator env is not integrated with the email extension, so we can't test the full flow until it is deployed.

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/37253846/234773589-07fc2e5c-262a-4f55-b766-8a3a9644fdc3.mov

to try locally follow setup here https://github.com/ONEARMY/community-platform/pull/2027

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
