### PR TITLE
chore(deps): drop unused react-tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "react-scripts": "5.0.1",
     "react-slick": "^0.25.2",
     "react-table": "^6.11.5",
-    "react-tooltip": "^4.2.20",
     "react-virtualized": "^9.22.3",
     "rxjs": "^6.6.3",
     "sass": "^1.45.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25399,7 +25399,6 @@ __metadata:
     react-scripts: 5.0.1
     react-slick: ^0.25.2
     react-table: ^6.11.5
-    react-tooltip: ^4.2.20
     react-virtualized: ^9.22.3
     resize-observer-polyfill: ^1.5.1
     rxjs: ^6.6.3
@@ -28590,7 +28589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^4.2.20, react-tooltip@npm:^4.2.21":
+"react-tooltip@npm:^4.2.21":
   version: 4.5.1
   resolution: "react-tooltip@npm:4.5.1"
   dependencies:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes unused `react-tooltip` dependency which is only used in the components workspace.