### PR TITLE
test: make events e2e test more robust by mocking reverse address fetch

### DIFF
--- a/packages/cypress/src/fixtures/searchResults.ts
+++ b/packages/cypress/src/fixtures/searchResults.ts
@@ -15,3 +15,25 @@ export const SingaporeStubResponse = [
     icon: 'https://nominatim.openstreetmap.org/ui/mapicons/poi_boundary_administrative.p.20.png',
   },
 ]
+
+export const SingaporeReverseStubResponse = {
+  place_id: 250166445,
+  licence:
+    'Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright',
+  osm_type: 'way',
+  osm_id: 733562800,
+  lat: '1.3572387983345497',
+  lon: '103.81937941431262',
+  display_name: 'Drongo Trail, Bishan, Singapore, Central, 578774, Singapore',
+  address: {
+    road: 'Drongo Trail',
+    suburb: 'Bishan',
+    city: 'Singapore',
+    county: 'Central',
+    'ISO3166-2-lvl6': 'SG-01',
+    postcode: '578774',
+    country: 'Singapore',
+    country_code: 'sg',
+  },
+  boundingbox: ['1.3569979', '1.3604959', '103.8188088', '103.8214283'],
+}

--- a/packages/cypress/src/integration/events.spec.ts
+++ b/packages/cypress/src/integration/events.spec.ts
@@ -1,4 +1,7 @@
-import { SingaporeStubResponse } from '../fixtures/searchResults'
+import {
+  SingaporeStubResponse,
+  SingaporeReverseStubResponse,
+} from '../fixtures/searchResults'
 
 describe('[Events]', () => {
   beforeEach(() => {
@@ -65,7 +68,8 @@ describe('[Events]', () => {
 
   describe('[Create an event]', () => {
     it('[By Authenticated]', () => {
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
+      cy.interceptAddressReverseFetch(SingaporeReverseStubResponse)
 
       cy.login('event_creator@test.com', 'test1234')
       cy.get('[data-cy=create-event]').click()
@@ -93,10 +97,14 @@ describe('[Events]', () => {
         .blur()
 
       cy.step('Publish the event')
+
       cy.get('[data-cy=submit]').should('not.be.disabled').click()
+
+      // Wait for event to be posted
       cy.wait(3000)
 
       cy.step('The new event is shown in /events')
+
       cy.get('[data-cy=card]')
         .contains('Create a test event')
         .should('be.exist')

--- a/packages/cypress/src/integration/notificationBanner.spec.ts
+++ b/packages/cypress/src/integration/notificationBanner.spec.ts
@@ -22,7 +22,7 @@ describe('[Notification Banner]', () => {
 
   describe('[By Authenticated user with filled profile]', () => {
     it('[Notification Banner is visible for user with blank profile]', () => {
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
 
       cy.login('howto_reader@test.com', 'test1234')
       cy.step('Go to User Settings')

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -143,7 +143,7 @@ describe('[Settings]', () => {
         url: `http://www.${freshSettings.userName}.com`,
       })
 
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
       setWorkspaceMapPin({
         description: expected.mapPinDescription,
         searchKeyword: 'Singapo',
@@ -331,7 +331,7 @@ describe('[Settings]', () => {
         url: `${freshSettings.userName}@test.com`,
       })
 
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
       setMemberMapPin({
         description: expected.mapPinDescription,
         searchKeyword: 'Singapo',
@@ -465,7 +465,7 @@ describe('[Settings]', () => {
         url: `http://settings_machine_bazarlink.com`,
       })
 
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
       setWorkspaceMapPin({
         description: expected.mapPinDescription,
         searchKeyword: 'singapo',
@@ -544,7 +544,7 @@ describe('[Settings]', () => {
         addContactLink({ index, label: 'website', url: link.url }),
       )
 
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
       setWorkspaceMapPin({
         description: expected.mapPinDescription,
         searchKeyword: 'Singa',
@@ -731,7 +731,7 @@ describe('[Settings]', () => {
       cy.get('[data-cy=plastic-pvc]').click()
       cy.get('[data-cy=plastic-other]').click()
 
-      cy.interceptAddressFetch(SingaporeStubResponse)
+      cy.interceptAddressSearchFetch(SingaporeStubResponse)
       setWorkspaceMapPin({
         description: expected.mapPinDescription,
         searchKeyword: 'Singapo',

--- a/packages/cypress/src/support/commands.ts
+++ b/packages/cypress/src/support/commands.ts
@@ -55,7 +55,9 @@ declare global {
        **/
       selectTag(tagName: string, selector?: string): Chainable<void>
 
-      interceptAddressFetch(addressResponse): Chainable<void>
+      interceptAddressSearchFetch(addressResponse): Chainable<void>
+
+      interceptAddressReverseFetch(addressResponse): Chainable<void>
     }
   }
 }
@@ -239,10 +241,16 @@ const attachCustomCommands = (Cypress: Cypress.Cypress) => {
     },
   )
 
-  Cypress.Commands.add('interceptAddressFetch', (addressResponse) => {
+  Cypress.Commands.add('interceptAddressSearchFetch', (addressResponse) => {
     cy.intercept('GET', 'https://nominatim.openstreetmap.org/search*', {
       body: addressResponse,
     }).as('fetchAddress')
+  })
+
+  Cypress.Commands.add('interceptAddressReverseFetch', (addressResponse) => {
+    cy.intercept('GET', 'https://nominatim.openstreetmap.org/reverse?*', {
+      body: addressResponse,
+    }).as('fetchAddressReverse')
   })
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Makes events test more robust by waiting for url to match rather than a specific set of time (previously set as 3 seconds)

https://www.npmjs.com/package/cypress-wait-until?activeTab=readme could also be an interesting option if this fails

## Git Issues

Closes #2287 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
