### PR TITLE
[refactor] Remove direct usage of Theme from "ImageInput.tsx"

### DIFF
--- a/src/common/Form/ImageInput/ImageInput.tsx
+++ b/src/common/Form/ImageInput/ImageInput.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react'
-import { Box, Image } from 'theme-ui'
-import styled from '@emotion/styled'
+import type { BoxProps, ThemeUIStyleObject } from 'theme-ui'
+import { Box, Flex, Image } from 'theme-ui'
 import { Button } from 'oa-components'
 import 'react-image-lightbox/style.css'
 import { ImageConverter } from './ImageConverter'
-// TODO: Remove direct usage of Theme
-import { preciousPlasticTheme } from 'oa-themes'
-const theme = preciousPlasticTheme.styles
 import Dropzone from 'react-dropzone'
 import type { IUploadedFileMeta } from '../../../stores/storage'
 import type { IConvertedFileMeta } from 'src/types'
@@ -15,44 +12,52 @@ interface ITitleProps {
   hasUploadedImg: boolean
 }
 
-const AlignCenterWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
-`
-// any export to fix: https://github.com/microsoft/TypeScript/issues/37597
-const ImageInputWrapper = styled(AlignCenterWrapper as any)<ITitleProps>`
-  position: relative;
-  height: 100%;
-  width: 100%;
-  border: ${(props) =>
-    props.hasUploadedImg ? 0 : `2px dashed ${theme.colors.background}`};
-  border-radius: ${theme.space[1]}px;
-  background-color: ${theme.colors.white};
-  cursor: pointer;
-`
+const alignCenterWrapperStyles: ThemeUIStyleObject = {
+  height: '100%',
+  width: '100%',
+  overflow: 'hidden',
+  justifyContent: 'center',
+  alignItems: 'center',
+}
 
-const UploadImageOverlay = styled(AlignCenterWrapper as any)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.2);
-  opacity:0;
-  visibility:hidden
-  transition: opacity 300ms ease-in;
-  border-radius: ${theme.space[1]}px;
-  
-  .image-input__wrapper:hover & {
-    visibility: visible;
-    opacity: 1;
-  }
-`
+// any export to fix: https://github.com/microsoft/TypeScript/issues/37597
+const ImageInputWrapper = (props: BoxProps & ITitleProps): JSX.Element => (
+  <Flex
+    sx={{
+      ...alignCenterWrapperStyles,
+      position: 'relative',
+      borderColor: 'background',
+      borderStyle: props.hasUploadedImg ? 'none' : 'dashed',
+      borderRadius: 1,
+      backgroundColor: 'white',
+    }}
+  >
+    {props.children}
+  </Flex>
+)
+
+const UploadImageOverlay = (props: BoxProps): JSX.Element => (
+  <Flex
+    sx={{
+      ...alignCenterWrapperStyles,
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.2)',
+      opacity: 0,
+      visibility: 'hidden',
+      transition: 'opacity 300ms ease-in',
+      borderRadius: 1,
+      '.image-input__wrapper:hover &': {
+        visibility: 'visible',
+        opacity: 1,
+      },
+    }}
+  >
+    {props.children}
+  </Flex>
+)
 
 /*
     This component takes multiple image using filepicker and resized clientside


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Implements the refactoring in #2285.

However, in converting the styled-components code to theme UI, I am not sure whether there is a better way of reusing styles, aside from defining a the base style object, then spreading it into the `sx` props.

## Git Issues

Closes #2285

## Screenshots/Videos

TODO, but the before/after looks the same to me. I could not get the overlay to activate because dropzone wouldn't work in dev mode.

Before


After
---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
