### PR TITLE
fix: space profile research count bug

### DIFF
--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -331,11 +331,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                 howtoCount={docs?.howtos.length || 0}
                 eventCount={docs?.events.length || 0}
                 usefulCount={stats.totalUseful}
-                researchCount={
-                  user.stats
-                    ? Object.keys(user.stats!.userCreatedResearch).length
-                    : 0
-                }
+                researchCount={docs?.research.length || 0}
               />
             </Box>
           </MobileBadge>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Space profile research count was using the user stats research figure.  As this has been removed/deprecated the profile would not load and get stuck into an error loop.  This pr switches the research count to the object returned from the user created docs function.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
