### PR TITLE
feat: introduce content modified timestamp

### DIFF
--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -51,10 +51,7 @@ export const notifyEventAccepted = functions.firestore
   .document('v3_events/{id}')
   .onUpdate(async (change, context) => {
     const info = change.after.exists ? change.after.data() : null
-    const prevInfo = change.before.exists ? change.before.data() : null
-    const previouslyAccepted = prevInfo?.moderation === 'accepted'
-    const shouldNotify = info.moderation === 'accepted' && !previouslyAccepted
-    if (!shouldNotify) {
+    if (info === null || info.moderation !== 'accepted') {
       return null
     }
 

--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -51,9 +51,13 @@ export const notifyEventAccepted = functions.firestore
   .document('v3_events/{id}')
   .onUpdate(async (change, context) => {
     const info = change.after.exists ? change.after.data() : null
-    if (info === null || info.moderation !== 'accepted') {
+    const prevInfo = change.before.exists ? change.before.data() : null
+    const previouslyAccepted = prevInfo?.moderation === 'accepted'
+    const shouldNotify = info.moderation === 'accepted' && !previouslyAccepted
+    if (!shouldNotify) {
       return null
     }
+
     const user = info._createdBy
     const url = info.url
     const location = info.location.country

--- a/functions/src/database/index.ts
+++ b/functions/src/database/index.ts
@@ -1,0 +1,1 @@
+exports.updates = require('./updates')

--- a/functions/src/database/updates.ts
+++ b/functions/src/database/updates.ts
@@ -1,0 +1,142 @@
+import * as functions from 'firebase-functions'
+import { DB_ENDPOINTS } from '../models'
+import { db } from '../Firebase/firestoreDB'
+
+let batch = db.batch()
+const BATCH_SIZE = 200
+let BATCH_COUNT = 0
+const operations = { updated: [], skipped: [] }
+
+/**
+ * One-off script to set lastEditTimestamp for all docs
+ * Once run this code will be deprecated, but retained for future reference
+ */
+export const lastEditTimestamp = functions.https.onCall(
+  async (dryRun: boolean, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'The function must be called while authenticated.',
+      )
+    }
+
+    const logPrefix = dryRun ? '[DRY RUN] ' : ''
+
+    try {
+      functions.logger.info(`${logPrefix}Starting lastEditTimestamp Setting`)
+
+      const howtoUpdates = []
+      const researchUpdates = []
+      const eventUpdates = []
+      const howtos = await db.collection(DB_ENDPOINTS.howtos).get()
+      const research = await db.collection(DB_ENDPOINTS.research).get()
+      const events = await db.collection(DB_ENDPOINTS.events).get()
+
+      if (!howtos.empty) {
+        // Get howto updates
+        howtos.forEach((ht) => {
+          const data = ht.data()
+          howtoUpdates.push({ id: ht.id, _lastEditTimestamp: data._modified })
+        })
+        await batchGeneration(howtoUpdates, 'howtos', dryRun, logPrefix)
+      }
+
+      if (!research.empty) {
+        functions.logger.info(`${logPrefix}Research: ${research.docs.length}`)
+        // Get research updates
+        research.forEach((r) => {
+          const data = r.data()
+          const latestUpdate = data.updates
+            ? data.updates[data.updates.length - 1]
+            : null
+          researchUpdates.push({
+            id: r.id,
+            _lastEditTimestamp: latestUpdate
+              ? latestUpdate._created
+              : data._modified,
+          })
+        })
+        functions.logger.info(`${logPrefix}Starting research batch generation`)
+        await batchGeneration(researchUpdates, 'research', dryRun, logPrefix)
+      }
+
+      if (!events.empty) {
+        functions.logger.info(`${logPrefix}Events: ${events.docs.length}`)
+        // Get event updates
+        events.forEach((e) => {
+          const data = e.data()
+          eventUpdates.push({ id: e.id, _lastEditTimestamp: data._modified })
+        })
+        functions.logger.info(`${logPrefix}Starting event batch generation`)
+        await batchGeneration(eventUpdates, 'events', dryRun, logPrefix)
+      }
+
+      return {
+        _dryRun: dryRun,
+        operations,
+        meta: {
+          howtoUpdates: howtoUpdates,
+          researchUpdates: researchUpdates,
+          eventUpdates: eventUpdates,
+        },
+      }
+    } catch (error) {
+      console.error(error)
+      throw new functions.https.HttpsError(
+        'internal',
+        'There was an error setting last edit timestamps.',
+      )
+    }
+  },
+)
+
+async function batchGeneration(
+  updateData: Record<string, any>[],
+  collection: 'events' | 'howtos' | 'research',
+  dryRun: boolean,
+  logPrefix: string,
+) {
+  functions.logger.info(
+    `${logPrefix}Starting batch generation for ${updateData.length} ${collection}`,
+  )
+  for (let i = 0; i < updateData.length; i++) {
+    const update = updateData[i]
+    try {
+      const ref = db.collection(DB_ENDPOINTS[collection]).doc(update.id)
+      batch.update(ref, update)
+      operations.updated.push({ ...update })
+
+      BATCH_COUNT++
+      // Commit batch in chunks to ensure firebase limits not hit
+      if (BATCH_COUNT === BATCH_SIZE && !dryRun) {
+        functions.logger.info(
+          `${logPrefix}Committing a batch of ${collection} updates`,
+        )
+        await batch.commit()
+        await _sleep(1000)
+        batch = db.batch()
+        BATCH_COUNT = 0
+      }
+    } catch (error) {
+      functions.logger.info(
+        `${logPrefix}Batch update failed for ${collection}: ${JSON.stringify(
+          update,
+        )}`,
+      )
+      operations.skipped.push({ ...update })
+    }
+  }
+
+  if (BATCH_COUNT > 0 && !dryRun) {
+    functions.logger.info(
+      `${logPrefix}Committing a batch of ${collection} updates`,
+    )
+    await batch.commit()
+    batch = db.batch()
+    BATCH_COUNT = 0
+  }
+}
+
+function _sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/functions/src/database/updates.ts
+++ b/functions/src/database/updates.ts
@@ -132,9 +132,10 @@ async function batchGeneration(
       `${logPrefix}Committing a batch of ${collection} updates`,
     )
     await batch.commit()
-    batch = db.batch()
-    BATCH_COUNT = 0
+    await _sleep(1000)
   }
+  batch = db.batch()
+  BATCH_COUNT = 0
 }
 
 function _sleep(ms: number) {

--- a/functions/src/database/updates.ts
+++ b/functions/src/database/updates.ts
@@ -23,7 +23,9 @@ export const contentModifiedTimestamp = functions.https.onCall(
     const logPrefix = dryRun ? '[DRY RUN] ' : ''
 
     try {
-      functions.logger.info(`${logPrefix}Starting contentModfiedTimestamp Setting`)
+      functions.logger.info(
+        `${logPrefix}Starting contentModifiedTimestamp Setting`,
+      )
 
       const howtoUpdates = []
       const researchUpdates = []

--- a/functions/src/database/updates.ts
+++ b/functions/src/database/updates.ts
@@ -8,10 +8,10 @@ let BATCH_COUNT = 0
 const operations = { updated: [], skipped: [] }
 
 /**
- * One-off script to set lastEditTimestamp for all docs
+ * One-off script to set contentModifiedTimestamp for all docs
  * Once run this code will be deprecated, but retained for future reference
  */
-export const lastEditTimestamp = functions.https.onCall(
+export const contentModifiedTimestamp = functions.https.onCall(
   async (dryRun: boolean, context) => {
     if (!context.auth) {
       throw new functions.https.HttpsError(
@@ -23,7 +23,7 @@ export const lastEditTimestamp = functions.https.onCall(
     const logPrefix = dryRun ? '[DRY RUN] ' : ''
 
     try {
-      functions.logger.info(`${logPrefix}Starting lastEditTimestamp Setting`)
+      functions.logger.info(`${logPrefix}Starting contentModfiedTimestamp Setting`)
 
       const howtoUpdates = []
       const researchUpdates = []
@@ -36,7 +36,10 @@ export const lastEditTimestamp = functions.https.onCall(
         // Get howto updates
         howtos.forEach((ht) => {
           const data = ht.data()
-          howtoUpdates.push({ id: ht.id, _lastEditTimestamp: data._modified })
+          howtoUpdates.push({
+            id: ht.id,
+            _contentModifiedTimestamp: data._modified,
+          })
         })
         await batchGeneration(howtoUpdates, 'howtos', dryRun, logPrefix)
       }
@@ -51,7 +54,7 @@ export const lastEditTimestamp = functions.https.onCall(
             : null
           researchUpdates.push({
             id: r.id,
-            _lastEditTimestamp: latestUpdate
+            _contentModifiedTimestamp: latestUpdate
               ? latestUpdate._created
               : data._modified,
           })
@@ -65,7 +68,10 @@ export const lastEditTimestamp = functions.https.onCall(
         // Get event updates
         events.forEach((e) => {
           const data = e.data()
-          eventUpdates.push({ id: e.id, _lastEditTimestamp: data._modified })
+          eventUpdates.push({
+            id: e.id,
+            _contentModifiedTimestamp: data._modified,
+          })
         })
         functions.logger.info(`${logPrefix}Starting event batch generation`)
         await batchGeneration(eventUpdates, 'events', dryRun, logPrefix)

--- a/functions/src/emulator/seed/content-generate.ts
+++ b/functions/src/emulator/seed/content-generate.ts
@@ -23,7 +23,7 @@ async function setMockHowto(user: IMockAuthUser) {
     _id,
     _created: new Date().toISOString(),
     _modified: new Date().toISOString(),
-    _lastEditTimestamp: new Date().toISOString(),
+    _contentModifiedTimestamp: new Date().toISOString(),
     _deleted: false,
     _createdBy: uid,
     cover_image: {

--- a/functions/src/emulator/seed/content-generate.ts
+++ b/functions/src/emulator/seed/content-generate.ts
@@ -23,6 +23,7 @@ async function setMockHowto(user: IMockAuthUser) {
     _id,
     _created: new Date().toISOString(),
     _modified: new Date().toISOString(),
+    _lastEditTimestamp: new Date().toISOString(),
     _deleted: false,
     _createdBy: uid,
     cover_image: {

--- a/functions/src/emulator/seed/users-create.ts
+++ b/functions/src/emulator/seed/users-create.ts
@@ -38,7 +38,7 @@ export async function seedUsersCreate() {
       _id: uid,
       _created: '2022-01-30T18:51:57.719Z',
       _modified: '2022-01-30T18:51:57.719Z',
-      _lastEditTimestamp: '2022-01-30T18:51:57.719Z',
+      _contentModifiedTimestamp: '2022-01-30T18:51:57.719Z',
       _deleted: false,
       displayName: user.label,
       userName: uid,

--- a/functions/src/emulator/seed/users-create.ts
+++ b/functions/src/emulator/seed/users-create.ts
@@ -38,6 +38,7 @@ export async function seedUsersCreate() {
       _id: uid,
       _created: '2022-01-30T18:51:57.719Z',
       _modified: '2022-01-30T18:51:57.719Z',
+      _lastEditTimestamp: '2022-01-30T18:51:57.719Z',
       _deleted: false,
       displayName: user.label,
       userName: uid,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,8 @@ exports.stats = require('./stats')
 
 exports.aggregations = require('./aggregations')
 
+exports.database = require('./database')
+
 exports.userUpdates = UserUpdates.handleUserUpdates
 // CC Note, 2020-04-40
 // folder-based naming conventions should be encourage from now on

--- a/src/modules/admin/pages/adminDatabase.tsx
+++ b/src/modules/admin/pages/adminDatabase.tsx
@@ -13,7 +13,9 @@ const AdminDB = observer(() => {
     updateRecords.howtoUpdates.map((howto) => (
       <li key={howto.id}>
         {howto.id}{' '}
-        {howto._lastEditTimestamp ? ' - ' + howto._lastEditTimestamp : ''}
+        {howto._contentModifiedTimestamp
+          ? ' - ' + howto._contentModifiedTimestamp
+          : ''}
         {howto.votedUseful && (
           <ul>
             {howto.votedUseful.map((vote) => (
@@ -31,7 +33,9 @@ const AdminDB = observer(() => {
     updateRecords.researchUpdates.map((research) => (
       <li key={research.id}>
         {research.id}{' '}
-        {research._lastEditTimestamp ? ' - ' + research._lastEditTimestamp : ''}
+        {research.__contentModifiedTimestamp
+          ? ' - ' + research._contentModifiedTimestamp
+          : ''}
         {research.votedUseful && (
           <ul>
             {research.votedUseful.map((vote) => (
@@ -48,7 +52,9 @@ const AdminDB = observer(() => {
     updateRecords.eventUpdates.map((event) => (
       <li key={event.id}>
         {event.id}{' '}
-        {event._lastEditTimestamp ? ' - ' + event._lastEditTimestamp : ''}
+        {event._contentModifiedTimestamp
+          ? ' - ' + event._contentModifiedTimestamp
+          : ''}
       </li>
     ))
   ) : (
@@ -80,11 +86,11 @@ const AdminDB = observer(() => {
     }
   }
 
-  const updateLastEditDryRun = async () => {
-    setUpdateState('Performing last edit timestamp dry run...')
+  const updateContentModifiedDryRun = async () => {
+    setUpdateState('Performing content modified timestamp dry run...')
     try {
       const operations = await functions.httpsCallable(
-        'database-updates-lastEditTimestamp',
+        'database-updates-contentModifiedTimestamp',
       )(true)
       setUpdateState('Dry run successful.')
       setUpdateRecords({ ...operations?.data?.meta })
@@ -92,16 +98,16 @@ const AdminDB = observer(() => {
       setUpdateState(`Error during dry run: \n ${error}`)
     }
   }
-  const updateLastEdit = async () => {
-    setUpdateState('Setting last edit timestamps...')
+  const updateContentModified = async () => {
+    setUpdateState('Setting content modified timestamps...')
     try {
       const operations = await functions.httpsCallable(
-        'database-updates-lastEditTimestamp',
+        'database-updates-contentModifiedTimestamp',
       )(false)
-      setUpdateState('Last edit timestamps set successfully.')
+      setUpdateState('Content modified timestamps set successfully.')
       setUpdateRecords({ ...operations?.data?.meta })
     } catch (error) {
-      setUpdateState(`Error setting last edit timestamps: \n ${error}`)
+      setUpdateState(`Error setting content modified timestamps: \n ${error}`)
     }
   }
 
@@ -111,14 +117,20 @@ const AdminDB = observer(() => {
       <Flex mb={6} sx={{ flexDirection: 'column' }}>
         <Flex mb={4} sx={{ flexDirection: 'column' }}>
           <Heading mb={2} variant="small" color={'black'}>
-            Set last edit timestamps
+            Set content modified timestamps
           </Heading>
           <Flex sx={{ flexDirection: 'row' }}>
-            <Button sx={{ marginRight: '10px' }} onClick={updateLastEditDryRun}>
-              Dry run setting last edit timestamps
+            <Button
+              sx={{ marginRight: '10px' }}
+              onClick={updateContentModifiedDryRun}
+            >
+              Dry run setting content modified timestamps
             </Button>
-            <Button sx={{ marginRight: '10px' }} onClick={updateLastEdit}>
-              Set last edit timestamps
+            <Button
+              sx={{ marginRight: '10px' }}
+              onClick={updateContentModified}
+            >
+              Set content modified timestamps
             </Button>
             {triggerUpdateState && <p>{triggerUpdateState}</p>}
           </Flex>

--- a/src/modules/admin/pages/adminDatabase.tsx
+++ b/src/modules/admin/pages/adminDatabase.tsx
@@ -1,40 +1,54 @@
 import { observer } from 'mobx-react'
 import { useState } from 'react'
-import { Button, Flex } from 'theme-ui'
+import { Button, Flex, Heading } from 'theme-ui'
 
 import { functions } from 'src/utils/firebase'
 
 const AdminDB = observer(() => {
   const [triggerMigrationState, setMigrationState] = useState<string>('')
+  const [triggerUpdateState, setUpdateState] = useState<string>('')
+  const [updateRecords, setUpdateRecords] = useState<Record<string, any>>({})
 
-  const [migrationRecords, setMigrationRecords] = useState<Record<string, any>>(
-    {},
-  )
-
-  const howtoList = migrationRecords.howtoUpdates ? (
-    migrationRecords.howtoUpdates.map((howto) => (
+  const howtoList = updateRecords.howtoUpdates ? (
+    updateRecords.howtoUpdates.map((howto) => (
       <li key={howto.id}>
-        {howto.id}
-        <ul>
-          {howto.votedUseful.map((vote) => (
-            <li key={howto.id + '-' + vote}>{vote}</li>
-          ))}
-        </ul>
+        {howto.id}{' '}
+        {howto._lastEditTimestamp ? ' - ' + howto._lastEditTimestamp : ''}
+        {howto.votedUseful && (
+          <ul>
+            {howto.votedUseful.map((vote) => (
+              <li key={howto.id + '-' + vote}>{vote}</li>
+            ))}
+          </ul>
+        )}
       </li>
     ))
   ) : (
     <></>
   )
 
-  const researchList = migrationRecords.researchUpdates ? (
-    migrationRecords.researchUpdates.map((research) => (
+  const researchList = updateRecords.researchUpdates ? (
+    updateRecords.researchUpdates.map((research) => (
       <li key={research.id}>
-        {research.id}
-        <ul>
-          {research.votedUseful.map((vote) => (
-            <li key={research.id + '-' + vote}>{vote}</li>
-          ))}
-        </ul>
+        {research.id}{' '}
+        {research._lastEditTimestamp ? ' - ' + research._lastEditTimestamp : ''}
+        {research.votedUseful && (
+          <ul>
+            {research.votedUseful.map((vote) => (
+              <li key={research.id + '-' + vote}>{vote}</li>
+            ))}
+          </ul>
+        )}
+      </li>
+    ))
+  ) : (
+    <></>
+  )
+  const eventList = updateRecords.eventUpdates ? (
+    updateRecords.eventUpdates.map((event) => (
+      <li key={event.id}>
+        {event.id}{' '}
+        {event._lastEditTimestamp ? ' - ' + event._lastEditTimestamp : ''}
       </li>
     ))
   ) : (
@@ -48,7 +62,7 @@ const AdminDB = observer(() => {
         'aggregations-migrate-userUseful',
       )(true)
       setMigrationState('Dry run successful.')
-      setMigrationRecords({ ...operations?.data?.meta })
+      setUpdateRecords({ ...operations?.data?.meta })
     } catch (error) {
       setMigrationState(`Error during dry run: \n ${error}`)
     }
@@ -60,23 +74,70 @@ const AdminDB = observer(() => {
         'aggregations-migrate-userUseful',
       )(false)
       setMigrationState('Migration successful.')
-      setMigrationRecords({ ...operations?.data?.meta })
+      setUpdateRecords({ ...operations?.data?.meta })
     } catch (error) {
       setMigrationState(`Error migrating useful: \n ${error}`)
+    }
+  }
+
+  const updateLastEditDryRun = async () => {
+    setUpdateState('Performing last edit timestamp dry run...')
+    try {
+      const operations = await functions.httpsCallable(
+        'database-updates-lastEditTimestamp',
+      )(true)
+      setUpdateState('Dry run successful.')
+      setUpdateRecords({ ...operations?.data?.meta })
+    } catch (error) {
+      setUpdateState(`Error during dry run: \n ${error}`)
+    }
+  }
+  const updateLastEdit = async () => {
+    setUpdateState('Setting last edit timestamps...')
+    try {
+      const operations = await functions.httpsCallable(
+        'database-updates-lastEditTimestamp',
+      )(false)
+      setUpdateState('Last edit timestamps set successfully.')
+      setUpdateRecords({ ...operations?.data?.meta })
+    } catch (error) {
+      setUpdateState(`Error setting last edit timestamps: \n ${error}`)
     }
   }
 
   return (
     <>
       <h2>Database Operations</h2>
-      <Flex>
-        <Button sx={{ marginRight: '10px' }} onClick={migrateUsefulDryRun}>
-          Dry run migrate user useful
-        </Button>
-        <Button sx={{ marginRight: '10px' }} onClick={migrateUseful}>
-          Migrate user useful
-        </Button>
-        {triggerMigrationState && <p>{triggerMigrationState}</p>}
+      <Flex mb={6} sx={{ flexDirection: 'column' }}>
+        <Flex mb={4} sx={{ flexDirection: 'column' }}>
+          <Heading mb={2} variant="small" color={'black'}>
+            Set last edit timestamps
+          </Heading>
+          <Flex sx={{ flexDirection: 'row' }}>
+            <Button sx={{ marginRight: '10px' }} onClick={updateLastEditDryRun}>
+              Dry run setting last edit timestamps
+            </Button>
+            <Button sx={{ marginRight: '10px' }} onClick={updateLastEdit}>
+              Set last edit timestamps
+            </Button>
+            {triggerUpdateState && <p>{triggerUpdateState}</p>}
+          </Flex>
+        </Flex>
+
+        <Flex sx={{ flexDirection: 'column' }}>
+          <Heading mb={2} variant="small" color={'black'}>
+            Migrate user useful
+          </Heading>
+          <Flex sx={{ flexDirection: 'row' }}>
+            <Button sx={{ marginRight: '10px' }} onClick={migrateUsefulDryRun}>
+              Dry run migrate user useful
+            </Button>
+            <Button sx={{ marginRight: '10px' }} onClick={migrateUseful}>
+              Migrate user useful
+            </Button>
+            {triggerMigrationState && <p>{triggerMigrationState}</p>}
+          </Flex>
+        </Flex>
       </Flex>
 
       <Flex
@@ -86,18 +147,31 @@ const AdminDB = observer(() => {
           wordWrap: 'break-word',
         }}
       >
-        {migrationRecords.howtoUpdates && (
-          <Flex sx={{ flexDirection: 'column', width: '50%' }}>
-            <h3>How-to Migrations - {migrationRecords.howtoUpdates.length}</h3>
+        {updateRecords.howtoUpdates && (
+          <Flex sx={{ flexDirection: 'column', width: '33%' }}>
+            <h3>
+              How-to {triggerMigrationState != '' ? 'Migrations' : 'Updates'} -{' '}
+              {updateRecords.howtoUpdates.length}
+            </h3>
             <ul>{howtoList}</ul>
           </Flex>
         )}
-        {migrationRecords.researchUpdates && (
-          <Flex sx={{ flexDirection: 'column', width: '50%' }}>
+        {updateRecords.researchUpdates && (
+          <Flex sx={{ flexDirection: 'column', width: '33%' }}>
             <h3>
-              Research Migrations - {migrationRecords.researchUpdates.length}
+              Research {triggerMigrationState != '' ? 'Migrations' : 'Updates'}{' '}
+              - {updateRecords.researchUpdates.length}
             </h3>
             <ul>{researchList}</ul>
+          </Flex>
+        )}
+        {updateRecords.eventUpdates && (
+          <Flex sx={{ flexDirection: 'column', width: '33%' }}>
+            <h3>
+              Event {triggerMigrationState != '' ? 'Migrations' : 'Updates'} -{' '}
+              {updateRecords.eventUpdates.length}
+            </h3>
+            <ul>{eventList}</ul>
           </Flex>
         )}
       </Flex>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -90,7 +90,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
 
   const dateLastEditText = (howto: IHowtoDB): string => {
     const lastEditDate = format(
-      new Date(howto._lastEditTimestamp),
+      new Date(howto._contentModifiedTimestamp),
       'DD-MM-YYYY',
     )
     const creationDate = format(new Date(howto._created), 'DD-MM-YYYY')

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -89,10 +89,13 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
   }
 
   const dateLastEditText = (howto: IHowtoDB): string => {
-    const lastModifiedDate = format(new Date(howto._modified), 'DD-MM-YYYY')
+    const lastEditDate = format(
+      new Date(howto._lastEditTimestamp),
+      'DD-MM-YYYY',
+    )
     const creationDate = format(new Date(howto._created), 'DD-MM-YYYY')
-    if (lastModifiedDate !== creationDate) {
-      return 'Last edit on ' + format(new Date(howto._modified), 'DD-MM-YYYY')
+    if (lastEditDate !== creationDate) {
+      return `Last edit on ${lastEditDate}`
     } else {
       return ''
     }

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -88,14 +88,14 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
     }
   }
 
-  const dateLastEditText = (howto: IHowtoDB): string => {
-    const lastEditDate = format(
-      new Date(howto._contentModifiedTimestamp),
+  const dateContentModifiedText = (howto: IHowtoDB): string => {
+    const contentModifiedDate = format(
+      new Date(howto._contentModifiedTimestamp || howto._modified),
       'DD-MM-YYYY',
     )
     const creationDate = format(new Date(howto._created), 'DD-MM-YYYY')
-    if (lastEditDate !== creationDate) {
-      return `Last edit on ${lastEditDate}`
+    if (contentModifiedDate !== creationDate) {
+      return `Last edit on ${contentModifiedDate}`
     } else {
       return ''
     }
@@ -211,7 +211,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             mt={1}
             mb={2}
           >
-            {dateLastEditText(howto)}
+            {dateContentModifiedText(howto)}
           </Text>
           <Heading mt={2} mb={1}>
             {/* HACK 2021-07-16 - new howtos auto capitalize title but not older */}

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -36,10 +36,13 @@ interface IProps {
 
 const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
   const dateLastUpdateText = (research: IResearch.ItemDB): string => {
-    const lastModifiedDate = format(new Date(research._modified), 'DD-MM-YYYY')
+    const lastEditDate = format(
+      new Date(research._lastEditTimestamp),
+      'DD-MM-YYYY',
+    )
     const creationDate = format(new Date(research._created), 'DD-MM-YYYY')
-    if (lastModifiedDate !== creationDate) {
-      return 'Last update on ' + lastModifiedDate
+    if (lastEditDate !== creationDate) {
+      return `Last update on ${lastEditDate}`
     } else {
       return ''
     }

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -37,7 +37,7 @@ interface IProps {
 const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
   const dateLastUpdateText = (research: IResearch.ItemDB): string => {
     const lastEditDate = format(
-      new Date(research._lastEditTimestamp),
+      new Date(research._contentModifiedTimestamp),
       'DD-MM-YYYY',
     )
     const creationDate = format(new Date(research._created), 'DD-MM-YYYY')

--- a/src/pages/Research/Content/ResearchDescription.tsx
+++ b/src/pages/Research/Content/ResearchDescription.tsx
@@ -36,13 +36,13 @@ interface IProps {
 
 const ResearchDescription = ({ research, isEditable, ...props }: IProps) => {
   const dateLastUpdateText = (research: IResearch.ItemDB): string => {
-    const lastEditDate = format(
-      new Date(research._contentModifiedTimestamp),
+    const contentModifiedDate = format(
+      new Date(research._contentModifiedTimestamp || research._modified),
       'DD-MM-YYYY',
     )
     const creationDate = format(new Date(research._created), 'DD-MM-YYYY')
-    if (lastEditDate !== creationDate) {
-      return `Last update on ${lastEditDate}`
+    if (contentModifiedDate !== creationDate) {
+      return `Last update on ${contentModifiedDate}`
     } else {
       return ''
     }

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -188,11 +188,11 @@ const ResearchListItem = ({ item }: IProps) => {
 }
 
 const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
-  const lastModifiedDate = format(new Date(item._modified), 'DD-MM-YYYY')
+  const lastEditDate = format(new Date(item._lastEditTimestamp), 'DD-MM-YYYY')
   const creationDate = format(new Date(item._created), 'DD-MM-YYYY')
 
-  if (lastModifiedDate !== creationDate) {
-    return variant === 'long' ? `Updated ${lastModifiedDate}` : lastModifiedDate
+  if (lastEditDate !== creationDate) {
+    return variant === 'long' ? `Updated ${lastEditDate}` : lastEditDate
   } else {
     return variant === 'long' ? `Created ${creationDate}` : creationDate
   }

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -188,7 +188,10 @@ const ResearchListItem = ({ item }: IProps) => {
 }
 
 const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
-  const lastEditDate = format(new Date(item._lastEditTimestamp), 'DD-MM-YYYY')
+  const lastEditDate = format(
+    new Date(item._contentModifiedTimestamp),
+    'DD-MM-YYYY',
+  )
   const creationDate = format(new Date(item._created), 'DD-MM-YYYY')
 
   if (lastEditDate !== creationDate) {

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -188,14 +188,16 @@ const ResearchListItem = ({ item }: IProps) => {
 }
 
 const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
-  const lastEditDate = format(
-    new Date(item._contentModifiedTimestamp),
+  const contentModifiedDate = format(
+    new Date(item._contentModifiedTimestamp || item._modified),
     'DD-MM-YYYY',
   )
   const creationDate = format(new Date(item._created), 'DD-MM-YYYY')
 
-  if (lastEditDate !== creationDate) {
-    return variant === 'long' ? `Updated ${lastEditDate}` : lastEditDate
+  if (contentModifiedDate !== creationDate) {
+    return variant === 'long'
+      ? `Updated ${contentModifiedDate}`
+      : contentModifiedDate
   } else {
     return variant === 'long' ? `Created ${creationDate}` : creationDate
   }

--- a/src/stores/Events/events.store.tsx
+++ b/src/stores/Events/events.store.tsx
@@ -118,7 +118,7 @@ export class EventStore extends ModuleStore {
         moderation: 'awaiting-moderation',
       }
       const doc = this.db.collection('events').doc()
-      return doc.set(event)
+      return doc.set(event, { set_last_edit_timestamp: true })
     } catch (error) {
       throw Error
     }

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -334,7 +334,10 @@ export class HowtoStore extends ModuleStore {
     }
   }
 
-  private async updateHowtoItem(howToItem: IHowto) {
+  private async updateHowtoItem(
+    howToItem: IHowto,
+    setLastEditTimestamp = false,
+  ) {
     const dbRef = this.db.collection<IHowto>(COLLECTION_NAME).doc(howToItem._id)
 
     logger.debug('updateHowtoItem', {
@@ -393,13 +396,16 @@ export class HowtoStore extends ModuleStore {
       howToItem.previousSlugs.push(howToItem.slug)
     }
 
-    await dbRef.set({
-      ...howToItem,
-      description,
-      comments,
-      mentions,
-      steps,
-    })
+    await dbRef.set(
+      {
+        ...howToItem,
+        description,
+        comments,
+        mentions,
+        steps,
+      },
+      { set_last_edit_timestamp: setLastEditTimestamp },
+    )
 
     // After successfully updating the database document queue up all the notifications
     // Should a notification be issued?
@@ -579,7 +585,7 @@ export class HowtoStore extends ModuleStore {
 
       logger.debug('populating database', howTo)
       // set the database document
-      this.activeHowto = await this.updateHowtoItem(howTo)
+      this.activeHowto = await this.updateHowtoItem(howTo, true)
       this.updateUploadStatus('Database')
       logger.debug('post added')
       // complete

--- a/src/stores/Maps/generatePins.tsx
+++ b/src/stores/Maps/generatePins.tsx
@@ -13,6 +13,7 @@ const MOCK_DB_META = (id?: string) => {
     _modified: d2.toISOString(),
     _deleted: false,
     _id: id ? id : randomID(),
+    _lastEditTimestamp: d2.toISOString(),
   }
   return meta
 }

--- a/src/stores/Maps/generatePins.tsx
+++ b/src/stores/Maps/generatePins.tsx
@@ -13,7 +13,7 @@ const MOCK_DB_META = (id?: string) => {
     _modified: d2.toISOString(),
     _deleted: false,
     _id: id ? id : randomID(),
-    _lastEditTimestamp: d2.toISOString(),
+    _contentModifiedTimestamp: d2.toISOString(),
   }
   return meta
 }

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -189,11 +189,9 @@ describe('research.store', () => {
         await store.addComment('fish', researchItem.updates[0])
 
         // Assert
-        expect(setFn).toHaveBeenCalledWith(
-          expect.objectContaining({
-            description: '@@{userId:username}',
-          }),
-        )
+        expect(setFn).toHaveBeenCalledTimes(1)
+        const [newResearchItem] = setFn.mock.calls[0]
+        expect(newResearchItem.description).toBe('@@{userId:username}')
       })
 
       it('preserves @mention within an Update description', async () => {

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -626,7 +626,7 @@ export class ResearchStore extends ModuleStore {
             _id: randomID(),
             _created: new Date().toISOString(),
             _modified: new Date().toISOString(),
-            _lastEditTimestamp: new Date().toISOString(),
+            _contentModifiedTimestamp: new Date().toISOString(),
             _deleted: false,
             comments: [],
           })

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -560,7 +560,11 @@ export class ResearchStore extends ModuleStore {
       }
       logger.debug('populating database', researchItem)
       // set the database document
-      const updatedItem = await this._updateResearchItem(dbRef, researchItem)
+      const updatedItem = await this._updateResearchItem(
+        dbRef,
+        researchItem,
+        true,
+      )
       this.updateResearchUploadStatus('Database')
       logger.debug('post added')
       if (updatedItem) {
@@ -622,6 +626,7 @@ export class ResearchStore extends ModuleStore {
             _id: randomID(),
             _created: new Date().toISOString(),
             _modified: new Date().toISOString(),
+            _lastEditTimestamp: new Date().toISOString(),
             _deleted: false,
             comments: [],
           })
@@ -642,7 +647,7 @@ export class ResearchStore extends ModuleStore {
         logger.debug('created:', newItem._created)
 
         // set the database document
-        await this._updateResearchItem(dbRef, newItem)
+        await this._updateResearchItem(dbRef, newItem, true)
         logger.debug('populate db ok')
         this.updateUpdateUploadStatus('Database')
         const createdItem = (await dbRef.get()) as IResearch.ItemDB
@@ -682,7 +687,7 @@ export class ResearchStore extends ModuleStore {
         newItem.updates[existingUpdateIndex]._deleted = true
 
         // set the database document
-        const updatedItem = await this._updateResearchItem(dbRef, newItem)
+        const updatedItem = await this._updateResearchItem(dbRef, newItem, true)
 
         if (updatedItem) {
           this.setActiveResearchItemBySlug(updatedItem.slug)
@@ -726,6 +731,7 @@ export class ResearchStore extends ModuleStore {
   private async _updateResearchItem(
     dbRef: DocReference<IResearch.Item>,
     researchItem: IResearch.Item,
+    setLastEditTimestamp = false,
   ) {
     const { text: researchDescription, users } = await this.addUserReference(
       researchItem.description,
@@ -793,11 +799,14 @@ export class ResearchStore extends ModuleStore {
       researchItem.previousSlugs.push(researchItem.slug)
     }
 
-    await dbRef.set({
-      ...cloneDeep(researchItem),
-      mentions,
-      description: researchDescription,
-    })
+    await dbRef.set(
+      {
+        ...cloneDeep(researchItem),
+        mentions,
+        description: researchDescription,
+      },
+      { set_last_edit_timestamp: setLastEditTimestamp },
+    )
 
     // Side effects from updating research item
     // consider moving these out of the store.

--- a/src/stores/databaseV2/DocReference.tsx
+++ b/src/stores/databaseV2/DocReference.tsx
@@ -126,7 +126,7 @@ export class DocReference<T> {
     }
 
     if (o.set_last_edit_timestamp)
-      meta._lastEditTimestamp = new Date().toISOString()
+      meta._contentModifiedTimestamp = new Date().toISOString()
 
     if (isDocUpdate) {
       delete meta._created

--- a/src/stores/databaseV2/types/index.d.ts
+++ b/src/stores/databaseV2/types/index.d.ts
@@ -32,6 +32,7 @@ export interface DBDoc {
   _created: ISODateString
   _modified: ISODateString
   _deleted: boolean
+  _lastEditTimestamp: ISODateString
 }
 
 export interface DBQueryOptions {

--- a/src/stores/databaseV2/types/index.d.ts
+++ b/src/stores/databaseV2/types/index.d.ts
@@ -32,7 +32,7 @@ export interface DBDoc {
   _created: ISODateString
   _modified: ISODateString
   _deleted: boolean
-  _lastEditTimestamp: ISODateString
+  _contentModifiedTimestamp: ISODateString
 }
 
 export interface DBQueryOptions {

--- a/src/test/factories/Howto.ts
+++ b/src/test/factories/Howto.ts
@@ -26,6 +26,7 @@ export const FactoryHowto = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
+  _lastEditTimestamp: faker.date.past().toString(),
   _createdBy: faker.internet.userName(),
   steps: [],
   mentions: [],

--- a/src/test/factories/Howto.ts
+++ b/src/test/factories/Howto.ts
@@ -26,7 +26,7 @@ export const FactoryHowto = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
-  _lastEditTimestamp: faker.date.past().toString(),
+  _contentModifiedTimestamp: faker.date.past().toString(),
   _createdBy: faker.internet.userName(),
   steps: [],
   mentions: [],

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -15,6 +15,7 @@ export const FactoryResearchItemUpdate = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
+  _lastEditTimestamp: faker.date.past().toString(),
   status: faker.helpers.arrayElement(['draft', 'published']),
   ...researchItemUpdateOverloads,
 })
@@ -27,6 +28,7 @@ export const FactoryResearchItem = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
+  _lastEditTimestamp: faker.date.past().toString(),
   description: faker.lorem.paragraphs(),
   title: faker.lorem.words(),
   slug: faker.lorem.slug(),

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -15,7 +15,7 @@ export const FactoryResearchItemUpdate = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
-  _lastEditTimestamp: faker.date.past().toString(),
+  _contentModifiedTimestamp: faker.date.past().toString(),
   status: faker.helpers.arrayElement(['draft', 'published']),
   ...researchItemUpdateOverloads,
 })
@@ -28,7 +28,7 @@ export const FactoryResearchItem = (
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
-  _lastEditTimestamp: faker.date.past().toString(),
+  _contentModifiedTimestamp: faker.date.past().toString(),
   description: faker.lorem.paragraphs(),
   title: faker.lorem.words(),
   slug: faker.lorem.slug(),

--- a/src/test/factories/User.ts
+++ b/src/test/factories/User.ts
@@ -9,7 +9,7 @@ export const FactoryUser = (
   _created: faker.date.past().toString(),
   _modified: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
-  _lastEditTimestamp: faker.date.past().toString(),
+  _contentModifiedTimestamp: faker.date.past().toString(),
   _authID: faker.datatype.uuid(),
   profileType: faker.helpers.arrayElement(Object.values(ProfileType)),
   userName: faker.internet.userName(),

--- a/src/test/factories/User.ts
+++ b/src/test/factories/User.ts
@@ -9,6 +9,7 @@ export const FactoryUser = (
   _created: faker.date.past().toString(),
   _modified: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
+  _lastEditTimestamp: faker.date.past().toString(),
   _authID: faker.datatype.uuid(),
   profileType: faker.helpers.arrayElement(Object.values(ProfileType)),
   userName: faker.internet.userName(),


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Implements a _lastEditTimestamp property to the document metadata which is only updated when a 'real' update/edit happens on a document.  The platform was using the modified date but as this is updated when someone comments or votes useful etc. it was leading to incorrect/misleading last edit/update dates being shown when viewing how-to's and research.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
