### PR TITLE
feat: allow multiple image upload for space profiles

### DIFF
--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -50,7 +50,7 @@ export const CoverImages = ({
                   height: '100px',
                   width: '150px',
                 }}
-                m="10px"
+                m={2}
                 data-cy="cover-image"
               >
                 <Field

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -31,72 +31,47 @@ export const CoverImages = ({
 }: {
   isMemberProfile: boolean
   coverImages: IUser['coverImages']
-}) =>
-  !isMemberProfile ? (
-    <>
-      <Text mb={2} mt={7} sx={{ width: '100%', fontSize: 2 }}>
-        Add a profile image *
-      </Text>
-      <Box
-        sx={{
-          height: '190px',
-          width: '190px',
-        }}
-        m="10px"
-        data-cy="cover-image"
-      >
-        <Field
-          hasText={false}
-          name="coverImages[0]"
-          validate={required}
-          validateFields={[]}
-          component={ImageInputField}
-          data-cy={`coverImages-0`}
-          initialValue={coverImages[0]}
-        />
-      </Box>
-    </>
-  ) : (
-    <>
-      <Text mb={2} mt={7} sx={{ width: '100%', fontSize: 2 }}>
-        Cover Image *
-      </Text>
-      <FieldArray
-        name="coverImages"
-        initialValue={coverImages as IUploadedFileMeta[]}
-      >
-        {({ fields, meta }) => {
-          return (
-            <>
-              {fields.map((name, index: number) => (
-                <Box
-                  key={name}
-                  sx={{
-                    height: '100px',
-                    width: '150px',
-                  }}
-                  m="10px"
-                  data-cy="cover-image"
-                >
-                  <Field
-                    hasText={false}
-                    name={name}
-                    validateFields={[]}
-                    data-cy={`coverImages-${index}`}
-                    component={ImageInputField}
-                  />
-                </Box>
-              ))}
-              {meta.error && (
-                <Text sx={{ fontSize: 0, margin: 1, color: 'error' }}>
-                  {meta.error}
-                </Text>
-              )}
-            </>
-          )
-        }}
-      </FieldArray>
-
+}) => (
+  <>
+    <Text mb={2} mt={7} sx={{ width: '100%', fontSize: 2 }}>
+      {!isMemberProfile ? 'Add a profile image *' : 'Cover Image *'}
+    </Text>
+    <FieldArray
+      name="coverImages"
+      initialValue={coverImages as IUploadedFileMeta[]}
+    >
+      {({ fields, meta }) => {
+        return (
+          <>
+            {fields.map((name, index: number) => (
+              <Box
+                key={name}
+                sx={{
+                  height: '100px',
+                  width: '150px',
+                }}
+                m="10px"
+                data-cy="cover-image"
+              >
+                <Field
+                  hasText={false}
+                  name={name}
+                  validateFields={[]}
+                  data-cy={`coverImages-${index}`}
+                  component={ImageInputField}
+                />
+              </Box>
+            ))}
+            {meta.error && (
+              <Text sx={{ fontSize: 0, margin: 1, color: 'error' }}>
+                {meta.error}
+              </Text>
+            )}
+          </>
+        )
+      }}
+    </FieldArray>
+    {!isMemberProfile && (
       <Box
         mt={2}
         p={2}
@@ -104,14 +79,13 @@ export const CoverImages = ({
       >
         <Text sx={{ fontSize: 1 }}>
           The cover images are shown in your profile and helps us evaluate your
-          account.
-        </Text>
-        <Text sx={{ fontSize: 1 }}>
-          Make sure the first image shows your space. Best size is 1920x1080.
+          account. Make sure the first image shows your space. Best size is
+          1920x1080.
         </Text>
       </Box>
-    </>
-  )
+    )}
+  </>
+)
 
 export class UserInfosSection extends React.Component<IProps, IState> {
   constructor(props: IProps) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This pr adds multiple image upload for space profiles as requested by Project Plastic team.  Previously only member profiles allowed multiple images to be uploaded.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
