### PR TITLE
fix: label maximum file size limits

### DIFF
--- a/src/common/Form/FileInput/UppyConfig.ts
+++ b/src/common/Form/FileInput/UppyConfig.ts
@@ -2,8 +2,8 @@ import type { UppyOptions } from '@uppy/core'
 
 export const UPPY_CONFIG: Partial<UppyOptions> = {
   restrictions: {
-    // max upload file size in bytes (i.e. 50 x 1000000 => 50 MB)
-    maxFileSize: 50 * 1000000,
+    // max upload file size in bytes (i.e. 50 x 1048576 => 50 MB)
+    maxFileSize: 50 * 1048576,
     maxNumberOfFiles: 5,
     minNumberOfFiles: null,
     allowedFileTypes: null,
@@ -18,7 +18,7 @@ export const UPPY_CONFIG: Partial<UppyOptions> = {
         0: 'You have to select at least %{smart_count} file',
         1: 'You have to select at least %{smart_count} files',
       },
-      exceedsSize: 'This file exceeds maximum allowed size of',
+      exceedsSize: 'This file exceeds maximum allowed size of %{size}',
       youCanOnlyUploadFileTypes: 'You can only upload: %{types}',
       companionError: 'Connection with Companion failed',
     },

--- a/src/pages/Howto/Content/Common/Howto.form.test.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.test.tsx
@@ -41,6 +41,17 @@ jest.mock('src/index', () => {
 })
 
 describe('Howto form', () => {
+  describe('Provides user information', () => {
+    it('shows maximum file size', async () => {
+      // Arrange
+      const formValues = FactoryHowto()
+      // Act
+      const wrapper = getWrapper(formValues, 'edit', {})
+
+      // Assert
+      expect(wrapper.getByText('Maximum file size 50MB')).toBeInTheDocument()
+    })
+  })
   describe('Invalid file warning', () => {
     it('Does not appear when submitting only fileLink', async () => {
       // Arrange

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -463,6 +463,13 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                         data-cy="files"
                                         component={FileInputField}
                                       />
+                                      <Text
+                                        color={'grey'}
+                                        mt={4}
+                                        sx={{ fontSize: 1 }}
+                                      >
+                                        Maximum file size 50MB
+                                      </Text>
                                     </Flex>
                                   </>
                                 )}


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

* Include maxFileSize value in error message from Uppy
* Change configuration to use binary definition for a megabyte
* Introduce hint to UI stating 50Mb maximum

![Screenshot 2023-07-11 at 08 16 31](https://github.com/ONEARMY/community-platform/assets/472589/b866696e-1951-4697-9aae-227084e44324)
