### PR TITLE
fix: howto step description length validation

### DIFF
--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -38,16 +38,16 @@ describe('[How To]', () => {
 
       cy.wrap($step).should(
         'contain',
-        `Descriptions must be more than 100 characters`,
+        `Descriptions must be at least 100 characters`,
       )
 
       cy.get('[data-cy=step-description]')
         .clear()
-        .type(
+        .invoke(
+          'val',
           faker.lorem
             .sentences(50)
             .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH + 1),
-          { delay: 1 },
         )
         .blur({ force: true })
 
@@ -59,14 +59,14 @@ describe('[How To]', () => {
       cy.get('[data-cy=step-description]')
         .clear()
         .type(
-          `description for step ${stepNumber}. This description should be more than 100 characters and less than 700 characters.`,
+          `description for step ${stepNumber}. This description should be between the minimum and maximum description length`,
         )
         .blur({ force: true })
 
       cy.get('[data-cy=step-description]').should('have.value', description)
       cy.get('[data-cy=character-count]')
         .should('be.visible')
-        .contains(`105 / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`)
+        .contains(`101 / ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH}`)
 
       if (videoUrl) {
         cy.step('Adding Video Url')
@@ -139,13 +139,13 @@ describe('[How To]', () => {
               type: 'image/jpeg',
             },
           ],
-          text: 'Description for step 1. This description should be more than 100 characters and less than 700 characters.',
+          text: 'Description for step 1. This description should be between the minimum and maximum description length',
           title: 'Step 1 is easy',
         },
         {
           _animationKey: 'unique2',
           images: [],
-          text: 'Description for step 2. This description should be more than 100 characters and less than 700 characters.',
+          text: 'Description for step 2. This description should be between the minimum and maximum description length',
           title: 'Step 2 is easy',
         },
       ],
@@ -300,7 +300,7 @@ describe('[How To]', () => {
               type: 'image/jpeg',
             },
           ],
-          text: 'Description for step 1. This description should be more than 100 characters and less than 700 characters.',
+          text: 'Description for step 1. This description should be between the minimum and maximum description length',
           title: 'Step 1 is easy',
         },
         {
@@ -325,7 +325,7 @@ describe('[How To]', () => {
               type: 'image/jpeg',
             },
           ],
-          text: 'Description for step 2. This description should be more than 100 characters and less than 700 characters.',
+          text: 'Description for step 2. This description should be between the minimum and maximum description length',
           title: 'Step 2 is easy',
         },
       ],

--- a/src/pages/Howto/Content/Common/Howto.form.test.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.test.tsx
@@ -4,8 +4,11 @@ import { HowtoForm } from './Howto.form'
 import { MemoryRouter } from 'react-router'
 import { ThemeProvider } from 'theme-ui'
 import { useCommonStores } from 'src'
-import { FactoryHowto } from 'src/test/factories/Howto'
+import { FactoryHowto, FactoryHowtoStep } from 'src/test/factories/Howto'
 import { testingThemeStyles } from 'src/test/utils/themeUtils'
+import { HOWTO_STEP_DESCRIPTION_MAX_LENGTH } from '../../constants'
+import { faker } from '@faker-js/faker'
+
 const Theme = testingThemeStyles
 
 jest.mock('src/index', () => {
@@ -133,6 +136,36 @@ describe('Howto form', () => {
       expect(
         wrapper.queryByTestId('invalid-file-warning'),
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('HowtoStep', () => {
+    describe('Description field', () => {
+      it('validation fails when description is over the limit', async () => {
+        // Arrange
+        const maxLength = HOWTO_STEP_DESCRIPTION_MAX_LENGTH
+        const longText = faker.random.alpha(maxLength + 1)
+        const formValues = FactoryHowto({
+          steps: [FactoryHowtoStep({ text: '' })],
+        })
+
+        // Act
+        const wrapper = getWrapper(formValues, 'edit', {})
+        const descriptionTextAreaElement =
+          wrapper.getByTestId('step-description')
+        descriptionTextAreaElement.focus()
+        fireEvent.change(descriptionTextAreaElement, {
+          target: { value: `${longText}` },
+        })
+        descriptionTextAreaElement.blur()
+
+        // Assert
+        expect(
+          wrapper.getByText(
+            `Descriptions must be less than ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters`,
+          ),
+        ).toBeInTheDocument()
+      })
     })
   })
 })

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -74,7 +74,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
    * Ensure that the How to description meets the following criteria:
    * - required
    * - minimum character length of 100 characters
-   * - maximum character length of 700 characters
+   * - maximum character length of 1000 characters
    *
    * @param value - How to step description field value
    */
@@ -83,11 +83,11 @@ class HowtoStep extends PureComponent<IProps, IState> {
       return 'Make sure this field is filled correctly'
     }
 
-    if (value.length < 100) {
-      return `Descriptions must be more than ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`
+    if (value.length < HOWTO_STEP_DESCRIPTION_MIN_LENGTH) {
+      return `Descriptions must be at least ${HOWTO_STEP_DESCRIPTION_MIN_LENGTH} characters`
     }
 
-    if (value.length > 700) {
+    if (value.length >= HOWTO_STEP_DESCRIPTION_MAX_LENGTH) {
       return `Descriptions must be less than ${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters`
     }
 
@@ -190,6 +190,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
               minLength={HOWTO_STEP_DESCRIPTION_MIN_LENGTH}
               maxLength={HOWTO_STEP_DESCRIPTION_MAX_LENGTH}
               data-cy="step-description"
+              data-testid="step-description"
               modifiers={{ capitalize: true }}
               component={FieldTextarea}
               style={{ resize: 'vertical', height: '300px' }}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The code was ensuring the step description for a how-to was less than 700 characters long, when in actuality we want to make sure it is less than 1000. The message displayed to the user was correct.
  - Integration tests were taking forever to type out 1000 characters, so one test has been updated to simply set the textarea value.

Testing: I could not figure out how to write tests for this. The closest I could get was the below, written in `Howto.form.test.tsx`. I could not get the `getBy___` methods to get anything from any of the steps. I also had trouble debugging. Any help would be much appreciated! Also, is this the right approach to test the validation function? Should we be targeting the `validateDescription` method directly? Or writing a test for `HowtoStep.form` (as opposed to `Howto.form` ?)

```js
  describe('HowtoStep', () => {
    describe('Description field', () => {
      it('validation fails when description is over the limit', async () => {
        // Arrange
        const maxLength = HOWTO_STEP_DESCRIPTION_MAX_LENGTH
        const longText = faker.random.alpha(maxLength + 1)
        const formValues = FactoryHowto({
          steps: [FactoryHowtoStep({ text: longText })],
        })

        // Act
        const wrapper = getWrapper(formValues, 'create', {})
        fireEvent.focus(wrapper.getByText(longText))

        // Assert
        expect(
          wrapper.getByText('Descriptions must be less than'),
        ).toBeInTheDocument()
      })
    })
  })
```


## Git Issues

Closes #2627

## Screenshots/Videos

Correct behavior:
![image](https://github.com/ONEARMY/community-platform/assets/42685363/1eb22045-48f1-48f1-9258-c57a41cbd269)


This is the fast version of the cypress test:

https://github.com/ONEARMY/community-platform/assets/42685363/004a16bd-f8b2-4f3e-abde-b3efe05e07ed


---

