### PR TITLE
feat: show follow button for non-logged in users

### DIFF
--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -103,10 +103,11 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
               />
             </Box>
           )}
-          {props.loggedInUser && (
+          {(
             <Button
               data-testid="follow-button"
               data-cy="follow-button"
+              data-tip={'Login to follow'}
               icon="thunderbolt"
               variant="outline"
               iconColor={

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -104,33 +104,31 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
             </Box>
           )}
 
-            <Button
-              data-testid="follow-button"
-              data-cy="follow-button"
-              data-tip={'Login to follow'}
-              icon="thunderbolt"
-              variant="outline"
-              iconColor={
-                research.subscribers?.includes(
-                  props?.loggedInUser?.userName || '',
-                )
-                  ? 'subscribed'
-                  : 'notSubscribed'
-              }
-              sx={{
-                fontSize: 2,
-                py: 0,
-                height: '41.5px', // TODO: Ideally this is a standard size
-              }}
-              onClick={props.onFollowingClick}
-            >
-              {research.subscribers?.includes(
+          <Button
+            data-testid="follow-button"
+            data-cy="follow-button"
+            data-tip={'Login to follow'}
+            icon="thunderbolt"
+            variant="outline"
+            iconColor={
+              research.subscribers?.includes(
                 props?.loggedInUser?.userName || '',
               )
-                ? 'Following'
-                : 'Follow'}
-            </Button>
-          
+                ? 'subscribed'
+                : 'notSubscribed'
+            }
+            sx={{
+              fontSize: 2,
+              py: 0,
+              height: '41.5px', // TODO: Ideally this is a standard size
+            }}
+            onClick={props.onFollowingClick}
+          >
+            {research.subscribers?.includes(props?.loggedInUser?.userName || '')
+              ? 'Following'
+              : 'Follow'}
+          </Button>
+
           {viewCount ? (
             <AuthWrapper roleRequired="beta-tester">
               <Box>

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -103,7 +103,7 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
               />
             </Box>
           )}
-          {(
+
             <Button
               data-testid="follow-button"
               data-cy="follow-button"
@@ -130,7 +130,7 @@ const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
                 ? 'Following'
                 : 'Follow'}
             </Button>
-          )}
+          
           {viewCount ? (
             <AuthWrapper roleRequired="beta-tester">
               <Box>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
Shown follow button for non-logged-in users
To achieve this I didn't allow it to render conditionally so that it can be visible to both logged-in as well as non-logged-in users. 
Also, I have added the tooltip that says "login to follow".

## Git Issues
#2337

## Screenshots/Videos

NA

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
