### PR TITLE
chore: increase threshold on code cov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,5 @@ status:
     default:
       target: auto
       threshold: 1%
+comment:
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,7 @@
 ignore:
   - "packages/documentation"
+status: 
+  project:
+    default:
+      target: auto
+      threshold: 1%


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

We have been seeing pretty much all status checks from Code cov fail due to coverage being reduced by ~0.5%. Whilst it would be great to have this level of strictness to our checks it is not possible with the current code. To avoid the risk of people [learning to ignore warnings](https://www.atlassian.com/incident-management/on-call/alert-fatigue#What-is-alert-fatigue?) from CodeCov we are going to increase the threshold for the foreseeable future. 

- chore(ci): increase threshold on code cov
- chore(tooling): reduce number of comments from codecov
