### PR TITLE
fix: update current imgIndex when clicking through images

### DIFF
--- a/packages/components/src/ImageGallery/ImageGallery.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.tsx
@@ -56,10 +56,11 @@ export const ImageGallery = (props: IProps) => {
     })
   }, [])
 
-  const setActive = (image: IUploadedFileMeta) => {
+  const setActive = (image: IUploadedFileMeta, imgIndex: number) => {
     setState({
       ...state,
       activeImage: image,
+      imgIndex: imgIndex,
     })
   }
 
@@ -101,7 +102,7 @@ export const ImageGallery = (props: IProps) => {
                 mb={3}
                 mt={4}
                 opacity={image === state.activeImage ? 1.0 : 0.5}
-                onClick={() => setActive(image)}
+                onClick={() => setActive(image, index)}
                 key={index}
               >
                 <Image

--- a/packages/components/src/ImageGallery/ImageGallery.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.tsx
@@ -22,10 +22,9 @@ export interface IProps {
 }
 
 interface IState {
-  activeImage: IUploadedFileMeta | null
+  activeImageIndex: number
   showLightbox: boolean
   images: Array<IUploadedFileMeta>
-  imgIndex: number
 }
 
 const ThumbCard = styled<CardProps & React.ComponentProps<any>>(Box)`
@@ -40,27 +39,24 @@ const ThumbCard = styled<CardProps & React.ComponentProps<any>>(Box)`
 
 export const ImageGallery = (props: IProps) => {
   const [state, setState] = useState<IState>({
-    activeImage: null,
+    activeImageIndex: 0,
     showLightbox: false,
     images: [],
-    imgIndex: 0,
   })
 
   useEffect(() => {
     const images = (props.images || []).filter((img) => img !== null)
-    const activeImage = images.length > 0 ? images[0] : null
     setState({
       ...state,
-      activeImage: activeImage,
+      activeImageIndex: 0,
       images: images,
     })
   }, [])
 
-  const setActive = (image: IUploadedFileMeta, imgIndex: number) => {
+  const setActive = (imageIndex: number) => {
     setState({
       ...state,
-      activeImage: image,
-      imgIndex: imgIndex,
+      activeImageIndex: imageIndex,
     })
   }
 
@@ -73,9 +69,11 @@ export const ImageGallery = (props: IProps) => {
     })
 
   const images = state.images
+  const activeImageIndex = state.activeImageIndex
+  const activeImage = images[activeImageIndex]
   const imageNumber = images.length
 
-  return state.activeImage ? (
+  return activeImage ? (
     <Flex sx={{ flexDirection: 'column' }}>
       <Flex sx={{ width: '100%' }}>
         <Image
@@ -87,7 +85,7 @@ export const ImageGallery = (props: IProps) => {
             objectFit: props.allowPortrait ? 'contain' : 'cover',
             height: [300, 450],
           }}
-          src={state.activeImage.downloadUrl}
+          src={activeImage.downloadUrl}
           onClick={() => {
             triggerLightbox()
           }}
@@ -101,8 +99,8 @@ export const ImageGallery = (props: IProps) => {
                 data-cy="thumbnail"
                 mb={3}
                 mt={4}
-                opacity={image === state.activeImage ? 1.0 : 0.5}
-                onClick={() => setActive(image, index)}
+                opacity={image === activeImage ? 1.0 : 0.5}
+                onClick={() => setActive(index)}
                 key={index}
               >
                 <Image
@@ -125,27 +123,23 @@ export const ImageGallery = (props: IProps) => {
 
       {state.showLightbox && (
         <Lightbox
-          mainSrc={state.images[state.imgIndex].downloadUrl}
-          nextSrc={
-            images[(state.imgIndex + 1) % state.images.length].downloadUrl
-          }
+          mainSrc={activeImage.downloadUrl}
+          nextSrc={images[(activeImageIndex + 1) % images.length].downloadUrl}
           prevSrc={
-            state.images[
-              (state.imgIndex + state.images.length - 1) % state.images.length
-            ].downloadUrl
+            images[(activeImageIndex + images.length - 1) % images.length]
+              .downloadUrl
           }
           onMovePrevRequest={() => {
             setState({
               ...state,
-              imgIndex:
-                (state.imgIndex + state.images.length - 1) %
-                state.images.length,
+              activeImageIndex:
+                (activeImageIndex + images.length - 1) % images.length,
             })
           }}
           onMoveNextRequest={() =>
             setState({
               ...state,
-              imgIndex: (state.imgIndex + 1) % state.images.length,
+              activeImageIndex: (activeImageIndex + 1) % images.length,
             })
           }
           onCloseRequest={() => triggerLightbox()}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

It was noticed that when viewing the photos from a gallery and then clicking the main image to open it full screen it would always open the first image rather than the selected one.

This pr updates the imgIndex when clicking through the thumbnails in the ImageGallery component so that the correct image is opened fullscreen.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
