### PR TITLE
fix: filter out draft/deleted research updates on listing view

### DIFF
--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -1,6 +1,5 @@
 import { format } from 'date-fns'
 import { Icon, ModerationStatus, Username } from 'oa-components'
-import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { isUserVerified } from 'src/common/isUserVerified'
 import type { IResearch } from 'src/models/research.models'
@@ -196,7 +195,13 @@ const calculateTotalComments = (item: IResearch.ItemDB) => {
 }
 
 const getUpdateText = (item: IResearch.ItemDB) => {
-  return item.updates?.length ? String(item.updates?.length) : '0'
+  return item.updates?.length
+    ? String(
+        item.updates.filter(
+          (update) => update.status !== 'draft' && update._deleted !== true,
+        ).length,
+      )
+    : '0'
 }
 
 export default ResearchListItem


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Filters out draft or deleted items when counting total number of updates.

Tests need to be added to verify this behaviour, waiting for #2620 to be merged as that refactors a lot of tests and components. 
