### PR TITLE
fix: fixes flaky user menu test

### DIFF
--- a/packages/cypress/src/integration/common.spec.ts
+++ b/packages/cypress/src/integration/common.spec.ts
@@ -69,11 +69,11 @@ describe('[Common]', () => {
       cy.url().should('include', `/u/${username}`)
 
       cy.step('Go to Settings')
-      cy.clickMenuItem(UserMenuItem.Settings)
+      cy.get(`[data-cy=menu-${UserMenuItem.Settings}]`).click()
       cy.url().should('include', 'settings')
 
       cy.step('Logout the session')
-      cy.clickMenuItem(UserMenuItem.LogOut)
+      cy.get(`[data-cy=menu-${UserMenuItem.LogOut}]`).click()
       cy.get('[data-cy=login]').should('be.visible')
       cy.get('[data-cy=join]').should('be.visible')
     })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Fixes the flaky test. Clicking the user menu when it is open rapidly closes and then re-opens the menu. In the integration test, there's a sub function that handles clicking on a menu item. If that command is run when the menu is already opens, it attempts to re-open the menu (causing a flicker) then click on a menu item. I believe the flicker causes instability.
  - This PR simply clicks on the item, instead of attempting to re-open it, as changing pages does not close the menu.

See stretch goals in the issue description for some additional potential changes

## Git Issues

Closes #2657

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

