### PR TITLE
fix: remove use of theme from admin subheader

### DIFF
--- a/packages/themes/src/fixing-fashion/styles.ts
+++ b/packages/themes/src/fixing-fashion/styles.ts
@@ -160,6 +160,9 @@ export const StyledComponentTheme: ThemeWithName = {
   maxContainerWidth,
   regular,
   bold,
+  sizes: {
+    container: maxContainerWidth,
+  },
   text: textVariants,
   zIndex,
 }

--- a/packages/themes/src/precious-plastic/styles.ts
+++ b/packages/themes/src/precious-plastic/styles.ts
@@ -123,6 +123,9 @@ export const styles: ThemeWithName = {
   colors,
   fonts,
   fontSizes,
+  sizes: {
+    container: maxContainerWidth,
+  },
   forms: {
     input: {
       background: colors.background,

--- a/packages/themes/src/project-kamp/styles.ts
+++ b/packages/themes/src/project-kamp/styles.ts
@@ -157,4 +157,7 @@ export const StyledComponentTheme: ThemeWithName = {
   bold,
   text: textVariants,
   zIndex,
+  sizes: {
+    container: maxContainerWidth,
+  },
 }

--- a/packages/themes/src/types/index.ts
+++ b/packages/themes/src/types/index.ts
@@ -117,4 +117,8 @@ export interface ThemeWithName {
   maxContainerWidth: number
   regular: number
   bold: number
+
+  sizes: {
+    container: number
+  }
 }

--- a/src/modules/admin/components/AdminSubheader.tsx
+++ b/src/modules/admin/components/AdminSubheader.tsx
@@ -1,75 +1,38 @@
-import { Box } from 'theme-ui'
-import { NavLink } from 'react-router-dom'
-import styled from '@emotion/styled'
+import { Box, NavLink } from 'theme-ui'
 import { MODULE } from 'src/modules'
-// TODO: Remove direct usage of Theme
-import { preciousPlasticTheme } from 'oa-themes'
-const theme = preciousPlasticTheme.styles
 import { ADMIN_PAGES } from '../admin.routes'
 import { Fragment } from 'react'
 
 const moduleName = MODULE.ADMIN
 
-const SubmenuLink = styled(NavLink)`
-  font-family: 'Inter', helveticaNeue, Arial, sans-serif;
-  padding: 0px ${(props) => props.theme.space[4]}px;
-  color: ${theme.colors.white};
-  &:hover {
-  }
-  &.active {
-    color: ${theme.colors.yellow.base};
-    text-decoration: underline;
-  }
-  &.disabled {
-    opacity: 0.5;
-  }
-`
-
-SubmenuLink.defaultProps = {
-  activeClassName: 'active',
-}
-
-// The parent container limits max width (at 1280px). Use custom query
-// to retain full width beyond this limit
-const fullWidthMarginOverride = `calc((${
-  theme.maxContainerWidth / 2
-}px - 50vw) - ${theme.space[4]}px  )`
-
-const SubheaderContainer = styled(Box)`
-  @media only screen and (min-width: ${theme.maxContainerWidth}px) {
-    margin-left: ${fullWidthMarginOverride}!important;
-    margin-right: ${fullWidthMarginOverride}!important;
-  }
-`
-
 const AdminSubheader = () => (
-  <SubheaderContainer
-    bg={theme.colors.black}
-    p={2}
-    sx={{ textAlign: 'right' }}
-    ml={[-2, -3, -4]} // adjust for main-container padding on regular screen breakpoints
-    mr={[-2, -3, -4]}
-    data-cy="admin-subheader"
-  >
-    {ADMIN_PAGES.map((p) => {
-      return p.disabled ? (
-        <Fragment key={p.path}>
-          <SubmenuLink
-            to={`/${moduleName}${p.path}`}
-            onClick={(e) => e.preventDefault()}
+  <Box bg={'black'} p={2} sx={{ textAlign: 'right' }} data-cy="admin-subheader">
+    {ADMIN_PAGES.map((page) => {
+      return page.disabled ? (
+        <Fragment key={page.path}>
+          <NavLink
+            href={`/${moduleName}${page.path}`}
             className="disabled"
             data-tip={'Coming soon...'}
+            onClick={(e) => {
+              e.preventDefault()
+            }}
+            sx={{ color: 'white', opacity: 0.5, px: 1 }}
           >
-            {p.title}
-          </SubmenuLink>
+            {page.title}
+          </NavLink>
         </Fragment>
       ) : (
-        <SubmenuLink key={p.path} to={`/${moduleName}${p.path}`} exact>
-          {p.title}
-        </SubmenuLink>
+        <NavLink
+          key={page.path}
+          href={`/${moduleName}${page.path}`}
+          sx={{ color: 'white', px: 1 }}
+        >
+          {page.title}
+        </NavLink>
       )
     })}
-  </SubheaderContainer>
+  </Box>
 )
 
 export default AdminSubheader

--- a/src/modules/admin/index.tsx
+++ b/src/modules/admin/index.tsx
@@ -4,6 +4,7 @@ import { MODULE } from '..'
 import adminRoutes from './admin.routes'
 import AdminSubheader from './components/AdminSubheader'
 import { AuthRoute } from 'src/pages/common/AuthRoute'
+import { Container } from 'theme-ui'
 
 const moduleName = MODULE.ADMIN
 
@@ -13,7 +14,9 @@ const moduleName = MODULE.ADMIN
 const AdminModuleContainer = () => (
   <AdminStoreV2Context.Provider value={new AdminStoreV2()}>
     <AdminSubheader />
-    <AuthRoute component={adminRoutes} roleRequired="admin" redirect="/" />
+    <Container>
+      <AuthRoute component={adminRoutes} roleRequired="admin" redirect="/" />
+    </Container>
   </AdminStoreV2Context.Provider>
 )
 
@@ -24,4 +27,5 @@ export const AdminModule: IPageMeta = {
   title: 'Admin',
   description: 'Admin Home Page',
   requiredRole: 'admin',
+  fullPageWidth: true,
 }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes direct usage of the theme object, instead accessing it within the `sx` property.

