### PR TITLE
fix(aggregations): fix user notification aggregation

### DIFF
--- a/functions/src/aggregations/userNotifications.aggregations.spec.ts
+++ b/functions/src/aggregations/userNotifications.aggregations.spec.ts
@@ -1,6 +1,12 @@
 import { DB_ENDPOINTS, IUserDB } from '../models'
 import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
 import type { INotification } from '../../../src/models'
+import { EmailNotificationFrequency } from 'oa-shared'
+
+// use require to allow import of exports.default syntax for the function
+const {
+  default: UserNotificationsAggregationFunction,
+} = require('./userNotifications.aggregations')
 
 const mockNotification: Partial<INotification> = { _id: 'notification_1' }
 
@@ -15,49 +21,86 @@ const userFactory = (_id: string, user: Partial<IUserDB> = {}): IUserDB => ({
   ...(user as IUserDB),
 })
 
+const userWithoutNotifications = userFactory('user_1')
+const userWithNotifications = userFactory('user_1', {
+  notifications: [mockNotification as INotification],
+})
+const userWithReadNotifications = userFactory('user_1', {
+  notifications: [
+    { read: true, ...(mockNotification as INotification) },
+    { notified: true, ...(mockNotification as INotification) },
+    { email: 'abc123', ...(mockNotification as INotification) },
+  ],
+})
+const userWithNeverEmailFrequency = userFactory('user_1', {
+  notifications: [mockNotification as INotification],
+  notification_settings: {
+    emailFrequency: EmailNotificationFrequency.NEVER,
+  },
+})
+
 describe('User Notifications Aggregation', () => {
   const db = FirebaseEmulatedTest.admin.firestore()
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()
-    await FirebaseEmulatedTest.seedFirestoreDB('users', [
-      userFactory('user_1', {
-        notifications: [mockNotification as INotification],
-      }),
-    ])
-    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications', [
-      { _id: 'emails_pending' },
-    ])
+    await FirebaseEmulatedTest.seedFirestoreDB('users', [userFactory('user_1')])
+    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications')
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    db.collection(targetEndpoint).doc('emails_pending').set({})
   })
-  afterEach(async () => {
+  afterAll(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()
   })
 
   it('Aggregates user notifications to collection', async () => {
-    const before = userFactory('user_1')
-    const after = userFactory('user_1', {
-      notifications: [mockNotification as INotification],
-    })
     const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
-      before,
-      after,
+      userWithoutNotifications,
+      userWithNotifications,
       'users',
       'user_1',
     )
-    // use require to allow import of exports.default syntax for the function
-    const {
-      default: UserNotificationsAggregationFunction,
-    } = require('./userNotifications.aggregations')
     await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
 
     // check if aggregated list of pending emails created in user_notifications endpoint
     // with a subset of information
     const targetEndpoint = DB_ENDPOINTS['user_notifications']
     const res = await db.collection(targetEndpoint).doc('emails_pending').get()
-    const { _authID, notification_settings, notifications } = after
+    const { _authID, notification_settings, notifications } =
+      userWithNotifications
     const { emailFrequency } = notification_settings
     expect(res.data()).toEqual({
       user_1: { _authID, emailFrequency, notifications },
     })
+  })
+
+  it('Does not aggregate read, notified, or emailed user notifications to collection', async () => {
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      userWithNotifications,
+      userWithReadNotifications,
+      'users',
+      'user_1',
+    )
+    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
+
+    // check if list is removed when all notifications are read, notified, or filtered
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
+    expect(res.data()).toEqual({})
+  })
+
+  it('Does not aggregate user notifications to collection for users with never frequency ', async () => {
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      userWithNotifications,
+      userWithNeverEmailFrequency,
+      'users',
+      'user_1',
+    )
+    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
+
+    // check if user is not added to list when they have "never" email frequency setting
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
+    expect(res.data()).toEqual({})
   })
 })

--- a/functions/src/aggregations/userNotifications.aggregations.spec.ts
+++ b/functions/src/aggregations/userNotifications.aggregations.spec.ts
@@ -25,7 +25,9 @@ describe('User Notifications Aggregation', () => {
         notifications: [mockNotification as INotification],
       }),
     ])
-    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications')
+    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications', [
+      { _id: 'emails_pending' },
+    ])
   })
   afterEach(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

this fixes a regression caused by https://github.com/ONEARMY/community-platform/pull/2344. We were accidentally dropping user notification aggregation updates, which prevented emails from being sent out.

i tested this fix by deploying the userNotification agg function to dev and confirming data was being populated in the `user_notifications` collection following new notifications. 

suggestions for improvement: this `functions/src/aggregations/common.aggregations.ts` file has become a little bloated with code that is not "common" to all aggregations. i think moving calculations for useful counting to the individual aggregation process functions would keep this a bit neater and easier to debug. i can draft an issue for this after lunch :) 

## Git Issues

Closes #2547 

## Screenshots/Videos

<img width="1792" alt="Screen Shot 2023-07-04 at 1 04 52 PM" src="https://github.com/ONEARMY/community-platform/assets/37253846/557fd31d-871b-433f-a8fa-0c85284f17e1">
<img width="1792" alt="Screen Shot 2023-07-04 at 2 00 01 PM" src="https://github.com/ONEARMY/community-platform/assets/37253846/89b13d5a-07fb-480b-bd8e-a1fcbf4e7856">



---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
