### PR TITLE
fix: compare against username property

### DIFF
--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -15,13 +15,21 @@ jest.mock('../../utils/helpers', () => ({
   },
 }))
 
-const factoryResearchItem = async (researchItemOverloads: any = {}) =>
-  factory(FactoryResearchItem, researchItemOverloads)
+const factoryResearchItem = async (researchItemOverloads: any = {}, ...rest) =>
+  factory(FactoryResearchItem, researchItemOverloads, ...rest)
 
-const factoryResearchItemFormInput = async (researchItemOverloads: any = {}) =>
-  factory(FactoryResearchItemFormInput, researchItemOverloads)
+const factoryResearchItemFormInput = async (
+  researchItemOverloads: any = {},
+  ...rest
+) => factory(FactoryResearchItemFormInput, researchItemOverloads, ...rest)
 
-const factory = async (mockFn, researchItemOverloads: any = {}) => {
+const factory = async (
+  mockFn,
+  researchItemOverloads: any = {},
+  activeUser = FactoryUser({
+    _id: 'fake-user',
+  }),
+) => {
   const researchItem = mockFn({
     updates: [FactoryResearchItemUpdate(), FactoryResearchItemUpdate()],
     ...researchItemOverloads,
@@ -30,11 +38,7 @@ const factory = async (mockFn, researchItemOverloads: any = {}) => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  store.setActiveUser(
-    FactoryUser({
-      _id: 'fake-user',
-    }),
-  )
+  store.setActiveUser(activeUser)
 
   let item = researchItem
 
@@ -769,6 +773,35 @@ describe('research.store', () => {
         'subscriber',
         `/research/${researchItem.slug}`,
       )
+    })
+
+    it('matches subscriber state for logged in user', async () => {
+      const { store } = await factoryResearchItem(
+        {
+          subscribers: ['subscriber'],
+        },
+        FactoryUser({
+          _id: 'fake-user-id',
+          userName: 'subscriber',
+        }),
+      )
+
+      // Assert
+      expect(store.userHasSubscribed).toBe(true)
+    })
+
+    it('does not match subscriber state for logged in user', async () => {
+      const { store } = await factoryResearchItem(
+        {
+          subscribers: ['subscriber'],
+        },
+        FactoryUser({
+          userName: 'another-user',
+        }),
+      )
+
+      // Assert
+      expect(store.userHasSubscribed).toBe(false)
     })
   })
 })

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -685,7 +685,7 @@ export class ResearchStore extends ModuleStore {
   get userHasSubscribed(): boolean {
     return (
       this.activeResearchItem?.subscribers?.includes(
-        this.activeUser?._id ?? '',
+        this.activeUser?.userName ?? '',
       ) ?? false
     )
   }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The bug behaviour here is that the Follow button would not show the correct Follow/Following state for some users. 

Reverts to using the `userName` property of User entity. There is some drift across user entities where the `_id` property could contain either the Firestore Auth ID **or** the username. This is something that will need to be addressed separately but is out of scope for this change.

Original implementation:
https://github.com/ONEARMY/community-platform/commit/bc6985ecff43ed87ae1ea9afb0e431aacdb8a357#diff-404a1450ddfbbd25ee32f597e3e8675f7142774a2efa5a730044cdf6ffed0847R234

