### PR TITLE
fix: add optimistic locking to research updates

### DIFF
--- a/src/models/common.models.tsx
+++ b/src/models/common.models.tsx
@@ -17,6 +17,10 @@ export type IModerationStatus =
   | 'rejected'
   | 'accepted'
 
+export interface ILockable {
+  lockVersion?: number
+}
+
 export interface IModerable {
   moderation: IModerationStatus
   _createdBy?: string

--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -1,6 +1,7 @@
 import type {
   DBDoc,
   IComment,
+  ILockable,
   IModerable,
   ISelectedTags,
   ISharedFeatures,
@@ -40,7 +41,7 @@ export namespace IResearch {
     status: 'draft' | 'published'
   }
 
-  export interface FormInput extends IModerable {
+  export interface FormInput extends ILockable, IModerable {
     title: string
     description: string
     researchCategory?: IResearchCategory


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Currently if there are 2 people editing the same research article, the person to save second will have their changes silently overwrite the first persons. This raises an error to notify that someone else has saved first

## Git Issues

Closes #2393

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

First save runs as expected

<img width="1428" alt="Screenshot 2023-06-21 at 11 45 38 PM" src="https://github.com/ONEARMY/community-platform/assets/13475443/c0b04963-01f9-4e83-8055-085a90874c3a">

This still needs a bit of work to surface it to users, but proof that it blocks the secondary update:

<img width="1437" alt="Screenshot 2023-06-21 at 11 45 47 PM" src="https://github.com/ONEARMY/community-platform/assets/13475443/66cb2288-99b1-4243-a59f-a83435213287">
