### PR TITLE
fix: update useful aggregation to only count useful from accepted docs

### DIFF
--- a/functions/src/aggregations/common.aggregations.ts
+++ b/functions/src/aggregations/common.aggregations.ts
@@ -127,6 +127,7 @@ export class AggregationHandler {
       const howtos = await db
         .collection(DB_ENDPOINTS.howtos)
         .where('votedUsefulBy', '!=', [])
+        .where('moderation', '==', 'accepted')
         .get()
 
       logger.info(`${targetAggregation} Howtos - ${howtos.docs.length}`)
@@ -142,6 +143,7 @@ export class AggregationHandler {
       const research = await db
         .collection(DB_ENDPOINTS.research)
         .where('votedUsefulBy', '!=', [])
+        .where('moderation', '==', 'accepted')
         .get()
 
       logger.info(
@@ -249,6 +251,7 @@ export class AggregationHandler {
       .collection(DB_ENDPOINTS.howtos)
       .where('_createdBy', '==', id)
       .where('votedUsefulBy', '!=', [])
+      .where('moderation', '==', 'accepted')
       .get()
 
     let totalUseful = 0
@@ -267,6 +270,7 @@ export class AggregationHandler {
       .collection(DB_ENDPOINTS.research)
       .where('_createdBy', '==', id)
       .where('votedUsefulBy', '!=', [])
+      .where('moderation', '==', 'accepted')
       .get()
 
     if (!createdResearch.empty) {
@@ -281,6 +285,7 @@ export class AggregationHandler {
       .collection(DB_ENDPOINTS.research)
       .where('collaborators', 'array-contains', id)
       .where('votedUsefulBy', '!=', [])
+      .where('moderation', '==', 'accepted')
       .get()
 
     if (!collaboratedResearch.empty) {

--- a/functions/src/aggregations/howto.aggregations.ts
+++ b/functions/src/aggregations/howto.aggregations.ts
@@ -10,7 +10,7 @@ interface IHowToAggregation extends IAggregation {
 const howtoAggregations: IHowToAggregation[] = [
   {
     sourceCollection: 'howtos',
-    sourceFields: ['votedUsefulBy'],
+    sourceFields: ['votedUsefulBy', 'moderation'],
     changeType: 'updated',
     targetCollection: 'aggregations',
     targetDocId: 'users_totalUseful',

--- a/functions/src/aggregations/research.aggregations.ts
+++ b/functions/src/aggregations/research.aggregations.ts
@@ -10,7 +10,7 @@ interface IResearchAggregation extends IAggregation {
 const researchAggregations: IResearchAggregation[] = [
   {
     sourceCollection: 'research',
-    sourceFields: ['votedUsefulBy', 'collaborators'],
+    sourceFields: ['votedUsefulBy', 'collaborators', 'moderation'],
     changeType: 'updated',
     targetCollection: 'aggregations',
     targetDocId: 'users_totalUseful',


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Useful aggregation was counting useful from how-to & research that was still awaiting moderation or rejected in the total count.  Updated so that only useful from accepted how-to/research is counted.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
