### PR TITLE
chore: ci workaround for deploying functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ commands:
       - run:
           # Use version of firebase-tools already installed in functions workspace to deploy
           name: Deploy to Firebase
-          command: ./functions/node_modules/.bin/firebase deploy --debug -P << parameters.alias >>
+          command: ./functions/node_modules/.bin/firebase deploy --debug -P << parameters.alias >> --non-interactive
           environment:
             GOOGLE_APPLICATION_CREDENTIALS: service_account.json
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Historically whenever we remove a function from a deployed instance of the Platform, this requires manual action to be taken. The `firebase deploy` command requires an interactive input to remove functions, the change here is hoping to automate this 🤞🏻 