### PR TITLE
fix: ensure plain object before save

### DIFF
--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -6,6 +6,7 @@ import {
   runInAction,
   toJS,
 } from 'mobx'
+import { cloneDeep } from 'lodash'
 import { createContext, useContext } from 'react'
 import { MAX_COMMENT_LENGTH } from 'src/constants'
 import { logger } from 'src/logger'
@@ -162,7 +163,7 @@ export class ResearchStore extends ModuleStore {
 
     const researchData = await toJS(dbRef.get('server'))
     if (researchData && !(researchData?.subscribers || []).includes(userId)) {
-      await this.updateResearchItem(dbRef, {
+      await this._updateResearchItem(dbRef, {
         ...researchData,
         subscribers: [userId].concat(researchData?.subscribers || []),
       })
@@ -184,7 +185,7 @@ export class ResearchStore extends ModuleStore {
 
     const researchData = await toJS(dbRef.get('server'))
     if (researchData) {
-      await this.updateResearchItem(dbRef, {
+      await this._updateResearchItem(dbRef, {
         ...researchData,
         subscribers: (researchData?.subscribers || []).filter(
           (id) => id !== userId,
@@ -294,12 +295,12 @@ export class ResearchStore extends ModuleStore {
     update: IResearch.Update | IResearch.UpdateDB,
   ) {
     const user = this.activeUser
-    const item = this.activeResearchItem
+    const researchItem = this.activeResearchItem
     const comment = text.slice(0, MAX_COMMENT_LENGTH).trim()
-    if (item && comment && user) {
+    if (researchItem && comment && user) {
       const dbRef = this.db
         .collection<IResearch.Item>(COLLECTION_NAME)
-        .doc(item._id)
+        .doc(researchItem._id)
       const id = dbRef.id
 
       try {
@@ -330,20 +331,20 @@ export class ResearchStore extends ModuleStore {
           ? [...toJS(updateWithMeta.comments), newComment]
           : [newComment]
 
-        const existingUpdateIndex = item.updates.findIndex(
+        const existingUpdateIndex = researchItem.updates.findIndex(
           (upd) => upd._id === (update as IResearch.UpdateDB)._id,
         )
 
         const newItem = {
-          ...toJS(item),
-          updates: [...toJS(item.updates)],
+          ...toJS(researchItem),
+          updates: [...toJS(researchItem.updates)],
         }
 
         newItem.updates[existingUpdateIndex] = {
           ...(updateWithMeta as IResearch.UpdateDB),
         }
 
-        await this.updateResearchItem(dbRef, newItem)
+        await this._updateResearchItem(dbRef, newItem)
 
         // Notify author and contributors
         await this.userNotificationsStore.triggerNotification(
@@ -417,7 +418,7 @@ export class ResearchStore extends ModuleStore {
           ...(updateWithMeta as IResearch.UpdateDB),
         }
 
-        await this.updateResearchItem(dbRef, newItem)
+        await this._updateResearchItem(dbRef, newItem)
         const createdItem = (await dbRef.get()) as IResearch.ItemDB
         runInAction(() => {
           this.activeResearchItem = createdItem
@@ -479,7 +480,7 @@ export class ResearchStore extends ModuleStore {
             ...(updateWithMeta as IResearch.UpdateDB),
           }
 
-          await this.updateResearchItem(dbRef, newItem)
+          await this._updateResearchItem(dbRef, newItem)
           const createdItem = (await dbRef.get()) as IResearch.ItemDB
           runInAction(() => {
             this.activeResearchItem = createdItem
@@ -490,140 +491,6 @@ export class ResearchStore extends ModuleStore {
       logger.error(err)
       throw new Error(err)
     }
-  }
-
-  /**
-   * Updates supplied dbRef after
-   * converting @mentions to user references
-   * on all required properties within researchItem object.
-   *
-   */
-  private async updateResearchItem(
-    dbRef: DocReference<IResearch.Item>,
-    researchItem: IResearch.Item,
-  ) {
-    const { text: researchDescription, users } = await this.addUserReference(
-      researchItem.description,
-    )
-    logger.debug('updateResearchItem', {
-      before: researchItem.description,
-      after: researchDescription,
-    })
-
-    const previousVersion = toJS(await dbRef.get('server'))
-
-    const mentions: any = []
-
-    await Promise.all(
-      researchItem.updates.map(async (up, idx) => {
-        const { text: newDescription, users } = await this.addUserReference(
-          up.description,
-        )
-
-        ;(users || []).map((username) => {
-          mentions.push({
-            username,
-            location: `update-${idx}`,
-          })
-        })
-
-        researchItem.updates[idx].description = newDescription
-
-        if (researchItem.updates[idx]) {
-          await Promise.all(
-            (researchItem.updates[idx].comments || ([] as IComment[])).map(
-              async (comment, commentIdx) => {
-                const { text, users } = await this.addUserReference(
-                  comment.text,
-                )
-
-                const researchUpdate = researchItem.updates[idx]
-                if (researchUpdate.comments) {
-                  researchUpdate.comments[commentIdx].text = text
-
-                  users.map((username) => {
-                    mentions.push({
-                      username,
-                      location: `update-${idx}-comment:${comment._id}`,
-                    })
-                  })
-                }
-              },
-            ),
-          )
-        }
-      }),
-    )
-    ;(users || []).map((username) => {
-      mentions.push({
-        username,
-        location: 'description',
-      })
-    })
-
-    if (researchItem.previousSlugs === undefined) {
-      researchItem.previousSlugs = []
-    }
-
-    if (!researchItem.previousSlugs.includes(researchItem.slug)) {
-      researchItem.previousSlugs.push(researchItem.slug)
-    }
-
-    await dbRef.set({
-      ...researchItem,
-      mentions,
-      description: researchDescription,
-    })
-
-    const previousMentionsList = researchItem.mentions || []
-    logger.debug(`Mentions:`, {
-      before: previousMentionsList,
-      after: mentions,
-    })
-
-    // Previous mentions
-    const previousMentions = previousMentionsList.map(
-      (mention) => `${mention.username}.${mention.location}`,
-    )
-
-    mentions.forEach((mention) => {
-      if (
-        !previousMentions.includes(`${mention.username}.${mention.location}`)
-      ) {
-        this.userNotificationsStore.triggerNotification(
-          'research_mention',
-          mention.username,
-          `/research/${researchItem.slug}#${mention.location}`,
-        )
-      }
-    })
-
-    // Notify each subscriber
-    const subscribers = researchItem.subscribers || []
-
-    // Only notify subscribers if there is a new update added
-    logger.debug('Notify each subscriber', {
-      subscribers,
-      beforeUpdateNumber: previousVersion?.updates
-        ? previousVersion?.updates.length
-        : 0,
-      afterUpdateNumber: researchItem?.updates.length,
-    })
-
-    if (
-      researchItem.updates.length >
-      (previousVersion?.updates ? previousVersion?.updates.length : 0)
-    ) {
-      subscribers.forEach((subscriber) =>
-        this.userNotificationsStore.triggerNotification(
-          'research_update',
-          subscriber,
-          `/research/${researchItem.slug}`,
-        ),
-      )
-    }
-
-    return await dbRef.get()
   }
 
   public async uploadResearch(values: IResearch.FormInput) {
@@ -673,7 +540,7 @@ export class ResearchStore extends ModuleStore {
       }
       logger.debug('populating database', researchItem)
       // set the database document
-      await this.updateResearchItem(dbRef, researchItem)
+      await this._updateResearchItem(dbRef, researchItem)
       this.updateResearchUploadStatus('Database')
       logger.debug('post added')
       const newItem = (await dbRef.get()) as IResearch.ItemDB
@@ -756,7 +623,7 @@ export class ResearchStore extends ModuleStore {
         logger.debug('created:', newItem._created)
 
         // set the database document
-        await this.updateResearchItem(dbRef, newItem)
+        await this._updateResearchItem(dbRef, newItem)
         logger.debug('populate db ok')
         this.updateUpdateUploadStatus('Database')
         const createdItem = (await dbRef.get()) as IResearch.ItemDB
@@ -796,7 +663,7 @@ export class ResearchStore extends ModuleStore {
         newItem.updates[existingUpdateIndex]._deleted = true
 
         // set the database document
-        await this.updateResearchItem(dbRef, newItem)
+        await this._updateResearchItem(dbRef, newItem)
         const createdItem = (await dbRef.get()) as IResearch.ItemDB
         runInAction(() => {
           this.activeResearchItem = createdItem
@@ -821,6 +688,141 @@ export class ResearchStore extends ModuleStore {
         this.activeUser?._id ?? '',
       ) ?? false
     )
+  }
+
+  /**
+   * Updates supplied dbRef after
+   * converting @mentions to user references
+   * on all required properties within researchItem object.
+   *
+   */
+  private async _updateResearchItem(
+    dbRef: DocReference<IResearch.Item>,
+    researchItem: IResearch.Item,
+  ) {
+    const { text: researchDescription, users } = await this.addUserReference(
+      researchItem.description,
+    )
+    logger.debug('updateResearchItem', {
+      researchItem,
+    })
+
+    const previousVersion = toJS(await dbRef.get('server'))
+
+    const mentions: any = []
+
+    await Promise.all(
+      researchItem.updates.map(async (up, idx) => {
+        const { text: newDescription, users } = await this.addUserReference(
+          up.description,
+        )
+
+        ;(users || []).map((username) => {
+          mentions.push({
+            username,
+            location: `update-${idx}`,
+          })
+        })
+
+        researchItem.updates[idx].description = newDescription
+
+        if (researchItem.updates[idx]) {
+          await Promise.all(
+            (researchItem.updates[idx].comments || ([] as IComment[])).map(
+              async (comment, commentIdx) => {
+                const { text, users } = await this.addUserReference(
+                  comment.text,
+                )
+
+                const researchUpdate = researchItem.updates[idx]
+                if (researchUpdate.comments) {
+                  researchUpdate.comments[commentIdx].text = text
+
+                  users.map((username) => {
+                    mentions.push({
+                      username,
+                      location: `update-${idx}-comment:${comment._id}`,
+                    })
+                  })
+                }
+              },
+            ),
+          )
+        }
+      }),
+    )
+    ;(users || []).map((username) => {
+      mentions.push({
+        username,
+        location: 'description',
+      })
+    })
+
+    if (researchItem.previousSlugs === undefined) {
+      researchItem.previousSlugs = []
+    }
+
+    if (!researchItem.previousSlugs.includes(researchItem.slug)) {
+      researchItem.previousSlugs.push(researchItem.slug)
+    }
+
+    await dbRef.set({
+      ...cloneDeep(researchItem),
+      mentions,
+      description: researchDescription,
+    })
+
+    // Side effects from updating research item
+    // consider moving these out of the store.
+    const previousMentionsList = researchItem.mentions || []
+    logger.debug(`Mentions:`, {
+      before: previousMentionsList,
+      after: mentions,
+    })
+
+    // Previous mentions
+    const previousMentions = previousMentionsList.map(
+      (mention) => `${mention.username}.${mention.location}`,
+    )
+
+    mentions.forEach((mention) => {
+      if (
+        !previousMentions.includes(`${mention.username}.${mention.location}`)
+      ) {
+        this.userNotificationsStore.triggerNotification(
+          'research_mention',
+          mention.username,
+          `/research/${researchItem.slug}#${mention.location}`,
+        )
+      }
+    })
+
+    // Notify each subscriber
+    const subscribers = researchItem.subscribers || []
+
+    // Only notify subscribers if there is a new update added
+    logger.debug('Notify each subscriber', {
+      subscribers,
+      beforeUpdateNumber: previousVersion?.updates
+        ? previousVersion?.updates.length
+        : 0,
+      afterUpdateNumber: researchItem?.updates.length,
+    })
+
+    if (
+      researchItem.updates.length >
+      (previousVersion?.updates ? previousVersion?.updates.length : 0)
+    ) {
+      subscribers.forEach((subscriber) =>
+        this.userNotificationsStore.triggerNotification(
+          'research_update',
+          subscriber,
+          `/research/${researchItem.slug}`,
+        ),
+      )
+    }
+
+    return await dbRef.get()
   }
 }
 


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

There was a problem saving issues because the `collaborator` property being sent through to Dexie was still an observable array. This caused an error to be thrown by IndexDB/Dexie. 

This fix forces a plain object to be passed through.

Not addressed by this PR:
* Although an error was thrown by Dexie, the record on Firestore was updated. So when reloading the page the comment would be added as expected. What should the UI do if there is a crash at IndexDB, should it force a page reload to ensure alignment with origin?


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
