### PR TITLE
refactor: useful button to use history.push rather than external link

### DIFF
--- a/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
+++ b/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
@@ -1,8 +1,9 @@
 import { useTheme } from '@emotion/react'
 import { useEffect, useState } from 'react'
 import type { ThemeUIStyleObject } from 'theme-ui'
-import { Flex, Text } from 'theme-ui'
-import { Button, ExternalLink, Icon, Tooltip } from '../'
+import { Text } from 'theme-ui'
+import { Button, Tooltip } from '../'
+import { useHistory } from 'react-router-dom'
 
 export interface IProps {
   hasUserVotedUseful: boolean
@@ -15,6 +16,7 @@ export interface IProps {
 
 export const UsefulStatsButton = (props: IProps) => {
   const theme: any = useTheme()
+  const history = useHistory()
 
   const [votedUsefulCount, setVotedUsefulCount] = useState<number>()
   const [hasUserVotedUseful, setHasUserVotedUseful] = useState<boolean>()
@@ -36,87 +38,46 @@ export const UsefulStatsButton = (props: IProps) => {
     setDisabled(false)
   }
 
-  return props.isLoggedIn ? (
-    <Button
-      data-cy="vote-useful"
-      onClick={handleUsefulClick}
-      disabled={disabled}
-      sx={{
-        fontSize: 2,
-        backgroundColor: theme.colors.white,
-        py: 0,
-        '&:hover': {
-          backgroundColor: theme.colors.softblue,
-        },
-        ...props.sx,
-      }}
-      icon={hasUserVotedUseful ? 'star' : 'star-active'}
-    >
-      <Text
-        pr={2}
-        py={2}
-        sx={{
-          display: 'inline-block',
-        }}
-      >
-        {votedUsefulCount}
-      </Text>
-      <Text
-        pl={2}
-        py={2}
-        sx={{
-          display: 'inline-block',
-          borderLeft: `1px solid ${theme.colors.black}`,
-        }}
-      >
-        {hasUserVotedUseful ? 'Marked as useful' : 'Mark as useful'}
-      </Text>
-    </Button>
-  ) : (
+  return (
     <>
-      <ExternalLink
-        href="/sign-in"
-        data-cy="vote-useful-redirect"
-        data-tip={'Login to add your vote'}
+      <Button
+        data-tip={props.isLoggedIn ? '' : 'Login to add your vote'}
+        data-cy={props.isLoggedIn ? 'vote-useful' : 'vote-useful-redirect'}
+        onClick={() =>
+          props.isLoggedIn ? handleUsefulClick() : history.push('/sign-in')
+        }
+        disabled={disabled}
         sx={{
-          ...theme.buttons.subtle,
-          borderColor: theme.colors.black,
-          backgroundColor: theme.colors.white,
-          display: 'inline-flex',
           fontSize: 2,
-          gap: 2,
-          px: 2,
+          backgroundColor: theme.colors.white,
           py: 0,
           '&:hover': {
             backgroundColor: theme.colors.softblue,
-            borderColor: theme.colors.black,
           },
           ...props.sx,
         }}
+        icon={hasUserVotedUseful ? 'star' : 'star-active'}
       >
-        <Icon glyph={hasUserVotedUseful ? 'star' : 'star-active'} />
-        <Flex>
-          <Text
-            pr={2}
-            py={2}
-            sx={{
-              display: 'inline-block',
-            }}
-          >
-            {votedUsefulCount}
-          </Text>
-          <Text
-            pl={2}
-            py={2}
-            sx={{
-              display: 'inline-block',
-              borderLeft: `1px solid ${theme.colors.black}`,
-            }}
-          >
-            {hasUserVotedUseful ? 'Marked as useful' : 'Mark as useful'}
-          </Text>
-        </Flex>
-      </ExternalLink>
+        <Text
+          pr={2}
+          py={2}
+          sx={{
+            display: 'inline-block',
+          }}
+        >
+          {votedUsefulCount}
+        </Text>
+        <Text
+          pl={2}
+          py={2}
+          sx={{
+            display: 'inline-block',
+            borderLeft: `1px solid ${theme.colors.black}`,
+          }}
+        >
+          {hasUserVotedUseful ? 'Marked as useful' : 'Mark as useful'}
+        </Text>
+      </Button>
       <Tooltip />
     </>
   )


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This pr:

- Refactors the useful button to remove the use of the ExternalLink component if the user is logged out.
- Implements a history.push if the user is logged out that redirects to sign-in.

The reason for this change is so that the sign in doesn't open in another page and therefore after sign-in they land back on the page they started on.

## Git Issues

Closes #2536 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
