### PR TITLE
chore: fixes tests so there are no more errors

### DIFF
--- a/src/pages/Howto/Content/Common/Howto.form.test.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 import { Provider } from 'mobx-react'
 import { HowtoForm } from './Howto.form'
 import { MemoryRouter } from 'react-router'
@@ -27,6 +27,8 @@ jest.mock('src/index', () => {
             Database: false,
             Complete: false,
           },
+          validateTitleForSlug: jest.fn(),
+          uploadHowTo: jest.fn(),
         },
         tagsStore: {
           categoryTags: [
@@ -49,18 +51,25 @@ describe('Howto form', () => {
       // Arrange
       const formValues = FactoryHowto()
       // Act
-      const wrapper = getWrapper(formValues, 'edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(formValues, 'edit', {})
+      })
 
       // Assert
       expect(wrapper.getByText('Maximum file size 50MB')).toBeInTheDocument()
     })
   })
+
   describe('Invalid file warning', () => {
     it('Does not appear when submitting only fileLink', async () => {
       // Arrange
       const formValues = FactoryHowto({ fileLink: 'www.test.com' })
       // Act
-      const wrapper = getWrapper(formValues, 'edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(formValues, 'edit', {})
+      })
 
       // Assert
       expect(
@@ -79,7 +88,10 @@ describe('Howto form', () => {
       })
 
       // Act
-      const wrapper = getWrapper(formValues, 'edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(formValues, 'edit', {})
+      })
 
       // Assert
       expect(
@@ -99,7 +111,10 @@ describe('Howto form', () => {
       })
 
       // Act
-      const wrapper = getWrapper(formValues, 'edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(formValues, 'edit', {})
+      })
 
       // Assert
       expect(wrapper.queryByTestId('invalid-file-warning')).toBeInTheDocument()
@@ -116,11 +131,16 @@ describe('Howto form', () => {
       })
 
       // Act
-      const wrapper = getWrapper(formValues, 'edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(formValues, 'edit', {})
+      })
 
       // clear files
       const reuploadFilesButton = wrapper.getByTestId('re-upload-files')
-      fireEvent.click(reuploadFilesButton)
+      await act(async () => {
+        fireEvent.click(reuploadFilesButton)
+      })
 
       // add fileLink
       const fileLink = wrapper.getByPlaceholderText(
@@ -150,14 +170,19 @@ describe('Howto form', () => {
         })
 
         // Act
-        const wrapper = getWrapper(formValues, 'edit', {})
+        let wrapper
+        await act(async () => {
+          wrapper = await getWrapper(formValues, 'edit', {})
+        })
+
         const descriptionTextAreaElement =
           wrapper.getByTestId('step-description')
-        descriptionTextAreaElement.focus()
+
+        fireEvent.focus(descriptionTextAreaElement)
         fireEvent.change(descriptionTextAreaElement, {
           target: { value: `${longText}` },
         })
-        descriptionTextAreaElement.blur()
+        fireEvent.blur(descriptionTextAreaElement)
 
         // Assert
         expect(
@@ -170,7 +195,7 @@ describe('Howto form', () => {
   })
 })
 
-const getWrapper = (formValues, parentType, navProps) => {
+const getWrapper = async (formValues, parentType, navProps) => {
   return render(
     <Provider {...useCommonStores().stores}>
       <ThemeProvider theme={Theme}>

--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -518,10 +518,10 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                             <AnimatePresence>
                               {fields.map((name, index: number) => (
                                 <AnimationContainer
-                                  key={fields.value[index]._animationKey}
+                                  key={`${fields.value[index]._animationKey}-1`}
                                 >
                                   <HowtoStep
-                                    key={fields.value[index]._animationKey}
+                                    key={`${fields.value[index]._animationKey}-2`}
                                     step={name}
                                     index={index}
                                     moveStep={(from, to) => {

--- a/src/pages/Howto/Content/Howto/Howto.test.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, act } from '@testing-library/react'
 import { ThemeProvider } from '@theme-ui/core'
 import { Provider } from 'mobx-react'
 import { MemoryRouter } from 'react-router'
@@ -42,7 +42,7 @@ jest.mock('src/index', () => ({
 
 import { Howto } from './Howto'
 
-const factory = (howtoStore?: Partial<HowtoStore>) =>
+const factory = async (howtoStore?: Partial<HowtoStore>) =>
   render(
     <Provider
       {...useCommonStores().stores}
@@ -58,53 +58,65 @@ const factory = (howtoStore?: Partial<HowtoStore>) =>
   )
 
 describe('Howto', () => {
-  it('shows verified badge', () => {
-    const { getAllByTestId } = factory({
-      ...mockHowtoStore(),
-      activeHowto: FactoryHowto({
-        _createdBy: 'HowtoAuthor',
-      }),
+  it('shows verified badge', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = await factory({
+        ...mockHowtoStore(),
+        activeHowto: FactoryHowto({
+          _createdBy: 'HowtoAuthor',
+        }),
+      })
     })
 
     expect(() => {
-      getAllByTestId('Username: verified badge')
+      wrapper.getAllByTestId('Username: verified badge')
     }).not.toThrow()
   })
 
-  it('does not show verified badge', () => {
-    const { getAllByTestId } = factory()
+  it('does not show verified badge', async () => {
+    let wrapper
+    await act(async () => {
+      wrapper = await factory()
+    })
 
     expect(() => {
-      getAllByTestId('Username: verified badge')
+      wrapper.getAllByTestId('Username: verified badge')
     }).toThrow()
   })
 
   describe('steps', () => {
-    it('shows 1 step', () => {
-      const { getAllByText } = factory({
-        ...mockHowtoStore(),
-        activeHowto: FactoryHowto({
-          _createdBy: 'HowtoAuthor',
-          steps: [FactoryHowtoStep()],
-        }),
+    it('shows 1 step', async () => {
+      let wrapper
+      await act(async () => {
+        wrapper = await factory({
+          ...mockHowtoStore(),
+          activeHowto: FactoryHowto({
+            _createdBy: 'HowtoAuthor',
+            steps: [FactoryHowtoStep()],
+          }),
+        })
       })
 
       expect(() => {
-        getAllByText('1 step')
+        wrapper.getAllByText('1 step')
       }).not.toThrow()
     })
 
-    it('shows 2 steps', () => {
-      const { getAllByText } = factory({
-        ...mockHowtoStore(),
-        activeHowto: FactoryHowto({
-          _createdBy: 'HowtoAuthor',
-          steps: [FactoryHowtoStep(), FactoryHowtoStep()],
-        }),
+    it('shows 2 steps', async () => {
+      let wrapper
+      await act(async () => {
+        wrapper = await factory({
+          ...mockHowtoStore(),
+          activeHowto: FactoryHowto({
+            _createdBy: 'HowtoAuthor',
+            steps: [FactoryHowtoStep(), FactoryHowtoStep()],
+          }),
+        })
       })
 
       expect(() => {
-        getAllByText('2 steps')
+        wrapper.getAllByText('2 steps')
       }).not.toThrow()
     })
   })

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
@@ -99,18 +99,21 @@ export const ResearchUpdateForm = observer((props: IProps) => {
   }
 
   // Display a confirmation dialog when leaving the page outside the React Router
-  const unloadDecorator = (form) => {
-    return form.subscribe(
-      ({ dirty }) => {
-        if (dirty && !store.updateUploadStatus.Complete) {
-          window.addEventListener('beforeunload', beforeUnload, false)
-          return
-        }
-        window.removeEventListener('beforeunload', beforeUnload, false)
-      },
-      { dirty: true },
-    )
-  }
+  const unloadDecorator = React.useCallback(
+    (form) => {
+      return form.subscribe(
+        ({ dirty }) => {
+          if (dirty && !store.updateUploadStatus.Complete) {
+            window.addEventListener('beforeunload', beforeUnload, false)
+            return
+          }
+          window.removeEventListener('beforeunload', beforeUnload, false)
+        },
+        { dirty: true },
+      )
+    },
+    [store.updateUploadStatus.Complete, beforeUnload],
+  )
 
   return (
     <>

--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import ResearchRoutes from './research.routes'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { cleanup, render, waitFor, act } from '@testing-library/react'
 import { ThemeProvider } from '@theme-ui/core'
 import { createMemoryHistory } from 'history'
 import { Provider } from 'mobx-react'
@@ -76,7 +76,11 @@ describe('research.routes', () => {
 
   describe('/research/', () => {
     it('renders the research listing', async () => {
-      const { wrapper } = renderFn('/research')
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research')).wrapper
+      })
+
       await waitFor(
         () =>
           expect(
@@ -91,7 +95,10 @@ describe('research.routes', () => {
 
   describe('/research/:slug', () => {
     it('renders an individual research article', async () => {
-      const { wrapper } = renderFn('/research/research-slug')
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/research-slug')).wrapper
+      })
 
       await waitFor(
         () => {
@@ -111,7 +118,10 @@ describe('research.routes', () => {
 
   describe('/research/create', () => {
     it('rejects a request without a user present', async () => {
-      const { wrapper } = renderFn('/research/create')
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/create')).wrapper
+      })
 
       await waitFor(() => {
         expect(
@@ -121,7 +131,10 @@ describe('research.routes', () => {
     })
 
     it('rejects a logged in user missing required role', async () => {
-      const { wrapper } = renderFn('/research/create')
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/create')).wrapper
+      })
 
       await waitFor(() => {
         expect(
@@ -131,12 +144,18 @@ describe('research.routes', () => {
     })
 
     it('accepts a logged in user with required role [research_creator]', async () => {
-      const { wrapper } = renderFn(
-        '/research/create',
-        FactoryUser({
-          userRoles: ['research_creator'],
-        }),
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/create',
+            FactoryUser({
+              userRoles: ['research_creator'],
+            }),
+          )
+        ).wrapper
+      })
+
       await waitFor(
         () => {
           expect(wrapper.getByText(/start your research/i)).toBeInTheDocument()
@@ -148,12 +167,17 @@ describe('research.routes', () => {
     })
 
     it('accepts a logged in user with required role [research_creator]', async () => {
-      const { wrapper } = renderFn(
-        '/research/create',
-        FactoryUser({
-          userRoles: ['research_editor'],
-        }),
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/create',
+            FactoryUser({
+              userRoles: ['research_editor'],
+            }),
+          )
+        ).wrapper
+      })
       await waitFor(
         () => {
           expect(wrapper.getByText(/start your research/i)).toBeInTheDocument()
@@ -167,7 +191,10 @@ describe('research.routes', () => {
 
   describe('/research/:slug/edit', () => {
     it('rejects a request without a user present', async () => {
-      const { wrapper } = renderFn('/research/an-example/edit', {})
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/an-example/edit', {})).wrapper
+      })
 
       await waitFor(() => {
         expect(
@@ -177,10 +204,18 @@ describe('research.routes', () => {
     })
 
     it('accepts a logged in user with required role', async () => {
-      const { wrapper } = renderFn(
-        '/research/an-example/edit',
-        FactoryUser({ userName: 'Jaasper', userRoles: ['research_editor'] }),
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/edit',
+            FactoryUser({
+              userName: 'Jaasper',
+              userRoles: ['research_editor'],
+            }),
+          )
+        ).wrapper
+      })
 
       await waitFor(() => {
         expect(wrapper.getByText(/edit your research/i)).toBeInTheDocument()
@@ -201,7 +236,11 @@ describe('research.routes', () => {
         }),
       })
 
-      const { history } = renderFn('/research/an-example/edit', activeUser)
+      let history
+      await act(async () => {
+        history = (await renderFn('/research/an-example/edit', activeUser))
+          .history
+      })
 
       await waitFor(() => {
         expect(history.location.pathname).toBe('/research/an-example')
@@ -221,7 +260,11 @@ describe('research.routes', () => {
         }),
       })
 
-      const { wrapper } = renderFn('/research/an-example/edit', activeUser)
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/an-example/edit', activeUser))
+          .wrapper
+      })
 
       await waitFor(() => {
         expect(wrapper.getByText(/edit your research/i)).toBeInTheDocument()
@@ -231,7 +274,12 @@ describe('research.routes', () => {
 
   describe('/research/:slug/new-update', () => {
     it('rejects a request without a user present', async () => {
-      const { wrapper } = renderFn('/research/an-example/new-update', {})
+      let wrapper
+      await act(async () => {
+        wrapper = (await renderFn('/research/an-example/new-update', {}))
+          .wrapper
+      })
+
       await waitFor(() => {
         expect(
           wrapper.getByText(/role required to access this page/),
@@ -240,11 +288,15 @@ describe('research.routes', () => {
     })
 
     it('accepts a logged in user with required role', async () => {
-      const { wrapper } = renderFn(
-        '/research/an-example/new-update',
-        FactoryUser({ userRoles: ['research_editor'] }),
-      )
-
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/new-update',
+            FactoryUser({ userRoles: ['research_editor'] }),
+          )
+        ).wrapper
+      })
       await waitFor(() => {
         expect(wrapper.getByTestId('EditResearchUpdate')).toBeInTheDocument()
       })
@@ -253,9 +305,14 @@ describe('research.routes', () => {
 
   describe('/research/:slug/edit-update/:id', () => {
     it('rejects a request without a user present', async () => {
-      const { wrapper } = renderFn(
-        '/research/an-example/edit-update/nested-research-update',
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/edit-update/nested-research-update',
+          )
+        ).wrapper
+      })
 
       await waitFor(() => {
         expect(
@@ -284,10 +341,15 @@ describe('research.routes', () => {
         }),
       })
 
-      const { wrapper } = renderFn(
-        '/research/an-example/edit-update/nested-research-update',
-        activeUser,
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/edit-update/nested-research-update',
+            activeUser,
+          )
+        ).wrapper
+      })
 
       await waitFor(() => {
         expect(wrapper.getByTestId(/EditResearchUpdate/i)).toBeInTheDocument()
@@ -295,10 +357,15 @@ describe('research.routes', () => {
     })
 
     it('rejects logged in user who is not author', async () => {
-      const { wrapper } = renderFn(
-        '/research/an-example/edit-update/nested-research-update',
-        FactoryUser(),
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/edit-update/nested-research-update',
+            FactoryUser(),
+          )
+        ).wrapper
+      })
 
       await waitFor(() => {
         expect(
@@ -326,10 +393,15 @@ describe('research.routes', () => {
         }),
       })
 
-      const { wrapper } = renderFn(
-        '/research/an-example/edit-update/nested-research-update',
-        activeUser,
-      )
+      let wrapper
+      await act(async () => {
+        wrapper = (
+          await renderFn(
+            '/research/an-example/edit-update/nested-research-update',
+            activeUser,
+          )
+        ).wrapper
+      })
 
       await waitFor(() => {
         expect(wrapper.getByTestId(/EditResearchUpdate/i)).toBeInTheDocument()
@@ -338,7 +410,7 @@ describe('research.routes', () => {
   })
 })
 
-const renderFn = (url, fnUser?) => {
+const renderFn = async (url, fnUser?) => {
   const localUser = fnUser || FactoryUser()
   const history = createMemoryHistory({
     initialEntries: [url],

--- a/src/pages/Settings/UserSettings.test.tsx
+++ b/src/pages/Settings/UserSettings.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from '@testing-library/react'
+import { render, act, waitFor, screen } from '@testing-library/react'
 import { Provider } from 'mobx-react'
 import { UserSettings } from './UserSettings'
 import { useCommonStores } from 'src'
@@ -49,11 +49,11 @@ describe('UserSettings', () => {
     jest.resetAllMocks()
   })
 
-  it('displays user settings', () => {
+  it('displays user settings', async () => {
     const user = FactoryUser()
 
     // Act
-    const wrapper = getWrapper(user)
+    const wrapper = await getWrapper(user)
 
     // Assert
     expect(wrapper.getByText('Edit profile'))
@@ -65,52 +65,72 @@ describe('UserSettings', () => {
       userRoles: ['admin'],
     })
 
-    // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
 
     // Assert
     await waitFor(() => wrapper.getByText('Admin settings'))
   })
 
-  it('displays one photo for member', () => {
+  it('displays one photo for member', async () => {
     const user = FactoryUser({ profileType: 'member' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(1)
   })
 
-  it('displays four photos for collection point', () => {
+  it('displays four photos for collection point', async () => {
     const user = FactoryUser({ profileType: 'collection-point' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
   })
 
-  it('displays four photos for community builder', () => {
+  it('displays four photos for community builder', async () => {
     const user = FactoryUser({ profileType: 'community-builder' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
   })
 
-  it('displays four photos for machine builder', () => {
+  it('displays four photos for machine builder', async () => {
     const user = FactoryUser({ profileType: 'machine-builder' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
   })
 
-  it('displays four photos for space', () => {
+  it('displays four photos for space', async () => {
     const user = FactoryUser({ profileType: 'space' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
   })
 
-  it('displays four photos for workspace', () => {
+  it('displays four photos for workspace', async () => {
     const user = FactoryUser({ profileType: 'workspace' })
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
     expect(wrapper.getAllByTestId('cover-image')).toHaveLength(4)
   })
 
@@ -126,7 +146,10 @@ describe('UserSettings', () => {
     mockGetUserProfile.mockResolvedValue(user)
 
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
 
     // Assert
     await waitFor(() => {
@@ -145,7 +168,10 @@ describe('UserSettings', () => {
     mockGetUserProfile.mockResolvedValue(user)
 
     // Act
-    const wrapper = getWrapper(user)
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
 
     // Assert
     await waitFor(() => screen.getByText('Update badges').click())
@@ -160,7 +186,7 @@ describe('UserSettings', () => {
   })
 })
 
-const getWrapper = (user) => {
+const getWrapper = async (user) => {
   const isAdmin = user.userRoles?.includes('admin')
 
   return render(


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

- Fixes all the errors related to tests.
  - Act errors
    - In tests, it appears that any async code or code that causes side-effects in the wrapper factories (i.e. anything inside the render function) will cause an act error, as all these changes must be settled before we're testing what the user experiences. This includes the dom, state, etc.
    - My initial suspicion that act could be removed was not correct
  - form decorator errors
    - memoizing decorator function definitions prevents each render from re defining those functions, and prevents a test error that was complaining that: `form decorators should not change from one render to the next as new values will be ignored`
  - duplicate key errors
    - in one place in the app we had duplicate keys assigned to 2 child elements


## Git Issues

Closes #2646

## Screenshots/Videos

No errors/warnings!
![image](https://github.com/ONEARMY/community-platform/assets/42685363/9afcbe5d-dcdd-4123-9b34-12a22dc72199)


---


Note:
- the act syntax is super confusing:
```ts
      let wrapper
      await act(async () => {
        wrapper = await getWrapper(formValues, 'edit', {})
      })
```

It can be fixed if we upgrade testing-library/react (requires updating react as well)

