### PR TITLE
fix: increase memory limit

### DIFF
--- a/functions/src/emailNotifications/index.ts
+++ b/functions/src/emailNotifications/index.ts
@@ -5,8 +5,11 @@ import { DB_ENDPOINTS, IUserDB } from '../models'
 import { EmailNotificationFrequency } from 'oa-shared'
 import { withErrorAlerting } from '../alerting/errorAlerting'
 
-exports.sendDaily = functions.pubsub
-  // Trigger daily at 3pm PT (https://crontab.guru/#0_15_*_*_*)
+const EMAIL_FUNCTION_MEMORY_LIMIT = '512MB'
+
+exports.sendDaily = functions
+  .runWith({ memory: EMAIL_FUNCTION_MEMORY_LIMIT })
+  .pubsub // Trigger daily at 3pm PT (https://crontab.guru/#0_15_*_*_*)
   .schedule('0 15 * * *')
   .timeZone('Europe/Lisbon')
   .onRun((context) =>
@@ -15,8 +18,9 @@ exports.sendDaily = functions.pubsub
     ),
   )
 
-exports.sendWeekly = functions.pubsub
-  // Trigger weekly at 3pm PT on Sunday (https://crontab.guru/#0_15_*_*_0)
+exports.sendWeekly = functions
+  .runWith({ memory: EMAIL_FUNCTION_MEMORY_LIMIT })
+  .pubsub // Trigger weekly at 3pm PT on Sunday (https://crontab.guru/#0_15_*_*_0)
   .schedule('0 15 * * 0')
   .timeZone('Europe/Lisbon')
   .onRun(async (context) =>
@@ -25,8 +29,9 @@ exports.sendWeekly = functions.pubsub
     ),
   )
 
-exports.sendMonthly = functions.pubsub
-  // Trigger monthly at 3pm PT on the first day of the month (https://crontab.guru/#0_15_1_*_*)
+exports.sendMonthly = functions
+  .runWith({ memory: EMAIL_FUNCTION_MEMORY_LIMIT })
+  .pubsub // Trigger monthly at 3pm PT on the first day of the month (https://crontab.guru/#0_15_1_*_*)
   .schedule('0 15 1 * *')
   .timeZone('Europe/Lisbon')
   .onRun(async (context) =>
@@ -35,37 +40,39 @@ exports.sendMonthly = functions.pubsub
     ),
   )
 
-exports.sendOnce = functions.https.onCall(async (_, context) => {
-  if (!context.auth) {
-    throw new functions.https.HttpsError(
-      'failed-precondition',
-      'The function must be called while authenticated.',
-    )
-  }
-  // Validate user exists and has admin status before triggering function.
-  const { uid: authId } = context.auth
-  const user = await db
-    .collection(DB_ENDPOINTS.users)
-    .where('_authID', '==', authId)
-    .get()
+exports.sendOnce = functions
+  .runWith({ memory: EMAIL_FUNCTION_MEMORY_LIMIT })
+  .https.onCall(async (_, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        'failed-precondition',
+        'The function must be called while authenticated.',
+      )
+    }
+    // Validate user exists and has admin status before triggering function.
+    const { uid: authId } = context.auth
+    const user = await db
+      .collection(DB_ENDPOINTS.users)
+      .where('_authID', '==', authId)
+      .get()
 
-  if (user) {
-    const { userRoles } = user.docs[0].data() as IUserDB
-    if (userRoles?.some((role) => ['admin', 'super-admin'].includes(role))) {
-      try {
-        await createNotificationEmails()
-        return 'OK'
-      } catch (error) {
-        console.error(error)
-        throw new functions.https.HttpsError(
-          'internal',
-          'There was an error creating emails.',
-        )
+    if (user) {
+      const { userRoles } = user.docs[0].data() as IUserDB
+      if (userRoles?.some((role) => ['admin', 'super-admin'].includes(role))) {
+        try {
+          await createNotificationEmails()
+          return 'OK'
+        } catch (error) {
+          console.error(error)
+          throw new functions.https.HttpsError(
+            'internal',
+            'There was an error creating emails.',
+          )
+        }
       }
     }
-  }
-  throw new functions.https.HttpsError(
-    'permission-denied',
-    'Emails can be triggered by admins only.',
-  )
-})
+    throw new functions.https.HttpsError(
+      'permission-denied',
+      'Emails can be triggered by admins only.',
+    )
+  })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

@davehakkens noticed emails were not being sent daily. looked into the logs and saw:
<img width="1732" alt="Screen Shot 2023-07-18 at 9 14 29 PM" src="https://github.com/ONEARMY/community-platform/assets/37253846/e0d0bac7-7d3b-4461-bb69-7c7978ad6d42">
which, sadly, isn't caught by our error handling (💔) because it occurs within firebase i presume. might be possible to set up an alert to the webhook from functions logs?

i can't find any super obvious memory drain here.. let me know if you see anything I'm missing. if not, seems reasonable to increase the memory usage. testing on dev, 512 seems to do the trick. 
this won't cost us anything extra - as of now we stay well within the 2mil free function invocations per month (https://cloud.google.com/functions/pricing)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
