### PR TITLE
fix: form values for files reset after reupload click

### DIFF
--- a/src/pages/Howto/Content/Common/Howto.form.test.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { Provider } from 'mobx-react'
 import { HowtoForm } from './Howto.form'
 import { MemoryRouter } from 'react-router'
@@ -40,54 +40,88 @@ jest.mock('src/index', () => {
 })
 
 describe('Howto form', () => {
-  it('Invalid file warning does not appear when submitting only fileLink', async () => {
-    // Arrange
-    const formValues = FactoryHowto({ fileLink: 'www.test.com' })
+  describe('Invalid file warning', () => {
+    it('Does not appear when submitting only fileLink', async () => {
+      // Arrange
+      const formValues = FactoryHowto({ fileLink: 'www.test.com' })
+      // Act
+      const wrapper = getWrapper(formValues, 'edit', {})
 
-    // Act
-    const wrapper = getWrapper(formValues, 'edit', {})
-
-    // Assert
-    expect(
-      wrapper.queryByTestId('invalid-file-warning'),
-    ).not.toBeInTheDocument()
-  })
-
-  it('Invalid file warning does not appear when submitting only files', async () => {
-    // Arrange
-    const formValues = FactoryHowto({
-      files: [
-        new File(['test file content'], 'test-file.pdf', {
-          type: 'application/pdf',
-        }),
-      ],
+      // Assert
+      expect(
+        wrapper.queryByTestId('invalid-file-warning'),
+      ).not.toBeInTheDocument()
     })
 
-    // Act
-    const wrapper = getWrapper(formValues, 'edit', {})
+    it('Does not appear when submitting only files', async () => {
+      // Arrange
+      const formValues = FactoryHowto({
+        files: [
+          new File(['test file content'], 'test-file.pdf', {
+            type: 'application/pdf',
+          }),
+        ],
+      })
 
-    // Assert
-    expect(
-      wrapper.queryByTestId('invalid-file-warning'),
-    ).not.toBeInTheDocument()
-  })
+      // Act
+      const wrapper = getWrapper(formValues, 'edit', {})
 
-  it('Invalid file warning appears when submitting 2 file types', async () => {
-    // Arrange
-    const formValues = FactoryHowto({
-      files: [
-        new File(['test file content'], 'test-file.pdf', {
-          type: 'application/pdf',
-        }),
-      ],
-      fileLink: 'www.test.com',
+      // Assert
+      expect(
+        wrapper.queryByTestId('invalid-file-warning'),
+      ).not.toBeInTheDocument()
     })
 
-    // Act
-    const wrapper = getWrapper(formValues, 'edit', {})
+    it('Appears when submitting 2 file types', async () => {
+      // Arrange
+      const formValues = FactoryHowto({
+        files: [
+          new File(['test file content'], 'test-file.pdf', {
+            type: 'application/pdf',
+          }),
+        ],
+        fileLink: 'www.test.com',
+      })
 
-    // Assert
-    expect(wrapper.queryByTestId('invalid-file-warning')).toBeInTheDocument()
+      // Act
+      const wrapper = getWrapper(formValues, 'edit', {})
+
+      // Assert
+      expect(wrapper.queryByTestId('invalid-file-warning')).toBeInTheDocument()
+    })
+
+    it('Does not appear when files are removed and filelink added', async () => {
+      // Arrange
+      const formValues = FactoryHowto({
+        files: [
+          new File(['test file content'], 'test-file.pdf', {
+            type: 'application/pdf',
+          }),
+        ],
+      })
+
+      // Act
+      const wrapper = getWrapper(formValues, 'edit', {})
+
+      // clear files
+      const reuploadFilesButton = wrapper.getByTestId('re-upload-files')
+      fireEvent.click(reuploadFilesButton)
+
+      // add fileLink
+      const fileLink = wrapper.getByPlaceholderText(
+        'Link to Gdrive, Dropbox, Grabcad etc',
+      )
+      fireEvent.change(fileLink, { target: { value: '<http://www.test.com>' } })
+
+      // submit form
+      const submitFormButton = wrapper.getByTestId('submit-form')
+      fireEvent.click(submitFormButton)
+
+      // Assert
+      expect(
+        wrapper.queryByTestId('invalid-file-warning'),
+      ).not.toBeInTheDocument()
+    })
   })
 })
 

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -390,6 +390,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                       />
                                     ))}
                                     <Button
+                                      data-testid="re-upload-files"
                                       variant={'outline'}
                                       icon="delete"
                                       onClick={() => {
@@ -572,6 +573,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                     <Button
                       large
                       data-cy={'submit'}
+                      data-testid="submit-form"
                       onClick={() => this.trySubmitForm(false)}
                       mt={3}
                       variant="primary"

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -190,7 +190,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
           }}
           validateOnBlur
           decorators={[this.calculatedFields]}
-          render={({ submitting, handleSubmit }) => {
+          render={({ submitting, handleSubmit, form }) => {
             return (
               <Flex mx={-2} bg={'inherit'} sx={{ flexWrap: 'wrap' }}>
                 <UnsavedChangesDialog
@@ -392,12 +392,13 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                     <Button
                                       variant={'outline'}
                                       icon="delete"
-                                      onClick={() =>
+                                      onClick={() => {
                                         this.setState({
                                           fileEditMode:
                                             !this.state.fileEditMode,
                                         })
-                                      }
+                                        form.change('files', [])
+                                      }}
                                     >
                                       Re-upload files (this will delete the
                                       existing ones)


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Resets the files in the form to an empty array when the re-upload button is clicked, causing problems in #2280 as pointed out by @davehakkens 

This is done using the formApi in react final form (https://final-form.org/docs/final-form/types/FormApi)

## Git Issues

Closes #2313

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
