### PR TITLE
feat: display all images uploaded by a member or space on their profile

### DIFF
--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -29,7 +29,7 @@ export const MemberProfile = ({ user, docs }: IProps) => {
     user.coverImages && user.coverImages[0]
       ? (user.coverImages[0] as IUploadedFileMeta).downloadUrl
       : DefaultMemberImage
-  
+
   //Get all images except the first one from user.coverImages
   const coverImages = user.coverImages ? user.coverImages.slice(1) : []
 
@@ -190,12 +190,8 @@ export const MemberProfile = ({ user, docs }: IProps) => {
               />
             </Box>
           ))}
-
-         
         </Flex>
       </Flex>
     </Card>
-
-          
   )
 }

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -29,6 +29,9 @@ export const MemberProfile = ({ user, docs }: IProps) => {
     user.coverImages && user.coverImages[0]
       ? (user.coverImages[0] as IUploadedFileMeta).downloadUrl
       : DefaultMemberImage
+  
+  //Get all images except the first one from user.coverImages
+  const coverImages = user.coverImages ? user.coverImages.slice(1) : []
 
   return (
     <Card
@@ -139,6 +142,60 @@ export const MemberProfile = ({ user, docs }: IProps) => {
         </Flex>
       </Flex>
       <UserCreatedDocuments docs={docs} />
+      <Flex
+        sx={{
+          px: [2, 4],
+          py: 4,
+          background: 'white',
+        }}
+      >
+        <MemberBadge
+          profileType="member"
+          size={50}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: '50%',
+            marginLeft: 50 * -0.5,
+            marginTop: 50 * -0.5,
+          }}
+          useLowDetailVersion
+        />
+        <Flex
+          px={4}
+          py={4}
+          sx={{ borderRadius: 1, flexDirection: ['column', 'row'] }}
+        >
+          {coverImages.map((image, index) => (
+            <Box
+              key={index}
+              sx={{
+                display: 'block',
+                width: '120px',
+                height: '120px',
+                maxWidth: 'none',
+                overflow: 'hidden',
+                margin: '0 auto',
+                mb: 3,
+              }}
+            >
+              <Image
+                loading="lazy"
+                src={image.downloadUrl}
+                sx={{
+                  objectFit: 'cover',
+                  width: '100%',
+                  height: '100%',
+                }}
+              />
+            </Box>
+          ))}
+
+         
+        </Flex>
+      </Flex>
     </Card>
+
+          
   )
 }

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -3,7 +3,7 @@ import type { IUserPP } from 'src/models/userPreciousPlastic.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { Box, Image, Flex, Heading, Card, Paragraph } from 'theme-ui'
 import DefaultMemberImage from 'src/assets/images/default_member.svg'
-import { MemberBadge, UserStatistics, Username } from 'oa-components'
+import { MemberBadge, UserStatistics, Username,ImageGallery } from 'oa-components'
 import UserContactAndLinks from './UserContactAndLinks'
 import { UserAdmin } from './UserAdmin'
 import { userStats } from 'src/common/hooks/userStats'
@@ -30,8 +30,20 @@ export const MemberProfile = ({ user, docs }: IProps) => {
       ? (user.coverImages[0] as IUploadedFileMeta).downloadUrl
       : DefaultMemberImage
 
-  //Get all images except the first one from user.coverImages
+  
   const coverImages = user.coverImages ? user.coverImages.slice(1) : []
+  const coverImagesMeta = coverImages.map((image) => {
+    return {
+      downloadUrl: image.downloadUrl,
+      contentType: image.contentType,
+      fullPath: image.fullPath,
+      name: image.name,
+      type: image.type,
+      size: image.size,
+      timeCreated: image.timeCreated,
+      updated: image.updated,
+    }
+  })
 
   return (
     <Card
@@ -161,36 +173,9 @@ export const MemberProfile = ({ user, docs }: IProps) => {
           }}
           useLowDetailVersion
         />
-        <Flex
-          px={4}
-          py={4}
-          sx={{ borderRadius: 1, flexDirection: ['column', 'row'] }}
-        >
-          {coverImages.map((image, index) => (
-            <Box
-              key={index}
-              sx={{
-                display: 'block',
-                width: '120px',
-                height: '120px',
-                maxWidth: 'none',
-                overflow: 'hidden',
-                margin: '0 auto',
-                mb: 3,
-              }}
-            >
-              <Image
-                loading="lazy"
-                src={image.downloadUrl}
-                sx={{
-                  objectFit: 'cover',
-                  width: '100%',
-                  height: '100%',
-                }}
-              />
-            </Box>
-          ))}
-        </Flex>
+
+        {coverImages.length > 0 && <ImageGallery images={coverImagesMeta} />}
+
       </Flex>
     </Card>
   )

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -3,7 +3,12 @@ import type { IUserPP } from 'src/models/userPreciousPlastic.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { Box, Image, Flex, Heading, Card, Paragraph } from 'theme-ui'
 import DefaultMemberImage from 'src/assets/images/default_member.svg'
-import { MemberBadge, UserStatistics, Username,ImageGallery } from 'oa-components'
+import {
+  MemberBadge,
+  UserStatistics,
+  Username,
+  ImageGallery,
+} from 'oa-components'
 import UserContactAndLinks from './UserContactAndLinks'
 import { UserAdmin } from './UserAdmin'
 import { userStats } from 'src/common/hooks/userStats'
@@ -30,7 +35,6 @@ export const MemberProfile = ({ user, docs }: IProps) => {
       ? (user.coverImages[0] as IUploadedFileMeta).downloadUrl
       : DefaultMemberImage
 
-  
   const coverImages = user.coverImages ? user.coverImages.slice(1) : []
   const coverImagesMeta = coverImages.map((image) => {
     return {
@@ -175,7 +179,6 @@ export const MemberProfile = ({ user, docs }: IProps) => {
         />
 
         {coverImages.length > 0 && <ImageGallery images={coverImagesMeta} />}
-
       </Flex>
     </Card>
   )


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR tries to answer this need #2490.
I've added the images in the user profile page.

## Git Issues

Closes #2490

## Screenshots/Videos

![Schermata del 2023-06-27 22-27-48](https://github.com/ONEARMY/community-platform/assets/48263116/3a449af3-93f5-46d5-8cd8-29d9df6ee030)


## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
