### PR TITLE
feat: expose logging method via routing

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,6 +12,10 @@
         "function": "seo-seoRender"
       },
       {
+        "source": "/_logging",
+        "function": "logToCloudLogging-logToCloudLogging"
+      },
+      {
         "source": "/research/**",
         "function": "seo-seoRender"
       },


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

At the moment the serverless functions are
only available via a hard to discover URL this
means they can not be found at a root relative path.

This change exposes them via a temporary URL for testing.
Opinions welcome on whether this should eventually be
exposed via a name spaced URI such as `/api/logging`.