### PR TITLE
fix: remove use of theme from forgot password

### DIFF
--- a/src/pages/Password/ForgotPassword.tsx
+++ b/src/pages/Password/ForgotPassword.tsx
@@ -1,18 +1,8 @@
 import React from 'react'
-import { Card, Flex, Heading } from 'theme-ui'
-import styled from '@emotion/styled'
-// TODO: Remove direct usage of Theme
-import { preciousPlasticTheme } from 'oa-themes'
-const theme = preciousPlasticTheme.styles
+import { Card, Flex, Heading, Label } from 'theme-ui'
 import { Button, FieldInput } from 'oa-components'
 import { Form, Field } from 'react-final-form'
 import { logger } from 'workbox-core/_private'
-
-const Label = styled.label`
- font-size: ${theme.fontSizes[2] + 'px'}
- margin-bottom: ${theme.space[2] + 'px'}
- display: block;
-`
 
 interface IFormValues {
   email: string


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes direct usage of the theme object, replacing it with the `Label` component that is used on the signup screen

## Git Issues

Closes #2295

## Screenshots/Videos

Seems to be no visual diff to my eyes -

On master:
<img width="1435" alt="Screenshot 2023-06-20 at 10 38 19 PM" src="https://github.com/ONEARMY/community-platform/assets/13475443/98b4b0ea-797e-4819-8072-5a033b5efd09">

After:
<img width="1434" alt="Screenshot 2023-06-20 at 10 37 30 PM" src="https://github.com/ONEARMY/community-platform/assets/13475443/f69ca3d4-9b09-45c6-b3f3-63375fc49929">
