### PR TITLE
fix: handle situation where multiple User records exist

### DIFF
--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -1,0 +1,51 @@
+jest.mock('../common/module.store')
+import { FactoryUser } from 'src/test/factories/User'
+import { UserStore } from './user.store'
+
+describe('userStore', () => {
+  describe('getUserProfile', () => {
+    it('returns a single user object when 2 exist', async () => {
+      // Arrange
+      const store = new UserStore({} as any)
+
+      // Lookup1
+      store.db.getWhere.mockReturnValueOnce([
+        FactoryUser({
+          _authID: 'an-auth-id',
+          _id: 'unwanted-user-doc',
+          _created: new Date('2023-01-01').toString(),
+          _lastActive: new Date('2020-01-01').toString(),
+        }),
+        FactoryUser({
+          _authID: 'an-auth-id',
+          _id: 'desired-user-doc',
+          _created: new Date('2020-01-01').toString(),
+          _lastActive: new Date('2020-01-01').toString(),
+        } as any),
+      ])
+
+      // Lookup2
+      store.db.getWhere.mockReturnValueOnce([])
+
+      // Assert
+      expect(await store.getUserProfile('an-auth-id')).toEqual({
+        _contentModifiedTimestamp: expect.any(String),
+        _created: expect.any(String),
+        _deleted: expect.any(Boolean),
+        _lastActive: expect.any(String),
+        _id: 'desired-user-doc',
+        _modified: expect.any(String),
+        country: expect.any(String),
+        _authID: 'an-auth-id',
+        verified: expect.any(Boolean),
+        userName: expect.any(String),
+        profileType: expect.any(String),
+        displayName: expect.any(String),
+        moderation: expect.any(String),
+        coverImages: expect.any(Array),
+        links: expect.any(Array),
+        notifications: expect.any(Array),
+      })
+    })
+  })
+})


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Fixes an issue where in a specific scenario `getUserProfile` will return `undefined` rather than a user profile. This prevents a user from being able to log in. 

The specific problem scenario is that there are 2 or more user records associated with the same `authID`. The `authID` property is a unique identifier which represents a [Firebase Auth user identity](https://firebase.google.com/docs/auth/). The existence of 2 user records points to a bug elsewhere which needs to resolving but this is a hotfix to unblock users. 
