### PR TITLE
feat: adds empty service-worker ahead of completely removing

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "theme-ui": "^0.15.7",
     "ts-node": "^10.4.0",
     "web-vitals": "^1.1.2",
+    "workbox-window": "^6.1.5",
     "yup": "^0.32.9"
   },
   "devDependencies": {
@@ -201,7 +202,20 @@
     "terser": "3.14.1",
     "ts-loader": "^7.0.5",
     "typescript": "4.5.5",
-    "wait-on": "^5.2.1"
+    "wait-on": "^5.2.1",
+    "workbox-background-sync": "^6.1.5",
+    "workbox-broadcast-update": "^6.1.5",
+    "workbox-cacheable-response": "^6.1.5",
+    "workbox-core": "^6.1.5",
+    "workbox-expiration": "^6.1.5",
+    "workbox-google-analytics": "^6.1.5",
+    "workbox-navigation-preload": "^6.1.5",
+    "workbox-precaching": "^6.1.5",
+    "workbox-range-requests": "^6.1.5",
+    "workbox-recipes": "^6.1.5",
+    "workbox-routing": "^6.1.5",
+    "workbox-strategies": "^6.1.5",
+    "workbox-streams": "^6.1.5"
   },
   "engines": {
     "npm": "please-use-yarn",

--- a/packages/cypress/src/support/commands.ts
+++ b/packages/cypress/src/support/commands.ts
@@ -13,6 +13,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       deleteIDB(name: string): Promise<boolean>
+      clearServiceWorkers(): Promise<void>
       setSessionStorage(key: string, value: string): Promise<void>
       /** login with firebase credentials, optionally check ui login element updated*/
       login(
@@ -96,6 +97,26 @@ const attachCustomCommands = (Cypress: Cypress.Cypress) => {
         .its('sessionStorage')
         .invoke('getItem', key)
         .should('eq', value)
+    })
+  })
+
+  Cypress.Commands.add('clearServiceWorkers', () => {
+    cy.window().then((w) => {
+      cy.wrap('Clearing service workers').then(() => {
+        return new Cypress.Promise((resolve) => {
+          // if running production builds locally may also need to remove service workers between runs
+          if (w.navigator && navigator.serviceWorker) {
+            navigator.serviceWorker.getRegistrations().then((registrations) => {
+              registrations.forEach((registration) => {
+                registration.unregister()
+              })
+              resolve()
+            })
+          } else {
+            resolve()
+          }
+        })
+      })
     })
   })
 

--- a/packages/cypress/src/support/hooks.ts
+++ b/packages/cypress/src/support/hooks.ts
@@ -22,6 +22,7 @@ before(() => {
   Cypress.Promise.onPossiblyUnhandledRejection((error) => {
     throw error
   })
+  cy.clearServiceWorkers()
   // clear idb
   cy.deleteIDB('OneArmyCache')
   // cy.deleteIDB('firebaseLocalStorageDb')
@@ -63,6 +64,7 @@ afterEach(() => {
  * been added to the database
  */
 after(() => {
+  cy.clearServiceWorkers()
   cy.wrap('Clear DB').then({ timeout: 120000 }, () => {
     return new Cypress.Promise((resolve, reject) => {
       // force resolve in case of server issues (sometimes a bit flaky)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,12 +7,3 @@ initErrorHandler()
 export { useCommonStores }
 
 ReactDOM.render(<App />, document.getElementById('root') as HTMLElement)
-
-// Clean up any old service workers
-if (navigator.serviceWorker) {
-  navigator.serviceWorker.getRegistrations().then((registrations) => {
-    for (const registration of registrations) {
-      registration.unregister()
-    }
-  })
-}

--- a/src/pages/common/ServiceWorkerUpdateNotification/ServiceWorkerUpdateNotification.tsx
+++ b/src/pages/common/ServiceWorkerUpdateNotification/ServiceWorkerUpdateNotification.tsx
@@ -1,0 +1,48 @@
+import { memo, useEffect, useState } from 'react'
+
+import * as serviceWorkerRegistration from 'src/serviceWorkerRegistration'
+import { Prompt } from 'react-router'
+import { logger } from 'src/logger'
+
+/**
+ * Handle the registration and update of service worker
+ * When a new service worker is detected let it take control of the current page (skipWaiting)
+ * and refresh the page the next time the user attemps a navigation action
+ **/
+
+export const ServiceWorkerUpdateNotification = memo(() => {
+  const [reloadRequired, setReloadRequired] = useState(false)
+  const [swLoaded, setSWLoaded] = useState(false)
+
+  useEffect(() => {
+    if (!swLoaded) {
+      logger.debug('loading sw')
+      // register service worker, activating immediately (skipWaiting) and prompt reload
+      serviceWorkerRegistration.register({
+        handleSWControlling: () => {
+          logger.debug('new sw controlling')
+          setReloadRequired(true)
+        },
+        handleSWWaiting: (wb) => wb.messageSkipWaiting(),
+      })
+      setSWLoaded(true)
+    }
+  })
+
+  // If a new service worker has been loaded prevent route changes (which will use old sw assets)
+  // and force a page refresh instead when the user goes to navigate
+  return (
+    <>
+      <Prompt
+        when={reloadRequired}
+        message={(location) => {
+          // navigate to the target page, but via window navigation to reload the service worker
+          window.location.assign(location.pathname)
+          // allow the transition to proceed as normal (don't block the location assign)
+          return true
+        }}
+      />
+    </>
+  )
+})
+ServiceWorkerUpdateNotification.displayName = 'ServiceWorkerUpdateNotification'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { Analytics } from 'src/common/Analytics'
 import { NotFoundPage } from './NotFound/NotFound'
 import ScrollToTop from '../common/ScrollToTop'
 import Header from './common/Header/Header'
+import { ServiceWorkerUpdateNotification } from 'src/pages/common/ServiceWorkerUpdateNotification/ServiceWorkerUpdateNotification'
 import Main from 'src/pages/common/Layout/Main'
 import type { IPageMeta } from './PageList'
 import {
@@ -47,6 +48,7 @@ export class Routes extends React.Component<
         data-cy="page-container"
       >
         <BrowserRouter>
+          <ServiceWorkerUpdateNotification />
           <Analytics />
           {/* on page change scroll to top */}
           <ScrollToTop>

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,21 @@
+/// <reference lib="webworker" />
+/* eslint-disable no-restricted-globals */
+
+declare const self: ServiceWorkerGlobalScope
+
+// This variable must be present somewhere in your service worker file,
+// even if you decide not to use precaching. See https://cra.link/PWA
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _fullManifest = (self as any).__WB_MANIFEST
+
+self.addEventListener('install', (event: any) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+export {}

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,0 +1,113 @@
+// https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#clientsclaim
+import { logger } from './logger'
+import { Workbox } from 'workbox-window'
+
+// initial code adapted from create-react-app (v4)
+
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4.
+    window.location.hostname.match(
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
+    ),
+)
+
+interface RegisterSWCallback {
+  /** if waiting sw will not take control until notified to do so */
+  handleSWWaiting: (wb: Workbox) => void
+  /** when sw controlling page will likely need a reload */
+  handleSWControlling: () => void
+}
+
+export const register = (callback: RegisterSWCallback) => {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(
+      process.env.PUBLIC_URL as string,
+      window.location.href,
+    )
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+      return
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
+
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, callback)
+      } else {
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, callback)
+      }
+    })
+  }
+}
+
+/**
+ * Register a service worker (custom implementation)
+ * If existing service worker exists respond to waiting event
+ * adapted from https://developers.google.com/web/tools/workbox/guides/advanced-recipes
+ * alternate: https://redfin.engineering/how-to-fix-the-refresh-button-when-using-service-workers-a8e27af6df68
+ */
+const registerValidSW = (swUrl: string, callback: RegisterSWCallback) => {
+  const wb = new Workbox(swUrl)
+  wb.addEventListener('waiting', () => {
+    // only trigger controlling callback if previously waiting sw activated (i.e. not first ever load)
+    wb.addEventListener('controlling', () => {
+      callback.handleSWControlling()
+    })
+    callback.handleSWWaiting(wb)
+  })
+  wb.register()
+}
+
+const checkValidServiceWorker = (
+  swUrl: string,
+  callback: RegisterSWCallback,
+) => {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' },
+  })
+    .then((response) => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get('content-type')
+      if (
+        response.status === 404 ||
+        (contentType != null && contentType.indexOf('javascript') === -1)
+      ) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then((registration) => {
+          registration.unregister().then(() => {
+            window.location.reload()
+          })
+        })
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl, callback)
+      }
+    })
+    .catch(() => {
+      logger.info(
+        'No internet connection found. App is running in offline mode.',
+      )
+    })
+}
+
+export const unregister = () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        registration.unregister()
+      })
+      .catch((error) => {
+        logger.error(error.message)
+      })
+  }
+}

--- a/src/stores/Platform/platform.store.tsx
+++ b/src/stores/Platform/platform.store.tsx
@@ -1,0 +1,29 @@
+import { observable, action, makeObservable } from 'mobx'
+import type { RootStore } from '..'
+
+/*
+The platform store handles information related to the platform, such as update
+status of service workers
+*/
+
+type ISWStatus = 'updated' | 'success' | null
+
+export class PlatformStore {
+  @observable
+  public serviceWorkerStatus: ISWStatus
+  @observable
+  public registration: ServiceWorkerRegistration
+  // eslint-disable-next-line
+  constructor(rootStore: RootStore) {
+    makeObservable(this)
+  }
+
+  @action
+  public setServiceWorkerStatus(
+    status: ISWStatus,
+    registration: ServiceWorkerRegistration,
+  ) {
+    this.serviceWorkerStatus = status
+    this.registration = registration
+  }
+}

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -6,6 +6,7 @@ import { EventStore } from './Events/events.store'
 import { HowtoStore } from './Howto/howto.store'
 import { MapsStore } from './Maps/maps.store'
 import { MobileMenuStore } from './MobileMenu/mobilemenu.store'
+import { PlatformStore } from './Platform/platform.store'
 import { ResearchCategoriesStore } from './ResearchCategories/researchCategories.store'
 import { TagsStore } from './Tags/tags.store'
 import { ThemeStore } from './Theme/theme.store'
@@ -32,6 +33,7 @@ const stores = (rootStore: RootStore) => {
     tagsStore: new TagsStore(rootStore),
     categoriesStore: new CategoriesStore(rootStore),
     researchCategoriesStore: new ResearchCategoriesStore(rootStore),
+    platformStore: new PlatformStore(rootStore),
     mobileMenuStore: new MobileMenuStore(rootStore),
     eventStore: new EventStore(rootStore),
     mapsStore: new MapsStore(rootStore),
@@ -48,6 +50,7 @@ export interface IStores {
   tagsStore: TagsStore
   categoriesStore: CategoriesStore
   researchCategoriesStore: ResearchCategoriesStore
+  platformStore: PlatformStore
   mobileMenuStore: MobileMenuStore
   eventStore: EventStore
   mapsStore: MapsStore

--- a/yarn.lock
+++ b/yarn.lock
@@ -25402,6 +25402,20 @@ __metadata:
     typescript: 4.5.5
     wait-on: ^5.2.1
     web-vitals: ^1.1.2
+    workbox-background-sync: ^6.1.5
+    workbox-broadcast-update: ^6.1.5
+    workbox-cacheable-response: ^6.1.5
+    workbox-core: ^6.1.5
+    workbox-expiration: ^6.1.5
+    workbox-google-analytics: ^6.1.5
+    workbox-navigation-preload: ^6.1.5
+    workbox-precaching: ^6.1.5
+    workbox-range-requests: ^6.1.5
+    workbox-recipes: ^6.1.5
+    workbox-routing: ^6.1.5
+    workbox-strategies: ^6.1.5
+    workbox-streams: ^6.1.5
+    workbox-window: ^6.1.5
     yup: ^0.32.9
   languageName: unknown
   linkType: soft
@@ -34144,7 +34158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-background-sync@npm:6.5.4":
+"workbox-background-sync@npm:6.5.4, workbox-background-sync@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-background-sync@npm:6.5.4"
   dependencies:
@@ -34154,7 +34168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-broadcast-update@npm:6.5.4":
+"workbox-broadcast-update@npm:6.5.4, workbox-broadcast-update@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-broadcast-update@npm:6.5.4"
   dependencies:
@@ -34208,7 +34222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-cacheable-response@npm:6.5.4":
+"workbox-cacheable-response@npm:6.5.4, workbox-cacheable-response@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-cacheable-response@npm:6.5.4"
   dependencies:
@@ -34217,14 +34231,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-core@npm:6.5.4":
+"workbox-core@npm:6.5.4, workbox-core@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-core@npm:6.5.4"
   checksum: d973cc6c1c5fdbde7f6642632384c2e0de48f08228eb234db2c97a18a7e5422b483005767e7b447ea774abc0772dfc1edef2ef2b5df174df4d40ae61d4c49719
   languageName: node
   linkType: hard
 
-"workbox-expiration@npm:6.5.4":
+"workbox-expiration@npm:6.5.4, workbox-expiration@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-expiration@npm:6.5.4"
   dependencies:
@@ -34234,7 +34248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-google-analytics@npm:6.5.4":
+"workbox-google-analytics@npm:6.5.4, workbox-google-analytics@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-google-analytics@npm:6.5.4"
   dependencies:
@@ -34246,7 +34260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-navigation-preload@npm:6.5.4":
+"workbox-navigation-preload@npm:6.5.4, workbox-navigation-preload@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-navigation-preload@npm:6.5.4"
   dependencies:
@@ -34255,7 +34269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-precaching@npm:6.5.4":
+"workbox-precaching@npm:6.5.4, workbox-precaching@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-precaching@npm:6.5.4"
   dependencies:
@@ -34266,7 +34280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-range-requests@npm:6.5.4":
+"workbox-range-requests@npm:6.5.4, workbox-range-requests@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-range-requests@npm:6.5.4"
   dependencies:
@@ -34275,7 +34289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-recipes@npm:6.5.4":
+"workbox-recipes@npm:6.5.4, workbox-recipes@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-recipes@npm:6.5.4"
   dependencies:
@@ -34289,7 +34303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-routing@npm:6.5.4":
+"workbox-routing@npm:6.5.4, workbox-routing@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-routing@npm:6.5.4"
   dependencies:
@@ -34298,7 +34312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-strategies@npm:6.5.4":
+"workbox-strategies@npm:6.5.4, workbox-strategies@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-strategies@npm:6.5.4"
   dependencies:
@@ -34307,7 +34321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-streams@npm:6.5.4":
+"workbox-streams@npm:6.5.4, workbox-streams@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-streams@npm:6.5.4"
   dependencies:
@@ -34339,7 +34353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-window@npm:6.5.4":
+"workbox-window@npm:6.5.4, workbox-window@npm:^6.1.5":
   version: 6.5.4
   resolution: "workbox-window@npm:6.5.4"
   dependencies:


### PR DESCRIPTION
This reverts commit 545f80481b3ead992603a031bed39bba79310495.

PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Introduces almost completely empty Service Worker script to remove all functionality. This is necessary because simply deleting the service worker file may not lead to the expected behaviour for all clients. Some browsers may not know that the file is meant to be gone and will continue serving the old service worker from their HTTP cache.