### PR TITLE
fix: profile load for users without links array

### DIFF
--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -14,7 +14,7 @@ interface IProps {
 }
 
 export const MemberProfile = ({ user }: IProps) => {
-  const userLinks = user?.links.filter(
+  const userLinks = (user?.links || []).filter(
     (linkItem) => !['discord', 'forum'].includes(linkItem.label),
   )
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Falls back to a blank array for the links property if user doc is missing it. This stops the filter that is part of the MemberProfile component from failing and preventing the profile form loading.

## Git Issues

Closes #2396

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
