### PR TITLE
fix: number of profile images shown on member / spaces profiles

### DIFF
--- a/src/pages/Settings/UserSettings.test.tsx
+++ b/src/pages/Settings/UserSettings.test.tsx
@@ -72,6 +72,48 @@ describe('UserSettings', () => {
     await waitFor(() => wrapper.getByText('Admin settings'))
   })
 
+  it('displays one photo for member', () => {
+    const user = FactoryUser({ profileType: 'member' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(1)
+  })
+
+  it('displays four photos for collection point', () => {
+    const user = FactoryUser({ profileType: 'collection-point' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
+  })
+
+  it('displays four photos for community builder', () => {
+    const user = FactoryUser({ profileType: 'community-builder' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
+  })
+
+  it('displays four photos for machine builder', () => {
+    const user = FactoryUser({ profileType: 'machine-builder' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
+  })
+
+  it('displays four photos for space', () => {
+    const user = FactoryUser({ profileType: 'space' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
+  })
+
+  it('displays four photos for workspace', () => {
+    const user = FactoryUser({ profileType: 'workspace' })
+    // Act
+    const wrapper = getWrapper(user)
+    expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
+  })
+
   it('presents the state', async () => {
     const user = FactoryUser({
       userRoles: ['admin'],

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -44,6 +44,7 @@ export const CoverImages = ({
         }}
         m="2"
         data-cy="cover-image"
+        data-testid="cover-image"
       >
         <Field
           hasText={false}
@@ -77,6 +78,7 @@ export const CoverImages = ({
                   }}
                   m="10px"
                   data-cy="cover-image"
+                  data-testid="cover-image"
                 >
                   <Field
                     hasText={false}

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -32,7 +32,7 @@ export const CoverImages = ({
   isMemberProfile: boolean
   coverImages: IUser['coverImages']
 }) =>
-  !isMemberProfile ? (
+  isMemberProfile ? (
     <>
       <Text mb={2} mt={7} sx={{ width: '100%', fontSize: 2 }}>
         Add a profile image *
@@ -104,10 +104,8 @@ export const CoverImages = ({
       >
         <Text sx={{ fontSize: 1 }}>
           The cover images are shown in your profile and helps us evaluate your
-          account.
-        </Text>
-        <Text sx={{ fontSize: 1 }}>
-          Make sure the first image shows your space. Best size is 1920x1080.
+          account. Make sure the first image shows your space. Best size is
+          1920x1080.
         </Text>
       </Box>
     </>

--- a/src/pages/Settings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/Settings/content/formSections/UserInfos.section.tsx
@@ -42,7 +42,7 @@ export const CoverImages = ({
           height: '190px',
           width: '190px',
         }}
-        m="10px"
+        m="2"
         data-cy="cover-image"
       >
         <Field


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Member profiles should allow 1 photo to be uploaded and space profiles should allow multiple.  The behaviour had been reversed on the platform.  This pr resets the functionality back to the requirement.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
