### PR TITLE
refactor: rename "yellow" variable to "accent"

### DIFF
--- a/packages/components/src/DownloadFiles/DownloadFiles.tsx
+++ b/packages/components/src/DownloadFiles/DownloadFiles.tsx
@@ -17,7 +17,7 @@ export const DownloadFiles = (props: DownloadFilesProps) => {
         p={2}
         mb={1}
         sx={{
-          background: 'yellow.base',
+          background: 'accent.base',
           border: '2px solid black',
           justifyContent: 'space-between',
           alignItems: 'center',

--- a/packages/components/src/FieldInput/FieldInput.tsx
+++ b/packages/components/src/FieldInput/FieldInput.tsx
@@ -39,7 +39,7 @@ const TextLimitIndicator = ({
   const colorVec = [
     { value: 1.0, color: 'red' },
     { value: 0.75, color: 'red2' },
-    { value: 0.6, color: 'yellow.base' },
+    { value: 0.6, color: 'accent.base' },
   ]
   const color = colorVec.find((cur) => cur.value <= percMax)?.color ?? 'black'
   return (

--- a/packages/components/src/FileInformation/FileInformation.tsx
+++ b/packages/components/src/FileInformation/FileInformation.tsx
@@ -29,7 +29,7 @@ const FileDetails = (props: {
       sx={{
         borderRadius: 1,
         border: '2px solid black',
-        background: 'yellow.base',
+        background: 'accent.base',
         color: 'black',
         justifyContent: 'space-between',
         alignItems: 'center',

--- a/packages/components/src/ModerationStatus/ModerationStatus.tsx
+++ b/packages/components/src/ModerationStatus/ModerationStatus.tsx
@@ -48,7 +48,7 @@ export const ModerationStatus = (props: Props) => {
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
         overflow: 'hidden',
-        background: 'yellow.base',
+        background: 'accent.base',
         padding: 1,
         borderRadius: 1,
         borderBottomRightRadius: 1,

--- a/packages/components/src/ResearchEditorOverview/ResearchEditorOverview.tsx
+++ b/packages/components/src/ResearchEditorOverview/ResearchEditorOverview.tsx
@@ -57,7 +57,7 @@ export const ResearchEditorOverview = (props: ResearchEditorOverviewProps) => {
                         whiteSpace: 'nowrap',
                         textOverflow: 'ellipsis',
                         overflow: 'hidden',
-                        background: 'yellow.base',
+                        background: 'accent.base',
                         padding: 1,
                         borderRadius: 1,
                         borderBottomRightRadius: 1,

--- a/packages/themes/src/common/button.ts
+++ b/packages/themes/src/common/button.ts
@@ -17,9 +17,9 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
   primary: {
     ...BASE_BUTTON,
     color: colors.black,
-    bg: colors.yellow.base,
+    bg: colors.accent.base,
     '&:hover': {
-      bg: colors.yellow.hover,
+      bg: colors.accent.hover,
       cursor: 'pointer',
     },
     '&[disabled]': {
@@ -27,7 +27,7 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
       cursor: 'not-allowed',
     },
     '&[disabled]:hover': {
-      bg: colors.yellow.base,
+      bg: colors.accent.base,
     },
   },
   secondary: {

--- a/packages/themes/src/fixing-fashion/styles.ts
+++ b/packages/themes/src/fixing-fashion/styles.ts
@@ -16,7 +16,7 @@ const fonts = {
 export const colors = {
   ...commonColors,
   primary: 'green',
-  yellow: { base: '#E95628', hover: 'hsl(14, 81%, 43%)' },
+  accent: { base: '#E95628', hover: 'hsl(14, 81%, 43%)' },
 }
 
 export const zIndex = {

--- a/packages/themes/src/precious-plastic/styles.ts
+++ b/packages/themes/src/precious-plastic/styles.ts
@@ -24,7 +24,7 @@ const fonts = {
 export const colors = {
   ...commonColors,
   primary: 'red',
-  yellow: { base: '#fee77b', hover: '#ffde45' },
+  accent: { base: '#fee77b', hover: '#ffde45' },
 }
 
 export const zIndex = {
@@ -56,7 +56,7 @@ const alerts = {
     borderRadius: 1,
     paddingX: 3,
     paddingY: 3,
-    backgroundColor: colors.yellow.base,
+    backgroundColor: colors.accent.base,
     color: colors.black,
     textAlign: 'center',
     fontWeight: 'normal',

--- a/packages/themes/src/project-kamp/styles.ts
+++ b/packages/themes/src/project-kamp/styles.ts
@@ -11,7 +11,7 @@ export type { ButtonVariants } from '../common/button'
 export const colors = {
   ...commonColors,
   primary: 'green',
-  yellow: { base: '#8ab57f', hover: 'hsl(108, 25%, 68%)' },
+  accent: { base: '#8ab57f', hover: 'hsl(108, 25%, 68%)' },
 }
 
 export const zIndex = {

--- a/packages/themes/src/types/index.ts
+++ b/packages/themes/src/types/index.ts
@@ -78,7 +78,7 @@ export interface ThemeWithName {
     black: string
     primary: string
     softyellow: string
-    yellow: { base: string; hover: string }
+    accent: { base: string; hover: string }
     blue: string
     red: string
     red2: string

--- a/src/modules/admin/pages/adminApprovals.tsx
+++ b/src/modules/admin/pages/adminApprovals.tsx
@@ -43,7 +43,7 @@ const AdminHome = observer(() => {
     background: 'white',
     '&:hover': {
       cursor: 'pointer',
-      backgroundColor: 'yellow.hover',
+      backgroundColor: 'accent.hover',
     },
     '& > td': {
       padding: '8px',

--- a/src/pages/common/Header/Menu/MenuDesktop.tsx
+++ b/src/pages/common/Header/Menu/MenuDesktop.tsx
@@ -26,7 +26,7 @@ const MenuLink = styled(NavLink)`
       display: block;
       position: absolute;
       bottom: -6px;
-      background-color: ${(props) => props.theme.colors.yellow.base};
+      background-color: ${(props) => props.theme.colors.accent.base};
       mask-size: contain;
       mask-image: url(${MenuCurrent});
       mask-repeat: no-repeat;

--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobileLink.tsx
@@ -40,7 +40,7 @@ const MenuLink = styled(NavLink)`
       display: block;
       position: absolute;
       bottom: -5px;
-      background-color: ${(props) => props.theme.colors.yellow.base};
+      background-color: ${(props) => props.theme.colors.accent.base};
       mask-size: contain;
       mask-image: url(${MenuCurrent});
       mask-repeat: no-repeat;


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

When I was looking through the application, I noticed that we use a color variable called yellow, which has 2 statuses: base and hover. Looking at the styles for each project, I came to the conclusion that this name is for the facade (it's not always yellow). I also looked in the documentation to see if this yellow appears as something "standard".

I changed the name from yellow to accents, and I changed it everywhere I found it used. Thus, it will be easy for the developer to understand the role of color.

