### PR TITLE
fix: member / space profile useful alignment to end of row

### DIFF
--- a/src/pages/User/content/UserCreatedDocumentsItem.tsx
+++ b/src/pages/User/content/UserCreatedDocumentsItem.tsx
@@ -59,7 +59,8 @@ const UserDocumentItem = ({ type, item }: IProps) => {
                   display: 'flex',
                   alignItems: 'center',
                   fontSize: ['12px', '12px', '14px'],
-                  minWidth: '30px',
+                  minWidth: '40px',
+                  justifyContent: 'flex-end',
                 }}
               >
                 {totalUseful}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Fixes alignment of useful badge when viewing the how-to and research items from member / space profile.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
