### PR TITLE
fix: unclear wording for Draft Button

### DIFF
--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -306,7 +306,7 @@ const ResearchForm = observer((props: IProps) => {
                     sx={{ width: '100%', display: 'block' }}
                   >
                     {props.formValues.moderation !== 'draft' ? (
-                      <span>Revert to draft</span>
+                      <span>Save as draft</span>
                     ) : (
                       <span>Save to draft</span>
                     )}{' '}


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Description

Fix wording of Draft button in http://localhost:3000/research/create from `Revert to Draft` to `Save as draft`

## Git Issues

Closes  #2508 

## Screenshots/Videos

![image](https://github.com/ONEARMY/community-platform/assets/88965204/72791b23-3bc4-4751-b826-b18c7549b448)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
