### PR TITLE
fix: switch notification store to use username instead of userid

### DIFF
--- a/src/stores/User/notifications.store.test.tsx
+++ b/src/stores/User/notifications.store.test.tsx
@@ -18,7 +18,7 @@ class MockNotificationsStore extends UserNotificationsStore {
   userStore = {
     user: FactoryUser({
       _id: 'userId',
-      userName: 'username',
+      userName: 'userName',
       notifications: [],
     }),
     updateUserProfile: jest.fn(),
@@ -36,7 +36,9 @@ describe('triggerNotification', () => {
 
   it('adds a new notification to user', async () => {
     const store = new MockNotificationsStore()
-    store.db.getWhere.mockReturnValue([FactoryUser({ _id: 'example' })])
+    store.db.getWhere.mockReturnValue([
+      FactoryUser({ _id: 'example', userName: 'example' }),
+    ])
     // Act
     await store.triggerNotification(
       'howto_mention',
@@ -98,7 +100,7 @@ describe('notifications.store', () => {
   it('deletes a notification', async () => {
     await store.deleteNotification(store.user!.notifications![0]._id)
 
-    expect(store.db.doc).toBeCalledWith('userId')
+    expect(store.db.doc).toBeCalledWith('userName')
     expect(store.db.set).toHaveBeenCalledTimes(1)
 
     const updatedUser = store.db.set.mock.calls[0][0]
@@ -109,13 +111,13 @@ describe('notifications.store', () => {
   it('marks all notifications as notified', async () => {
     await store.markAllNotificationsNotified()
 
-    expect(store.db.doc).toBeCalledWith('userId')
+    expect(store.db.doc).toBeCalledWith('userName')
     expect(store.db.set).toHaveBeenCalledTimes(1)
   })
   it('marks all notifications as read', async () => {
     await store.markAllNotificationsRead()
 
-    expect(store.db.doc).toBeCalledWith('userId')
+    expect(store.db.doc).toBeCalledWith('userName')
     expect(store.db.set).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/stores/User/notifications.store.ts
+++ b/src/stores/User/notifications.store.ts
@@ -92,7 +92,7 @@ export class UserNotificationsStore extends ModuleStore {
           ? [...toJS(user.notifications), newNotification]
           : [newNotification]
 
-        await this._updateUserNofications(user, notifications)
+        await this._updateUserNotifications(user, notifications)
       }
     } catch (err) {
       logger.error(err)
@@ -108,7 +108,7 @@ export class UserNotificationsStore extends ModuleStore {
         const notifications = toJS(user.notifications)
         notifications?.forEach((notification) => (notification.notified = true))
 
-        await this._updateUserNofications(user, notifications)
+        await this._updateUserNotifications(user, notifications)
         await this.userStore.updateUserProfile({ notifications })
       }
     } catch (err) {
@@ -125,7 +125,7 @@ export class UserNotificationsStore extends ModuleStore {
         const notifications = toJS(user.notifications)
         notifications?.forEach((notification) => (notification.read = true))
 
-        await this._updateUserNofications(user, { notifications })
+        await this._updateUserNotifications(user, { notifications })
         await this.userStore.updateUserProfile({ notifications })
       }
     } catch (err) {
@@ -143,7 +143,7 @@ export class UserNotificationsStore extends ModuleStore {
           (notification) => !(notification._id === id),
         )
 
-        await this._updateUserNofications(user, notifications)
+        await this._updateUserNotifications(user, notifications)
       }
     } catch (err) {
       logger.error(err)
@@ -151,8 +151,10 @@ export class UserNotificationsStore extends ModuleStore {
     }
   }
 
-  private async _updateUserNofications(user: IUserPPDB, notifications) {
-    const dbRef = this.db.collection<IUser>(USER_COLLECTION_NAME).doc(user.userName)
+  private async _updateUserNotifications(user: IUserPPDB, notifications) {
+    const dbRef = this.db
+      .collection<IUser>(USER_COLLECTION_NAME)
+      .doc(user.userName)
 
     return dbRef.set({
       ...toJS(user),

--- a/src/stores/User/notifications.store.ts
+++ b/src/stores/User/notifications.store.ts
@@ -72,7 +72,7 @@ export class UserNotificationsStore extends ModuleStore {
           _created: new Date().toISOString(),
           triggeredBy: {
             displayName: triggeredBy.displayName,
-            userId: triggeredBy._id,
+            userId: triggeredBy.userName,
           },
           relevantUrl: relevantUrl,
           type: type,
@@ -152,7 +152,7 @@ export class UserNotificationsStore extends ModuleStore {
   }
 
   private async _updateUserNofications(user: IUserPPDB, notifications) {
-    const dbRef = this.db.collection<IUser>(USER_COLLECTION_NAME).doc(user._id)
+    const dbRef = this.db.collection<IUser>(USER_COLLECTION_NAME).doc(user.userName)
 
     return dbRef.set({
       ...toJS(user),


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

It has been noticed duplicate users are getting reintroduced into the system and the 'wrong' users are in some cases the only ones getting updated. This was first noticed in the notifications records saved for the user records being different. As a result all uses of the user _id are being switched for userName so that if duplicates are created that it's definitely the user record that has an _id that matches the username that receives updates.  This pr:

- Switches use of user._id to user._userName in the notifications store.
- Fixes 'notifications' typos

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
