### PR TITLE
feat: hide deleted pins + delete pins when user deleted

### DIFF
--- a/src/pages/Maps/Maps.tsx
+++ b/src/pages/Maps/Maps.tsx
@@ -88,6 +88,7 @@ class MapsPage extends React.Component<IProps, IState> {
     // Only lookup if not already the active pin
     if (pinId && pinId !== this.props.mapsStore.activePin?._id) {
       const pin = await this.props.mapsStore.getPin(pinId)
+      if (pin._deleted) return
       this.props.mapsStore.setActivePin(pin)
     }
     // Center on the pin if first load

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -55,11 +55,14 @@ export class MapsStore extends ModuleStore {
     const isAdmin = hasAdminRights(activeUser)
     pins = pins
       .filter((p) => {
+        const isDeleted = p._deleted || false
         const isPinAccepted = p.moderation === 'accepted'
         const wasCreatedByUser = activeUser && p._id === activeUser.userName
         const isAdminAndAccepted = isAdmin && p.moderation !== 'rejected'
         return (
-          p.type && (isPinAccepted || wasCreatedByUser || isAdminAndAccepted)
+          p.type &&
+          !isDeleted &&
+          (isPinAccepted || wasCreatedByUser || isAdminAndAccepted)
         )
       })
       .map((p) => {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This pr:

- Filters out any pins that have the _deleted property set to true from displaying on the map
- Prevents direct browsing to the pin map card by entering the username directly in the url
- Adds a user update process that sets the _deleted property on map pins if a user has their _deleted property set to true
- Manual data cleansing also performed to ensure that all map pins for deleted users and user records that no longer exist have the _deleted flag set to true

## Git Issues

Closes #772 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
