### PR TITLE
fix(email-notifs): update email field to failed on error

### DIFF
--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -91,7 +91,9 @@ export interface INotification {
   type: NotificationType
   read: boolean
   notified: boolean
-  email?: string // id of the doc in the emails collection if notification was sent in an email
+  // email contains the id of the doc in the emails collection if the notification was included in
+  // an email or 'failed' if an email with this notification was attempted and encountered an error
+  email?: string
 }
 
 export const NotificationTypes = [


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

another detail i realized we needed...

if an email fails, i don't think we should keep attempting it. the way the pending email aggregation is written, notifications for a user will remain in the pending list until they are marked notified, read, or sent as an email. therefore, i updated the fn to set the `email` field to `'failed'` on error.

i also realized that my update function updated ALL the user's notifs, not just the ones that got sent out in the email... so fixed that

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
