### PR TITLE
chore: add Github action to triage stale issues

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+          days-before-pr-stale: 45
+          days-before-pr-close: 5
+          debug-only: true


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Adopt https://github.com/actions/stale to handle administration on very old PRs. The intent for this change is that this automation runs with debug out only and **does not** generate any comments on PRs. I want to trial it for a month and see how it goes before making public.

Although I would flag that with the current level of maintainer time available it is unlikely we will see any PRs reach the 45 day threshold. 