### PR TITLE
refactor: remove direct use of theme in howto description

### DIFF
--- a/packages/themes/src/common/variants.ts
+++ b/packages/themes/src/common/variants.ts
@@ -1,0 +1,14 @@
+import { commonColors } from './colors'
+
+export const variants = {
+  auxiliary: {
+    fontFamily: '"Inter", Helvetica Neue, Arial, sans-serif;',
+    fontSize: '12px',
+    color: commonColors.grey,
+  },
+  paragraph: {
+    fontFamily: '"Inter", Helvetica Neue, Arial, sans-serif;',
+    fontSize: '16px',
+    color: commonColors.grey,
+  },
+}

--- a/packages/themes/src/fixing-fashion/styles.ts
+++ b/packages/themes/src/fixing-fashion/styles.ts
@@ -1,4 +1,5 @@
 import { commonColors } from './../common/colors'
+import { variants } from '../common/variants'
 import type { ThemeWithName } from '../types'
 import spaceBadge from '../../assets/images/themes/fixing-fashion/avatar_space_lg.svg'
 import memberBadgeLowDetail from '../../assets/images/themes/fixing-fashion/avatar_member_sm.svg'
@@ -190,6 +191,7 @@ export const StyledComponentTheme: ThemeWithName = {
       fontFamily: fonts.body,
       color: 'grey',
     },
+    ...variants,
   },
   typography,
   zIndex,

--- a/packages/themes/src/precious-plastic/styles.ts
+++ b/packages/themes/src/precious-plastic/styles.ts
@@ -1,4 +1,5 @@
 import { commonColors } from './../common/colors'
+import { variants } from '../common/variants'
 import memberBadgeLowDetail from '../../assets/images/themes/precious-plastic/avatar_member_sm.svg'
 import memberBadgeHighDetail from '../../assets/images/themes/precious-plastic/avatar_member_lg.svg'
 import CollectionBadge from '../../assets/images/badges/pt-collection-point.svg'
@@ -219,6 +220,7 @@ export const styles: ThemeWithName = {
       fontFamily: fonts.body,
       color: 'grey',
     },
+    ...variants,
   },
   typography,
   zIndex,

--- a/packages/themes/src/project-kamp/styles.ts
+++ b/packages/themes/src/project-kamp/styles.ts
@@ -1,3 +1,4 @@
+import { variants } from '../common/variants'
 import memberBadgeLowDetail from '../../assets/images/themes/project-kamp/avatar_member_sm.svg'
 import memberBadgeHighDetail from '../../assets/images/themes/project-kamp/avatar_member_lg.svg'
 import logo from '../../assets/images/themes/project-kamp/project-kamp-header.png'
@@ -185,6 +186,7 @@ export const StyledComponentTheme: ThemeWithName = {
       fontFamily: fonts.body,
       color: 'grey',
     },
+    ...variants,
   },
   typography,
   zIndex,

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -17,12 +17,7 @@ import {
   DownloadFiles,
 } from 'oa-components'
 import type { IUser } from 'src/models/user.models'
-import {
-  isAllowToEditContent,
-  emStringToPx,
-  capitalizeFirstLetter,
-} from 'src/utils/helpers'
-import { useTheme } from '@emotion/react'
+import { isAllowToEditContent, capitalizeFirstLetter } from 'src/utils/helpers'
 import { Link } from 'react-router-dom'
 import { useCommonStores } from 'src/index'
 import {
@@ -50,11 +45,6 @@ interface IProps {
 }
 
 const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
-  const theme = useTheme()
-
-  const iconFlexDirection =
-    emStringToPx(theme.breakpoints[0]) > window.innerWidth ? 'column' : 'row'
-
   const [fileDownloadCount, setFileDownloadCount] = useState(
     howto.total_downloads,
   )
@@ -225,7 +215,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
         </Box>
 
         <Flex mt="4">
-          <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
+          <Flex mr="4" sx={{ flexDirection: ['column', 'row', 'row'] }}>
             <Image
               loading="lazy"
               src={StepsIcon}
@@ -238,7 +228,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
               ? `${howto.steps.length} step`
               : `${howto.steps.length} steps`}
           </Flex>
-          <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
+          <Flex mr="4" sx={{ flexDirection: ['column', 'row', 'row'] }}>
             <Image
               loading="lazy"
               src={TimeNeeded}
@@ -249,7 +239,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             />
             {howto.time}
           </Flex>
-          <Flex mr="4" sx={{ flexDirection: iconFlexDirection }}>
+          <Flex mr="4" sx={{ flexDirection: ['column', 'row', 'row'] }}>
             <Image
               loading="lazy"
               src={DifficultyLevel}

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -194,7 +194,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             </Link>
           )}
         </Flex>
-        <Box mt={3} mb={2}>
+        <Box mt={4} mb={2}>
           <Username
             user={{
               userName: howto._createdBy,
@@ -203,8 +203,8 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             isVerified={isUserVerified(howto._createdBy)}
           />
           <Text
+            variant="auxiliary"
             sx={{
-              ...theme.typography.auxiliary,
               color: 'lightgrey',
               '&!important': {
                 color: 'lightgrey',
@@ -219,7 +219,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             {/* HACK 2021-07-16 - new howtos auto capitalize title but not older */}
             {capitalizeFirstLetter(howto.title)}
           </Heading>
-          <Text sx={{ ...theme.typography.paragraph, whiteSpace: 'pre-line' }}>
+          <Text variant="paragraph" sx={{ whiteSpace: 'pre-line' }}>
             <LinkifyText>{howto.description}</LinkifyText>
           </Text>
         </Box>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -22,9 +22,7 @@ import {
   emStringToPx,
   capitalizeFirstLetter,
 } from 'src/utils/helpers'
-// TODO: Remove direct usage of Theme
-import { preciousPlasticTheme } from 'oa-themes'
-const theme = preciousPlasticTheme.styles
+import { useTheme } from '@emotion/react'
 import { Link } from 'react-router-dom'
 import { useCommonStores } from 'src/index'
 import {
@@ -40,9 +38,6 @@ import {
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { isUserVerified } from 'src/common/isUserVerified'
 
-const iconFlexDirection =
-  emStringToPx(theme.breakpoints[0]) > window.innerWidth ? 'column' : 'row'
-
 interface IProps {
   howto: IHowtoDB & { taglist: any }
   loggedInUser: IUser | undefined
@@ -55,6 +50,11 @@ interface IProps {
 }
 
 const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
+  const theme = useTheme()
+
+  const iconFlexDirection =
+    emStringToPx(theme.breakpoints[0]) > window.innerWidth ? 'column' : 'row'
+
   const [fileDownloadCount, setFileDownloadCount] = useState(
     howto.total_downloads,
   )
@@ -121,9 +121,9 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
       data-id={howto._id}
       className="howto-description-container"
       sx={{
-        borderRadius: theme.radii[2] + 'px',
+        borderRadius: 2,
         bg: 'white',
-        borderColor: theme.colors.black,
+        borderColor: 'black',
         borderStyle: 'solid',
         borderWidth: '2px',
         overflow: 'hidden',
@@ -205,7 +205,10 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
           <Text
             sx={{
               ...theme.typography.auxiliary,
-              color: `${theme.colors.lightgrey} !important`,
+              color: 'lightgrey',
+              '&!important': {
+                color: 'lightgrey',
+              },
             }}
             mt={1}
             mb={2}
@@ -290,9 +293,9 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
               <Text
                 data-cy="file-download-counter"
                 sx={{
-                  fontSize: '12px',
-                  color: '#61646B',
-                  paddingLeft: '8px',
+                  fontSize: 1,
+                  color: 'grey',
+                  paddingLeft: 1,
                 }}
               >
                 {fileDownloadCount}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes direct use of theme and adds theme aware properties where possible, this does highlight the need to move remove typography in favour of variants in the themes (adding to my TODO).

Also uses breakpoints to set flexDirection dynamically.