### PR TITLE
feat: allow draft how-to save without form validation

### DIFF
--- a/functions/src/emulator/seed/content-generate.ts
+++ b/functions/src/emulator/seed/content-generate.ts
@@ -47,6 +47,7 @@ async function setMockHowto(user: IMockAuthUser) {
         text: 'Mock generated comment',
       },
     ],
+    previousSlugs: [_id],
   }
   await setDoc('howtos', _id, howto)
 }

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -42,24 +42,28 @@ describe('[How To]', () => {
 
         cy.wrap($step).should(
           'contain',
-          `Descriptions must be at least ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`,
+          `Should be more than ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`,
         )
 
         cy.get('[data-cy=step-description]')
           .clear()
-          .type(
+          .invoke(
+            'val',
             faker.lorem
               .sentences(50)
               .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH + 1),
-            { delay: 1 },
           )
           .blur({ force: true })
 
-        cy.wrap($step).should(
-          'contain',
-          `Descriptions must be less than ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters`,
-        )
+        cy.wrap($step).should('contain', `${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`)
       }
+
+      cy.get('[data-cy=step-description]')
+        .clear()
+        .type(
+          `Description for step ${stepNumber}. This description should be between the minimum and maximum description length`,
+        )
+        .blur({ force: true })
 
       cy.get('[data-cy=step-description]').should('have.value', description)
       cy.get('[data-cy=character-count]')

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -4,6 +4,8 @@ import {
   HOWTO_TITLE_MIN_LENGTH,
   HOWTO_STEP_DESCRIPTION_MIN_LENGTH,
 } from '../../../../../src/pages/Howto/constants'
+const creatorEmail = 'howto_creator@test.com'
+const creatorPassword = 'test1234'
 
 describe('[How To]', () => {
   beforeEach(() => {
@@ -102,6 +104,35 @@ describe('[How To]', () => {
     cy.get('[data-cy=confirm]').click()
   }
 
+  describe('[Draft a how-to]', () => {
+    it('[By Authenticated]', () => {
+      cy.login(creatorEmail, creatorPassword)
+      cy.wait(2000)
+      cy.step('Access the create-how-to')
+      cy.get('[data-cy=create]').click()
+
+      cy.step('Add required title')
+      cy.get('[data-cy=intro-title]').type('Quick draft').blur({ force: true })
+
+      cy.step('Cannot be published')
+      cy.get('[data-cy=submit]').click()
+      cy.contains('Make sure this field is filled correctly').should('exist')
+
+      cy.step('Draft was created')
+      cy.get('[data-cy=draft]').click()
+      cy.get('[data-cy=view-howto]:enabled', { timeout: 20000 })
+        .click()
+        .url()
+        .should('include', `/how-to/quick-draft`)
+      cy.get('[data-cy=moderationstatus-draft]').should('exist')
+
+      // Then add everything so that it could be submitted, but save of draft again
+
+      // Then submit and check again
+
+    })
+  })
+
   describe('[Create a how-to]', () => {
     const expected = {
       _createdBy: 'howto_creator',
@@ -173,7 +204,7 @@ describe('[How To]', () => {
     }
 
     it('[By Authenticated]', () => {
-      cy.login('howto_creator@test.com', 'test1234')
+      cy.login(creatorEmail, creatorPassword)
       cy.wait(2000)
       cy.step('Access the create-how-to')
       cy.get('[data-cy=create]').click()
@@ -254,7 +285,7 @@ describe('[How To]', () => {
       stub.returns(false)
       cy.on('window:confirm', stub)
 
-      cy.login('howto_creator@test.com', 'test1234')
+      cy.login(creatorEmail, creatorPassword)
       cy.wait(2000)
       cy.step('Access the create-how-to')
       cy.get('[data-cy=create]').click()
@@ -380,7 +411,7 @@ describe('[How To]', () => {
     it('[By Authenticated]', () => {
       cy.step('Prevent non-owner access to edit howto')
       cy.visit('/how-to')
-      cy.login('howto_creator@test.com', 'test1234')
+      cy.login(creatorEmail, creatorPassword)
       cy.visit(editHowtoUrl)
       // user should be redirect to how-to page
       cy.location('pathname').should('eq', howtoUrl)

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -34,63 +34,65 @@ describe('[How To]', () => {
     cy.get(`[data-cy=step_${stepIndex}]:visible`).within(($step) => {
       cy.get('[data-cy=step-title]').clear().type(`Step ${stepNumber} is easy`)
 
-      cy.get('[data-cy=step-description]')
-        .clear()
-        .type(`description for step ${stepNumber}`)
-        .blur({ force: true })
+      if (stepIndex === 0) {
+        cy.get('[data-cy=step-description]')
+          .clear()
+          .type(`description for step ${stepNumber}`)
+          .blur({ force: true })
 
-      cy.wrap($step).should(
-        'contain',
-        `Should be more than ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`,
-      )
-
-      cy.get('[data-cy=step-description]')
-        .clear({ force: true })
-        // Speeds up test by avoiding typing and then updates character count by typing
-        .invoke(
-          'val',
-          faker.lorem
-            .sentences(50)
-            .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH - 1),
+        cy.wrap($step).should(
+          'contain',
+          `Should be more than ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`,
         )
-        .type('Reach maximum character count')
 
-      cy.wrap($step).should(
-        'contain',
-        `${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`,
-      )
+        cy.get('[data-cy=step-description]')
+          .clear({ force: true })
+          // Speeds up test by avoiding typing and then updates character count by typing
+          .invoke(
+            'val',
+            faker.lorem
+              .sentences(50)
+              .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH - 1),
+          )
+          .type('Reach maximum character count')
 
-      cy.get('[data-cy=step-description]')
-        .clear()
-        .type(
-          `Description for step ${stepNumber}. This description should be between the minimum and maximum description length`,
+        cy.wrap($step).should(
+          'contain',
+          `${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`,
         )
-        .blur({ force: true })
 
-      cy.get('[data-cy=step-description]').should('have.value', description)
-      cy.get('[data-cy=character-count]')
-        .should('be.visible')
-        .contains(`101 / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`)
+        cy.get('[data-cy=step-description]')
+          .clear()
+          .type(
+            `Description for step ${stepNumber}. This description should be between the minimum and maximum description length`,
+          )
+          .blur({ force: true })
 
-      if (videoUrl) {
-        cy.step('Adding Video Url')
-        cy.get('[data-cy=step-videoUrl]').clear().type(videoUrl)
-      } else {
-        cy.step('Uploading pics')
-        const hasExistingPics =
-          Cypress.$($step).find('[data-cy=delete-step-img]').length > 0
-        if (hasExistingPics) {
-          cy.wrap($step)
-            .find('[data-cy=delete-image]')
-            .each(($deleteButton) => {
-              cy.wrap($deleteButton).click()
-            })
+        cy.get('[data-cy=step-description]').should('have.value', description)
+        cy.get('[data-cy=character-count]')
+          .should('be.visible')
+          .contains(`101 / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`)
+
+        if (videoUrl) {
+          cy.step('Adding Video Url')
+          cy.get('[data-cy=step-videoUrl]').clear().type(videoUrl)
+        } else {
+          cy.step('Uploading pics')
+          const hasExistingPics =
+            Cypress.$($step).find('[data-cy=delete-step-img]').length > 0
+          if (hasExistingPics) {
+            cy.wrap($step)
+              .find('[data-cy=delete-image]')
+              .each(($deleteButton) => {
+                cy.wrap($deleteButton).click()
+              })
+          }
+          images.forEach((image, index) => {
+            cy.get(`[data-cy=step-image-${index}]`)
+              .find(':file')
+              .attachFile(image)
+          })
         }
-        images.forEach((image, index) => {
-          cy.get(`[data-cy=step-image-${index}]`)
-            .find(':file')
-            .attachFile(image)
-        })
       }
     })
   }
@@ -129,7 +131,6 @@ describe('[How To]', () => {
       // Then add everything so that it could be submitted, but save of draft again
 
       // Then submit and check again
-
     })
   })
 

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -13,16 +13,15 @@ import type { ISelectedTags } from './tags.model'
 // By default all how-to form input fields come as strings
 // The IHowto interface can imposes the correct formats on fields
 // Additionally convert from local filemeta to uploaded filemeta
-export interface IHowto extends IHowtoFormInput, IModerable, ISharedFeatures {
+export interface IHowto extends IHowtoFormInput {
   _createdBy: string
-  cover_image: IUploadedFileMeta
+  cover_image?: IUploadedFileMeta
   fileLink?: string
-  files: Array<IUploadedFileMeta | File | null>
-  steps: IHowtoStep[]
   // Comments were added in V2, old howto's may not have the property
   comments?: IComment[]
   total_downloads?: number
   mentions: UserMention[]
+  previousSlugs: string[]
 }
 
 /**
@@ -32,34 +31,36 @@ export type IHowtoDB = IHowto & DBDoc
 
 export interface IHowtoStep extends IHowToStepFormInput {
   // *** NOTE - adding an '_animationKey' field to track when specific array element removed for
-  images: Array<IUploadedFileMeta | null>
+  images?: Array<IUploadedFileMeta | null>
   videoUrl?: string
-  title: string
-  text: string
+  title?: string
+  text?: string
   _animationKey?: string
 }
 
 export interface IHowToStepFormInput {
-  images: Array<IUploadedFileMeta | IConvertedFileMeta | null>
-  title: string
-  text: string
+  images?: Array<IUploadedFileMeta | IConvertedFileMeta | null>
+  title?: string
+  text?: string
+  videoUrl?: string
   _animationKey?: string
 }
 
-export interface IHowtoFormInput extends IModerable {
-  // NOTE cover image input starts as convertedFileMeta but is transformed on upload
-  cover_image: IUploadedFileMeta | IConvertedFileMeta
-  title: string
-  description: string
-  difficulty_level: 'Easy' | 'Medium' | 'Hard' | 'Very Hard'
-  time: string
-  fileLink?: string
-  files: Array<IUploadedFileMeta | File | null>
-  steps: IHowToStepFormInput[]
+export interface IHowtoFormInput extends IModerable, ISharedFeatures {
   slug: string
+  title: string
   category?: ICategory
-  // note, tags will remain optional as if populated {} will be stripped by db (firestore)
-  tags?: ISelectedTags
+  // NOTE cover image input starts as convertedFileMeta but is transformed on upload
+  cover_image?: IUploadedFileMeta | IConvertedFileMeta
   // Added to be able to recover on edit by admin
   creatorCountry?: string
+  description?: string
+  difficulty_level?: 'Easy' | 'Medium' | 'Hard' | 'Very Hard'
+  files?: Array<IUploadedFileMeta | File | null>
+  fileLink?: string
+  mentions?: UserMention[]
+  steps: IHowToStepFormInput[] | []
+  // note, tags will remain optional as if populated {} will be stripped by db (firestore)
+  tags?: ISelectedTags
+  time?: string
 }

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -59,7 +59,7 @@ export interface IHowtoFormInput extends IModerable, ISharedFeatures {
   files?: Array<IUploadedFileMeta | File | null>
   fileLink?: string
   mentions?: UserMention[]
-  steps: IHowToStepFormInput[] | []
+  steps: IHowToStepFormInput[]
   // note, tags will remain optional as if populated {} will be stripped by db (firestore)
   tags?: ISelectedTags
   time?: string

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -36,6 +36,7 @@ import {
   setAllowDraftSaveTrue,
   validateTitle,
   validateUrlAcceptEmpty,
+  validationWrapper,
 } from 'src/utils/validators'
 import IconHeaderHowto from 'src/assets/images/header-section/howto-header-icon.svg'
 import { COMPARISONS } from 'src/utils/comparisons'
@@ -129,9 +130,6 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
       this.setState({ showInvalidFileWarning: false })
       return true
     }
-  }
-  private validationWrapper = (value, allValues, validator) => {
-    return allValues.allowDraftSave ? undefined : validator(value)
   }
   public onSubmit = async (formValues: IHowtoFormInput) => {
     if (!this.checkFilesValid(formValues)) {
@@ -338,7 +336,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   id="time"
                                   name="time"
                                   validate={(values, allValues) =>
-                                    this.validationWrapper(
+                                    validationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -365,7 +363,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   name="difficulty_level"
                                   data-cy="difficulty-select"
                                   validate={(values, allValues) =>
-                                    this.validationWrapper(
+                                    validationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -387,7 +385,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   name="description"
                                   data-cy="intro-description"
                                   validate={(values, allValues) =>
-                                    this.validationWrapper(
+                                    validationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -486,7 +484,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                         isEqual={COMPARISONS.textInput}
                                         maxLength={MAX_LINK_LENGTH}
                                         validate={(values, allValues) =>
-                                          this.validationWrapper(
+                                          validationWrapper(
                                             values,
                                             allValues,
                                             validateUrlAcceptEmpty,
@@ -539,7 +537,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   id="cover_image"
                                   name="cover_image"
                                   validate={(values, allValues) =>
-                                    this.validationWrapper(
+                                    validationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -589,7 +587,6 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                     onDelete={(fieldIndex: number) => {
                                       fields.remove(fieldIndex)
                                     }}
-                                    validationWrapper={this.validationWrapper}
                                   />
                                 </AnimationContainer>
                               ))}

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -29,11 +29,13 @@ import { PostingGuidelines } from './PostingGuidelines'
 import { DIFFICULTY_OPTIONS, TIME_OPTIONS } from './FormSettings'
 import { HowToSubmitStatus } from './SubmitStatus'
 import {
-  required,
-  validateUrlAcceptEmpty,
-  minValue,
   composeValidators,
+  minValue,
+  required,
+  setAllowDraftSaveFalse,
+  setAllowDraftSaveTrue,
   validateTitle,
+  validateUrlAcceptEmpty,
 } from 'src/utils/validators'
 import IconHeaderHowto from 'src/assets/images/header-section/howto-header-icon.svg'
 import { COMPARISONS } from 'src/utils/comparisons'
@@ -205,12 +207,8 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
           }}
           initialValues={formValues}
           mutators={{
-            setAllowDraftSaveTrue: (_, state, utils) => {
-              utils.changeValue(state, 'allowDraftSave', () => true)
-            },
-            setAllowDraftSaveFalse: (_, state, utils) => {
-              utils.changeValue(state, 'allowDraftSave', () => false)
-            },
+            setAllowDraftSaveTrue,
+            setAllowDraftSaveFalse,
             ...arrayMutators,
           }}
           validateOnBlur
@@ -647,7 +645,9 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                     <Box sx={{ display: ['none', 'none', 'block'] }}>
                       <PostingGuidelines />
                     </Box>
-                    <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
+                    <Flex
+                      sx={{ flexDirection: 'column', alignItems: 'center' }}
+                    >
                       <Button
                         data-cy={'draft'}
                         onClick={() => {

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -647,24 +647,29 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                     <Box sx={{ display: ['none', 'none', 'block'] }}>
                       <PostingGuidelines />
                     </Box>
-                    <Button
-                      data-cy={'draft'}
-                      onClick={() => {
-                        form.mutators.setAllowDraftSaveTrue()
-                        this.trySubmitForm(true)
-                      }}
-                      mt={[0, 0, 3]}
-                      variant="secondary"
-                      type="submit"
-                      disabled={submitting}
-                      sx={{ width: '100%', display: 'block' }}
-                    >
-                      {formValues.moderation !== 'draft' ? (
-                        <span>Save to draft</span>
-                      ) : (
-                        <span>Revert to draft</span>
-                      )}
-                    </Button>
+                    <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
+                      <Button
+                        data-cy={'draft'}
+                        onClick={() => {
+                          form.mutators.setAllowDraftSaveTrue()
+                          this.trySubmitForm(true)
+                        }}
+                        mt={[0, 0, 3]}
+                        variant="secondary"
+                        type="submit"
+                        disabled={submitting}
+                        sx={{ width: '100%', display: 'block' }}
+                      >
+                        {formValues.moderation !== 'draft' ? (
+                          <span>Save draft</span>
+                        ) : (
+                          <span>Revert to draft</span>
+                        )}
+                      </Button>
+                      <Text sx={{ fontSize: 1, textAlign: 'center' }}>
+                        A draft can be saved any time
+                      </Text>
+                    </Flex>
                     <Button
                       large
                       data-cy={'submit'}

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -30,13 +30,13 @@ import { DIFFICULTY_OPTIONS, TIME_OPTIONS } from './FormSettings'
 import { HowToSubmitStatus } from './SubmitStatus'
 import {
   composeValidators,
+  draftValidationWrapper,
   minValue,
   required,
   setAllowDraftSaveFalse,
   setAllowDraftSaveTrue,
   validateTitle,
   validateUrlAcceptEmpty,
-  validationWrapper,
 } from 'src/utils/validators'
 import IconHeaderHowto from 'src/assets/images/header-section/howto-header-icon.svg'
 import { COMPARISONS } from 'src/utils/comparisons'
@@ -336,7 +336,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   id="time"
                                   name="time"
                                   validate={(values, allValues) =>
-                                    validationWrapper(
+                                    draftValidationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -363,7 +363,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   name="difficulty_level"
                                   data-cy="difficulty-select"
                                   validate={(values, allValues) =>
-                                    validationWrapper(
+                                    draftValidationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -385,7 +385,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   name="description"
                                   data-cy="intro-description"
                                   validate={(values, allValues) =>
-                                    validationWrapper(
+                                    draftValidationWrapper(
                                       values,
                                       allValues,
                                       required,
@@ -484,7 +484,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                         isEqual={COMPARISONS.textInput}
                                         maxLength={MAX_LINK_LENGTH}
                                         validate={(values, allValues) =>
-                                          validationWrapper(
+                                          draftValidationWrapper(
                                             values,
                                             allValues,
                                             validateUrlAcceptEmpty,
@@ -537,7 +537,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   id="cover_image"
                                   name="cover_image"
                                   validate={(values, allValues) =>
-                                    validationWrapper(
+                                    draftValidationWrapper(
                                       values,
                                       allValues,
                                       required,

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -7,10 +7,10 @@ import styled from '@emotion/styled'
 import type { IHowtoStep } from 'src/models/howto.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import {
+  draftValidationWrapper,
   required,
   minValue,
   composeValidators,
-  validationWrapper,
 } from 'src/utils/validators'
 import { COMPARISONS } from 'src/utils/comparisons'
 import {
@@ -170,7 +170,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
               maxLength={HOWTO_TITLE_MAX_LENGTH}
               minLength={HOWTO_TITLE_MIN_LENGTH}
               validate={(value, allValues) =>
-                validationWrapper(
+                draftValidationWrapper(
                   value,
                   allValues,
                   composeValidators(required, minValue(HOWTO_TITLE_MIN_LENGTH)),
@@ -196,7 +196,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
               component={FieldTextarea}
               style={{ resize: 'vertical', height: '300px' }}
               validate={(value, allValues) =>
-                validationWrapper(
+                draftValidationWrapper(
                   value,
                   allValues,
                   composeValidators(
@@ -252,7 +252,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
               component={FieldInput}
               placeholder="https://youtube.com/watch?v="
               validate={(value, allValues) =>
-                validationWrapper(
+                draftValidationWrapper(
                   value,
                   allValues,
                   this.validateMedia.bind(this),

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -28,6 +28,11 @@ interface IProps {
   images: IUploadedFileMeta[]
   onDelete: (index: number) => void
   moveStep: (indexfrom: number, indexTo: number) => void
+  validationWrapper: (
+    value: string,
+    allValues: any,
+    validator: (string) => void,
+  ) => void
 }
 interface IState {
   showDeleteModal: boolean
@@ -81,7 +86,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
    * @param value - How to step description field value
    */
   render() {
-    const { step, index } = this.props
+    const { step, index, validationWrapper } = this.props
     const _labelStyle = {
       fontSize: 2,
       marginBottom: 2,
@@ -164,10 +169,13 @@ class HowtoStep extends PureComponent<IProps, IState> {
               placeholder={`Title of this step (max ${HOWTO_TITLE_MAX_LENGTH} characters)`}
               maxLength={HOWTO_TITLE_MAX_LENGTH}
               minLength={HOWTO_TITLE_MIN_LENGTH}
-              validate={composeValidators(
-                required,
-                minValue(HOWTO_TITLE_MIN_LENGTH),
-              )}
+              validate={(value, allValues) =>
+                validationWrapper(
+                  value,
+                  allValues,
+                  composeValidators(required, minValue(HOWTO_TITLE_MIN_LENGTH)),
+                )
+              }
               validateFields={[]}
               isEqual={COMPARISONS.textInput}
               showCharacterCount
@@ -187,10 +195,16 @@ class HowtoStep extends PureComponent<IProps, IState> {
               modifiers={{ capitalize: true }}
               component={FieldTextarea}
               style={{ resize: 'vertical', height: '300px' }}
-              validate={composeValidators(
-                required,
-                minValue(HOWTO_STEP_DESCRIPTION_MIN_LENGTH),
-              )}
+              validate={(value, allValues) =>
+                validationWrapper(
+                  value,
+                  allValues,
+                  composeValidators(
+                    required,
+                    minValue(HOWTO_STEP_DESCRIPTION_MIN_LENGTH),
+                  ),
+                )
+              }
               validateFields={[]}
               isEqual={COMPARISONS.textInput}
               showCharacterCount
@@ -237,7 +251,13 @@ class HowtoStep extends PureComponent<IProps, IState> {
               data-cy="step-videoUrl"
               component={FieldInput}
               placeholder="https://youtube.com/watch?v="
-              validate={(url) => this.validateMedia(url)}
+              validate={(value, allValues) =>
+                validationWrapper(
+                  value,
+                  allValues,
+                  this.validateMedia.bind(this),
+                )
+              }
               validateFields={[]}
               isEqual={COMPARISONS.textInput}
             />

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -6,7 +6,12 @@ import { Button, FieldInput, FieldTextarea, Modal } from 'oa-components'
 import styled from '@emotion/styled'
 import type { IHowtoStep } from 'src/models/howto.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
-import { required, minValue, composeValidators } from 'src/utils/validators'
+import {
+  required,
+  minValue,
+  composeValidators,
+  validationWrapper,
+} from 'src/utils/validators'
 import { COMPARISONS } from 'src/utils/comparisons'
 import {
   HOWTO_STEP_DESCRIPTION_MIN_LENGTH,
@@ -28,11 +33,6 @@ interface IProps {
   images: IUploadedFileMeta[]
   onDelete: (index: number) => void
   moveStep: (indexfrom: number, indexTo: number) => void
-  validationWrapper: (
-    value: string,
-    allValues: any,
-    validator: (string) => void,
-  ) => void
 }
 interface IState {
   showDeleteModal: boolean
@@ -86,7 +86,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
    * @param value - How to step description field value
    */
   render() {
-    const { step, index, validationWrapper } = this.props
+    const { step, index } = this.props
     const _labelStyle = {
       fontSize: 2,
       marginBottom: 2,

--- a/src/pages/Howto/Content/Howto/Howto.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.tsx
@@ -96,7 +96,7 @@ export class Howto extends React.Component<
 > {
   private moderateHowto = async (accepted: boolean) => {
     const _howto = this.store.activeHowto
-    if (_howto) {
+    if (_howto && _howto.moderation !== 'draft') {
       _howto.moderation = accepted ? 'accepted' : 'rejected'
       await this.store.moderateHowto(_howto)
     }
@@ -144,7 +144,7 @@ export class Howto extends React.Component<
     seoTagsUpdate({
       title: this.store.activeHowto?.title,
       description: this.store.activeHowto?.description,
-      imageUrl: this.store.activeHowto?.cover_image.downloadUrl,
+      imageUrl: this.store.activeHowto?.cover_image?.downloadUrl,
     })
     this.setState({
       isLoading: false,

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -305,22 +305,23 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
                 redirectToSignIn={!loggedInUser ? redirectToSignIn : undefined}
               />
             )}
-            {howto.files
-              .filter(Boolean)
-              .map(
-                (file, index) =>
-                  file && (
-                    <DownloadStaticFile
-                      allowDownload
-                      file={file}
-                      key={file ? file.name : `file-${index}`}
-                      handleClick={handleDownloadClick}
-                      redirectToSignIn={
-                        !loggedInUser ? redirectToSignIn : undefined
-                      }
-                    />
-                  ),
-              )}
+            {howto.files &&
+              howto.files
+                .filter(Boolean)
+                .map(
+                  (file, index) =>
+                    file && (
+                      <DownloadStaticFile
+                        allowDownload
+                        file={file}
+                        key={file ? file.name : `file-${index}`}
+                        handleClick={handleDownloadClick}
+                        redirectToSignIn={
+                          !loggedInUser ? redirectToSignIn : undefined
+                        }
+                      />
+                    ),
+                )}
             {typeof fileDownloadCount === 'number' && (
               <Text
                 data-cy="file-download-counter"
@@ -343,17 +344,19 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
           position: 'relative',
         }}
       >
-        <AspectImage
-          loading="lazy"
-          ratio={12 / 9}
-          sx={{
-            objectFit: 'cover',
-            width: '100%',
-          }}
-          src={howto.cover_image.downloadUrl}
-          crossOrigin=""
-          alt="how-to cover"
-        />
+        {howto.cover_image && (
+          <AspectImage
+            loading="lazy"
+            ratio={12 / 9}
+            sx={{
+              objectFit: 'cover',
+              width: '100%',
+            }}
+            src={howto.cover_image.downloadUrl}
+            crossOrigin=""
+            alt="how-to cover"
+          />
+        )}
         {howto.moderation !== 'accepted' && (
           <ModerationStatus
             status={howto.moderation}

--- a/src/pages/Howto/Content/Howto/Step/Step.tsx
+++ b/src/pages/Howto/Content/Howto/Step/Step.tsx
@@ -57,7 +57,7 @@ export default class Step extends PureComponent<IProps> {
                 >
                   <Heading mb={0}>
                     {/* HACK 2021-07-16 - new howtos auto capitalize title but not older */}
-                    {capitalizeFirstLetter(step.title)}
+                    {step.title && capitalizeFirstLetter(step.title)}
                   </Heading>
                   <Box>
                     <Text
@@ -70,7 +70,7 @@ export default class Step extends PureComponent<IProps> {
                     >
                       <LinkifyText>
                         {/* HACK 2021-07-16 - new howtos auto capitalize title but not older */}
-                        {capitalizeFirstLetter(step.text)}
+                        {step.text && capitalizeFirstLetter(step.text)}
                       </LinkifyText>
                     </Text>
                   </Box>

--- a/src/pages/Howto/Content/HowtoList/HowToCard.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowToCard.tsx
@@ -47,7 +47,7 @@ export const HowToCard = (props: IProps) => {
                 objectFit: 'cover',
               }}
               threshold={500}
-              src={howto.cover_image.downloadUrl}
+              src={howto.cover_image?.downloadUrl}
               crossOrigin=""
             />
           </Flex>

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -26,7 +26,7 @@ import {
   setAllowDraftSaveFalse,
   setAllowDraftSaveTrue,
   validateTitle,
-  validationWrapper,
+  draftValidationWrapper,
 } from 'src/utils/validators'
 import { PostingGuidelines } from './PostingGuidelines'
 import { ResearchSubmitStatus } from './SubmitStatus'
@@ -231,7 +231,7 @@ const ResearchForm = observer((props: IProps) => {
                                 name="description"
                                 data-cy="intro-description"
                                 validate={(value, allValues) =>
-                                  validationWrapper(
+                                  draftValidationWrapper(
                                     value,
                                     allValues,
                                     (value, allValues) =>

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -20,9 +20,11 @@ import { useResearchStore } from 'src/stores/Research/research.store'
 import { COMPARISONS } from 'src/utils/comparisons'
 import { stripSpecialCharacters } from 'src/utils/helpers'
 import {
-  required,
-  minValue,
   composeValidators,
+  minValue,
+  required,
+  setAllowDraftSaveFalse,
+  setAllowDraftSaveTrue,
   validateTitle,
 } from 'src/utils/validators'
 import { PostingGuidelines } from './PostingGuidelines'
@@ -133,12 +135,8 @@ const ResearchForm = observer((props: IProps) => {
         }}
         initialValues={props.formValues}
         mutators={{
-          setIsDraftTrue: (_, state, utils) => {
-            utils.changeValue(state, 'isDraft', () => true)
-          },
-          setIsDraftFalse: (_, state, utils) => {
-            utils.changeValue(state, 'isDraft', () => false)
-          },
+          setAllowDraftSaveFalse,
+          setAllowDraftSaveTrue,
           ...arrayMutators,
         }}
         validateOnBlur
@@ -321,7 +319,7 @@ const ResearchForm = observer((props: IProps) => {
                   <Button
                     data-cy={'draft'}
                     onClick={() => {
-                      form.mutators.setIsDraftTrue()
+                      form.mutators.setAllowDraftSaveTrue()
                       setSubmissionHandler({ shouldSubmit: true, draft: true })
                     }}
                     mt={[0, 0, 3]}
@@ -340,7 +338,7 @@ const ResearchForm = observer((props: IProps) => {
                     large
                     data-cy={'submit'}
                     onClick={() => {
-                      form.mutators.setIsDraftFalse()
+                      form.mutators.setAllowDraftSaveFalse()
                       setSubmissionHandler({
                         shouldSubmit: true,
                         draft: false,

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -26,6 +26,7 @@ import {
   setAllowDraftSaveFalse,
   setAllowDraftSaveTrue,
   validateTitle,
+  validationWrapper,
 } from 'src/utils/validators'
 import { PostingGuidelines } from './PostingGuidelines'
 import { ResearchSubmitStatus } from './SubmitStatus'
@@ -230,9 +231,14 @@ const ResearchForm = observer((props: IProps) => {
                                 name="description"
                                 data-cy="intro-description"
                                 validate={(value, allValues) =>
-                                  allValues.isDraft
-                                    ? undefined
-                                    : required(value)
+                                  validationWrapper(
+                                    value,
+                                    allValues,
+                                    (value, allValues) =>
+                                      allValues.isDraft
+                                        ? undefined
+                                        : required(value),
+                                  )
                                 }
                                 validateFields={[]}
                                 isEqual={COMPARISONS.textInput}

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -234,10 +234,7 @@ const ResearchForm = observer((props: IProps) => {
                                   draftValidationWrapper(
                                     value,
                                     allValues,
-                                    (value, allValues) =>
-                                      allValues.isDraft
-                                        ? undefined
-                                        : required(value),
+                                    required,
                                   )
                                 }
                                 validateFields={[]}

--- a/src/stores/Howto/howto.store.test.ts
+++ b/src/stores/Howto/howto.store.test.ts
@@ -69,8 +69,6 @@ const factory = async (
 
 describe('howto.store', () => {
   describe('uploadHowTo', () => {
-    it.todo('updates an existing item')
-
     it('creates a draft when only a title is provided', async () => {
       const howtos = [FactoryHowtoDraft({})]
       const { store, howToItem, setFn } = await factory(howtos)
@@ -80,6 +78,28 @@ describe('howto.store', () => {
       const [newHowto] = setFn.mock.calls[0]
       expect(setFn).toHaveBeenCalledTimes(1)
       expect(newHowto.title).toBe('Quick draft')
+    })
+
+    it('updates an existing item', async () => {
+      const { store, setFn } = await factory()
+
+      const howto = FactoryHowtoDraft({})
+      await store.uploadHowTo(howto)
+
+      const [originalHowto] = setFn.mock.calls[0]
+      expect(setFn).toHaveBeenCalledTimes(1)
+      expect(originalHowto.title).toBe('Quick draft')
+
+      const updatedHowtos = FactoryHowtoDraft({
+        _id: originalHowto._id,
+        steps: [FactoryHowtoStep(), FactoryHowtoStep(), FactoryHowtoStep()],
+      })
+
+      await store.uploadHowTo(updatedHowtos)
+
+      const [finalHowto] = setFn.mock.calls[1]
+      expect(setFn).toHaveBeenCalledTimes(2)
+      expect(finalHowto.steps).toHaveLength(3)
     })
 
     it('captures mentions within description', async () => {

--- a/src/stores/Howto/howto.store.test.ts
+++ b/src/stores/Howto/howto.store.test.ts
@@ -1,7 +1,11 @@
 jest.mock('../common/module.store')
 import type { IHowtoDB, IUser } from 'src/models'
 import { FactoryComment } from 'src/test/factories/Comment'
-import { FactoryHowto, FactoryHowtoStep } from 'src/test/factories/Howto'
+import {
+  FactoryHowto,
+  FactoryHowtoDraft,
+  FactoryHowtoStep,
+} from 'src/test/factories/Howto'
 import { FactoryUser } from 'src/test/factories/User'
 import type { RootStore } from '..'
 import { HowtoStore } from './howto.store'
@@ -66,6 +70,17 @@ const factory = async (
 describe('howto.store', () => {
   describe('uploadHowTo', () => {
     it.todo('updates an existing item')
+
+    it('creates a draft when only a title is provided', async () => {
+      const howtos = [FactoryHowtoDraft({})]
+      const { store, howToItem, setFn } = await factory(howtos)
+
+      await store.uploadHowTo(howToItem)
+
+      const [newHowto] = setFn.mock.calls[0]
+      expect(setFn).toHaveBeenCalledTimes(1)
+      expect(newHowto.title).toBe('Quick draft')
+    })
 
     it('captures mentions within description', async () => {
       const howtos = [

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -511,6 +511,9 @@ export class HowtoStore extends ModuleStore {
       const fileLink = values.fileLink ?? ''
       const mentions = (values as IHowtoDB)?.mentions ?? []
       const previousSlugs = (values as IHowtoDB).previousSlugs ?? []
+      if (!previousSlugs.includes(slug)) {
+        previousSlugs.push(slug)
+      }
       const total_downloads = values['total_downloads'] ?? 0
 
       const howTo: IHowto = {

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -20,7 +20,6 @@ import type { IConvertedFileMeta } from 'src/types'
 import { getUserCountry } from 'src/utils/getUserCountry'
 import {
   filterModerableItems,
-  formatLowerNoSpecial,
   hasAdminRights,
   needsModeration,
   randomID,
@@ -374,10 +373,6 @@ export class HowtoStore extends ModuleStore {
       }),
     )
 
-    if (howToItem.previousSlugs === undefined) {
-      howToItem.previousSlugs = []
-    }
-
     if (!howToItem.previousSlugs.includes(howToItem.slug)) {
       howToItem.previousSlugs.push(howToItem.slug)
     }
@@ -522,16 +517,6 @@ export class HowtoStore extends ModuleStore {
       this.updateUploadStatus('Files')
 
       // populate DB
-      // create previousSlugs based on available slug or title
-      const previousSlugs: string[] = []
-      if (values.slug) {
-        previousSlugs.push(values.slug)
-      } else if (values.title) {
-        const titleToSlug = formatLowerNoSpecial(values.title)
-        previousSlugs.push(titleToSlug)
-      }
-
-      // populate DB
 
       const {
         description,
@@ -546,6 +531,7 @@ export class HowtoStore extends ModuleStore {
       const creatorCountry = this.setCreatorCountry(user, values)
       const fileLink = values.fileLink ?? ''
       const mentions = (values as IHowtoDB)?.mentions ?? []
+      const previousSlugs = (values as IHowtoDB).previousSlugs ?? []
       const total_downloads =
         files && !values['total_downloads'] ? 0 : values['total_downloads']
 

--- a/src/stores/common/mentions/index.ts
+++ b/src/stores/common/mentions/index.ts
@@ -18,12 +18,13 @@ import type { UserStore } from '../../User/user.store'
  * }>
  */
 export const changeMentionToUserReference = async (
-  text: string,
+  text: string | undefined,
   userStore: UserStore,
 ): Promise<{
   text: string
   mentionedUsers: string[]
 }> => {
+  text = text || ''
   const mentions = text.match(/\B@[​a-z0-9_-]+/g)
   const mentionedUsers = new Set<string>()
 

--- a/src/stores/common/mentions/index.ts
+++ b/src/stores/common/mentions/index.ts
@@ -18,13 +18,12 @@ import type { UserStore } from '../../User/user.store'
  * }>
  */
 export const changeMentionToUserReference = async (
-  text: string | undefined,
+  text: string,
   userStore: UserStore,
 ): Promise<{
   text: string
   mentionedUsers: string[]
 }> => {
-  text = text || ''
   const mentions = text.match(/\B@[​a-z0-9_-]+/g)
   const mentionedUsers = new Set<string>()
 

--- a/src/test/factories/Howto.ts
+++ b/src/test/factories/Howto.ts
@@ -64,3 +64,24 @@ export const FactoryHowtoStep = (
   text: faker.lorem.paragraphs(2),
   ...howtoStepOverloads,
 })
+
+export const FactoryHowtoDraft = (
+  howtoOverloads: Partial<IHowtoDB> = {},
+): IHowtoDB => ({
+  _id: faker.datatype.uuid(),
+  _contentModifiedTimestamp: faker.date.past().toString(),
+  _created: faker.date.past().toString(),
+  _createdBy: faker.internet.userName(),
+  _deleted: false,
+  _modified: faker.date.past().toString(),
+  files: [],
+  slug: 'quick-draft',
+  moderation: 'draft',
+  mentions: [],
+  title: 'Quick draft',
+  steps: [],
+  previousSlugs: [],
+  tags: {},
+  total_downloads: 0,
+  ...howtoOverloads,
+})

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -1,0 +1,27 @@
+import { draftValidationWrapper } from './validators'
+
+describe('draftValidationWrapper', () => {
+  it('returns the validator when draft save is not allowed', () => {
+    const allValues = {
+      allowDraftSave: false,
+    }
+    const value = 'title'
+    const validator = jest.fn()
+
+    draftValidationWrapper(value, allValues, validator)
+
+    expect(validator).toHaveBeenCalledWith(value)
+  })
+
+  it('returns undefined when draft save is allowed', () => {
+    const allValues = {
+      allowDraftSave: true,
+    }
+    const value = 'title'
+    const validator = jest.fn()
+
+    draftValidationWrapper(value, allValues, validator)
+
+    expect(validator).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -86,11 +86,20 @@ const addProtocolMutator = ([name], state, { changeValue }) => {
 const ensureExternalUrl = (url: string) =>
   typeof url === 'string' && url.indexOf('://') === -1 ? `https://${url}` : url
 
+const setAllowDraftSaveFalse = (_, state, utils) =>
+  utils.changeValue(state, 'allowDraftSave', () => false)
+
+const setAllowDraftSaveTrue = (_, state, utils) => {
+  utils.changeValue(state, 'allowDraftSave', () => true)
+}
+
 export {
   validateUrl,
   validateUrlAcceptEmpty,
   validateEmail,
   required,
+  setAllowDraftSaveFalse,
+  setAllowDraftSaveTrue,
   addProtocolMutator,
   ensureExternalUrl,
   maxValue,

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -73,8 +73,8 @@ const validateTitle =
 
     return await store.validateTitleForSlug(value, documentType, originalId)
   }
-  
-const validationWrapper = (value, allValues, validator) => {
+
+const draftValidationWrapper = (value, allValues, validator) => {
   return allValues.allowDraftSave ? undefined : validator(value)
 }
 
@@ -103,7 +103,7 @@ export {
   validateUrl,
   validateUrlAcceptEmpty,
   validateEmail,
-  validationWrapper,
+  draftValidationWrapper,
   required,
   setAllowDraftSaveFalse,
   setAllowDraftSaveTrue,

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -5,6 +5,8 @@ import type { ResearchStore } from 'src/stores/Research/research.store'
 
 type documentTypes = 'howtos' | 'research'
 type storeTypes = HowtoStore | ResearchStore
+
+import type { Mutator } from 'final-form'
 /****************************************************************************
  *            General Validation Methods
  * **************************************************************************/
@@ -71,6 +73,10 @@ const validateTitle =
 
     return await store.validateTitleForSlug(value, documentType, originalId)
   }
+  
+const validationWrapper = (value, allValues, validator) => {
+  return allValues.allowDraftSave ? undefined : validator(value)
+}
 
 /****************************************************************************
  *            FORM MUTATORS
@@ -86,10 +92,10 @@ const addProtocolMutator = ([name], state, { changeValue }) => {
 const ensureExternalUrl = (url: string) =>
   typeof url === 'string' && url.indexOf('://') === -1 ? `https://${url}` : url
 
-const setAllowDraftSaveFalse = (_, state, utils) =>
+const setAllowDraftSaveFalse: Mutator = (_, state, utils) =>
   utils.changeValue(state, 'allowDraftSave', () => false)
 
-const setAllowDraftSaveTrue = (_, state, utils) => {
+const setAllowDraftSaveTrue: Mutator = (_, state, utils) => {
   utils.changeValue(state, 'allowDraftSave', () => true)
 }
 
@@ -97,6 +103,7 @@ export {
   validateUrl,
   validateUrlAcceptEmpty,
   validateEmail,
+  validationWrapper,
   required,
   setAllowDraftSaveFalse,
   setAllowDraftSaveTrue,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This allows users to save a draft how-to with (at a minimum) a title provided. The smallest UI change has been done to enable this. But a lot of store changes were required for this to happen smoothly.

## Git Issues

Closes #2540 

## Screenshots/Videos

<img width="485" alt="Screenshot 2023-07-13 at 09 11 42" src="https://github.com/ONEARMY/community-platform/assets/16688508/7844b007-d101-4a14-8509-4efb4bc6c484">
