### PR TITLE
chore: refactor to remove unused additional admin prop

### DIFF
--- a/packages/components/src/__mocks__/AuthWrapper.mock.tsx
+++ b/packages/components/src/__mocks__/AuthWrapper.mock.tsx
@@ -1,9 +1,4 @@
 export const AuthWrapper = (props: any) => {
   console.log(`MockAuthWrapper:`, props)
-
-  if (!props.additionalAdmins.includes(props.roleRequired)) {
-    return null
-  }
-
   return <>{props.children}</>
 }

--- a/src/common/AuthWrapper.tsx
+++ b/src/common/AuthWrapper.tsx
@@ -13,8 +13,6 @@ interface IProps {
   userStore?: UserStore
   roleRequired?: UserRole | UserRole[]
   fallback?: React.ReactNode
-  /** Optional additional user IDs that have admin rights (e.g. content creators) */
-  additionalAdmins?: string[]
   children: React.ReactNode
 }
 
@@ -22,13 +20,8 @@ interface IProps {
 @observer
 export class AuthWrapper extends React.Component<IProps> {
   render() {
-    const { userStore, roleRequired, additionalAdmins, children, fallback } =
-      this.props
-    const isAuthorized = isUserAuthorized(
-      userStore?.user,
-      roleRequired,
-      additionalAdmins,
-    )
+    const { userStore, roleRequired, children, fallback } = this.props
+    const isAuthorized = isUserAuthorized(userStore?.user, roleRequired)
     const childElements =
       roleRequired === 'beta-tester' ? (
         <div className="beta-tester-feature">{children}</div>
@@ -39,12 +32,7 @@ export class AuthWrapper extends React.Component<IProps> {
   }
 }
 
-const isUserAuthorized = (user, roleRequired, additionalAdmins) => {
-  // provide access to named users
-  if (additionalAdmins && user?._id && additionalAdmins.includes(user?._id)) {
-    return true
-  }
-
+const isUserAuthorized = (user, roleRequired) => {
   const userRoles = user?.userRoles || []
 
   // If no role required just check if user is logged in

--- a/src/pages/common/AuthRoute.tsx
+++ b/src/pages/common/AuthRoute.tsx
@@ -13,24 +13,15 @@ export const AuthRoute = observer(
   (props: {
     component: React.ComponentType<any>
     roleRequired?: UserRole | UserRole[]
-    /** User ids to be treated as admin, e.g. content creator */
-    additionalAdmins?: string[]
     /** Page to redirect if role not satisfied (default shows message) */
     redirect?: string
     path?: string
     exact?: boolean
   }) => {
-    const {
-      component: Component,
-      roleRequired,
-      additionalAdmins,
-      redirect,
-      ...rest
-    } = props
+    const { component: Component, roleRequired, redirect, ...rest } = props
 
     return (
       <AuthWrapper
-        additionalAdmins={additionalAdmins}
         roleRequired={roleRequired}
         fallback={
           redirect ? (


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes unused `additionalAdmin` prop, described as: _Optional additional user IDs that have admin rights (e.g. content creators_
