### PR TITLE
docs: add a maintainers section to the developer documentation

### DIFF
--- a/packages/documentation/docs/Maintainers/Onboarding.md
+++ b/packages/documentation/docs/Maintainers/Onboarding.md
@@ -1,0 +1,29 @@
+---
+id: onboarding
+title: Onboarding
+---
+
+As a new maintainer, you're joining a small team of dedicated contributors who are working to make this project a success. This document is designed to help you get up to speed quickly and start contributing to the project as a maintainer. The aim is to provide an overview of the tools and processes we use.
+
+## Checklist
+
+The following items outline the various access you will need to work across the Platform. You **do not need**
+access to all of these items, in fact from a security perspective you want to balance having the least possible access with those needed to get the job done.
+
+- [ ] Grant user access to Firebase projects
+  - [ ] Precious Plastic PROD
+  - [ ] Precious Plastic DEV
+  - [ ] Project Kamp PROD
+  - [ ] Project Kamp DEV
+  - [ ] Fixing Fashion PROD
+  - [ ] Fixing Fashion DEV
+- [ ] Grant GitHub maintainer permissions
+- [ ] Raise all contributors PR stating maintainer status
+- [ ] Grant access to Google Analytics for each site
+- [ ] Google Cloud Console grant admin permissions for user
+  - [ ] Precious Plastic PROD
+  - [ ] Precious Plastic DEV
+  - [ ] Project Kamp PROD
+  - [ ] Project Kamp DEV
+  - [ ] Fixing Fashion PROD
+  - [ ] Fixing Fashion DEV

--- a/packages/documentation/docs/Maintainers/Overview.md
+++ b/packages/documentation/docs/Maintainers/Overview.md
@@ -1,0 +1,12 @@
+---
+id: overview
+title: Overview
+---
+
+Welcome to the maintainer documentation for the Platform project! As a maintainer, you play a crucial role in ensuring the success and sustainability of our project. This documentation is designed to provide you with the information and resources you need to effectively manage the project and collaborate with other contributors.
+
+As a maintainer, you are responsible for a variety of tasks, including reviewing and merging pull requests, triaging issues, and coordinating releases. You also play an important role in setting the direction and vision for the project, working with the community to define goals and prioritize features.
+
+In this documentation, you'll find information on project governance, community guidelines, and best practices for maintaining the project.
+
+We're grateful for your contributions as a maintainer, and we hope this documentation will help you navigate the challenges and opportunities of open source development. Let's work together to build something great!

--- a/packages/documentation/sidebars.js
+++ b/packages/documentation/sidebars.js
@@ -82,6 +82,22 @@ module.exports = {
       id: 'Security',
     },
     {
+      type: 'category',
+      label: 'Maintainers',
+      items: [
+        {
+          type: 'doc',
+          label: 'Overview',
+          id: 'Maintainers/overview',
+        },
+        {
+          type: 'doc',
+          label: 'Onboarding',
+          id: 'Maintainers/onboarding',
+        },
+      ],
+    },
+    {
       type: 'link',
       label: 'Component Storybook',
       href: 'pathname:///storybook-static/index.html',


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

We propose creating a new documentation section that will outline the roles and responsibilities of the Maintainers. The purpose of this section is to simplify the onboarding process and facilitate knowledge sharing among all Maintainers. Since the project Maintainers are primarily volunteers, we should expect that people will need to take breaks from their responsibilities.

By documenting the processes, we can prevent knowledge silos and ensure that others can take over without issues.