### PR TITLE
refactor: improve updates around user profile

### DIFF
--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -44,6 +44,7 @@ export interface IUser {
   stats?: IUserStats
   notification_settings?: INotificationSettings
   notifications?: INotification[]
+  profileCreated?: ISODateString
 }
 
 export interface IUserBadges {

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -45,6 +45,7 @@ export interface IUser {
   notification_settings?: INotificationSettings
   notifications?: INotification[]
   profileCreated?: ISODateString
+  profileCreationTrigger?: string
 }
 
 export interface IUserBadges {

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -111,3 +111,13 @@ export type INotificationSettings = {
   }
   emailFrequency: EmailNotificationFrequency
 }
+
+export type IBadgeUpdate = {
+  _id: string
+  badges?: IUserBadges
+}
+
+export type INotificationUpdate = {
+  _id: string
+  notifications?: INotification[]
+}

--- a/src/pages/Settings/SettingsPage.tsx
+++ b/src/pages/Settings/SettingsPage.tsx
@@ -122,7 +122,11 @@ export class SettingsPage extends React.Component<IProps, IState> {
     try {
       logger.debug({ profile: vals }, 'SettingsPage.saveProfile')
       const { adminEditableUserId } = this.props
-      await this.injected.userStore.updateUserProfile(vals, adminEditableUserId)
+      await this.injected.userStore.updateUserProfile(
+        vals,
+        'settings-save-profile',
+        adminEditableUserId,
+      )
       logger.debug(`before setState`)
       this.setState(
         {

--- a/src/stores/User/notifications.store.test.tsx
+++ b/src/stores/User/notifications.store.test.tsx
@@ -21,7 +21,7 @@ class MockNotificationsStore extends UserNotificationsStore {
       userName: 'userName',
       notifications: [],
     }),
-    updateUserProfile: jest.fn(),
+    refreshActiveUserDetails: jest.fn(),
   }
   constructor() {
     super(null as any)
@@ -46,10 +46,10 @@ describe('triggerNotification', () => {
       'https://example.com',
     )
     // Expect
-    const [newUser] = store.db.set.mock.calls[0]
+    const [newUser] = store.db.update.mock.calls[0]
 
     expect(store.db.doc).toBeCalledWith('example')
-    expect(store.db.set).toBeCalledTimes(1)
+    expect(store.db.update).toBeCalledTimes(1)
     expect(newUser.notifications).toHaveLength(1)
     expect(newUser.notifications[0]).toEqual(
       expect.objectContaining({
@@ -101,9 +101,9 @@ describe('notifications.store', () => {
     await store.deleteNotification(store.user!.notifications![0]._id)
 
     expect(store.db.doc).toBeCalledWith('userName')
-    expect(store.db.set).toHaveBeenCalledTimes(1)
+    expect(store.db.update).toHaveBeenCalledTimes(1)
 
-    const updatedUser = store.db.set.mock.calls[0][0]
+    const updatedUser = store.db.update.mock.calls[0][0]
     expect(updatedUser.notifications).toHaveLength(
       store.userStore.user!.notifications!.length - 1,
     )
@@ -112,12 +112,12 @@ describe('notifications.store', () => {
     await store.markAllNotificationsNotified()
 
     expect(store.db.doc).toBeCalledWith('userName')
-    expect(store.db.set).toHaveBeenCalledTimes(1)
+    expect(store.db.update).toHaveBeenCalledTimes(1)
   })
   it('marks all notifications as read', async () => {
     await store.markAllNotificationsRead()
 
     expect(store.db.doc).toBeCalledWith('userName')
-    expect(store.db.set).toHaveBeenCalledTimes(1)
+    expect(store.db.update).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/stores/User/notifications.store.ts
+++ b/src/stores/User/notifications.store.ts
@@ -113,7 +113,7 @@ export class UserNotificationsStore extends ModuleStore {
         notifications?.forEach((notification) => (notification.notified = true))
 
         await this._updateUserNotifications(user, notifications)
-        await this.userStore.updateUserProfile({ notifications })
+        await this.userStore.refreshActiveUserDetails()
       }
     } catch (err) {
       logger.error(err)
@@ -129,8 +129,8 @@ export class UserNotificationsStore extends ModuleStore {
         const notifications = toJS(user.notifications)
         notifications?.forEach((notification) => (notification.read = true))
 
-        await this._updateUserNotifications(user, { notifications })
-        await this.userStore.updateUserProfile({ notifications })
+        await this._updateUserNotifications(user, notifications)
+        await this.userStore.refreshActiveUserDetails()
       }
     } catch (err) {
       logger.error(err)

--- a/src/stores/User/notifications.store.ts
+++ b/src/stores/User/notifications.store.ts
@@ -1,6 +1,6 @@
 import type {
   INotification,
-  IUser,
+  INotificationUpdate,
   NotificationType,
 } from 'src/models/user.models'
 import { action, makeObservable, toJS } from 'mobx'
@@ -157,12 +157,14 @@ export class UserNotificationsStore extends ModuleStore {
 
   private async _updateUserNotifications(user: IUserPPDB, notifications) {
     const dbRef = this.db
-      .collection<IUser>(USER_COLLECTION_NAME)
+      .collection<INotificationUpdate>(USER_COLLECTION_NAME)
       .doc(user.userName)
 
-    return dbRef.set({
-      ...toJS(user),
+    const notificationUpdate = {
+      _id: user.userName,
       notifications,
-    })
+    }
+
+    await dbRef.update(notificationUpdate)
   }
 }

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -12,7 +12,7 @@ describe('userStore', () => {
       store.db.getWhere.mockReturnValueOnce([
         FactoryUser({
           _authID: 'an-auth-id',
-          _id: 'unwanted-user-doc',
+          _id: 'an-auth-id',
           _created: new Date('2023-01-01').toString(),
           _lastActive: new Date('2020-01-01').toString(),
         }),

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -7,7 +7,13 @@ import { formatLowerNoSpecial } from '../../utils/helpers'
 import { ModuleStore } from '../common/module.store'
 import { Storage } from '../storage'
 
-import type { IUser, IUserBadges, IUserDB } from 'src/models/user.models'
+import type {
+  IBadgeUpdate,
+  INotificationUpdate,
+  IUser,
+  IUserBadges,
+  IUserDB,
+} from 'src/models/user.models'
 import type { IUserPP, IUserPPDB } from 'src/models/userPreciousPlastic.models'
 import type { IFirebaseUser } from 'src/utils/firebase'
 import type { RootStore } from '..'
@@ -194,14 +200,14 @@ export class UserStore extends ModuleStore {
   }
 
   public async updateUserBadge(userId: string, badges: IUserBadges) {
-    const dbRef = this.db.collection<IUserPP>(COLLECTION_NAME).doc(userId)
-    await this.db
-      .collection(COLLECTION_NAME)
-      .doc(userId)
-      .set({
-        ...toJS(await dbRef.get('server')),
-        badges,
-      })
+    const dbRef = this.db.collection<IBadgeUpdate>(COLLECTION_NAME).doc(userId)
+
+    const badgeUpdate = {
+      _id: userId,
+      badges,
+    }
+
+    await dbRef.update(badgeUpdate)
   }
 
   /**
@@ -336,17 +342,16 @@ export class UserStore extends ModuleStore {
           (notification) => !(notification._id === id),
         )
 
-        const updatedUser: IUserPPDB = {
-          ...toJS(user),
+        const dbRef = this.db
+          .collection<INotificationUpdate>(COLLECTION_NAME)
+          .doc(user._id)
+
+        const notificationUpdate = {
+          _id: user._id,
           notifications,
         }
 
-        const dbRef = this.db
-          .collection<IUser>(COLLECTION_NAME)
-          .doc(updatedUser._id)
-
-        await dbRef.set(updatedUser)
-        //TODO: ensure current user is updated
+        await dbRef.update(notificationUpdate)
       }
     } catch (err) {
       logger.error(err)

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -266,6 +266,17 @@ export class UserStore extends ModuleStore {
     this.setUpdateStatus('Complete')
   }
 
+  public async refreshActiveUserDetails() {
+    if (!this.activeUser) return
+
+    const user = await this.db
+      .collection<IUserPP>(COLLECTION_NAME)
+      .doc(this.activeUser._id)
+      .get('server')
+
+    this.updateActiveUser(user)
+  }
+
   public async sendEmailVerification() {
     if (this.authUser) {
       return this.authUser.sendEmailVerification()

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -161,7 +161,7 @@ export class UserStore extends ModuleStore {
 
     if (lookup.length > 1) {
       logger.warn('Multiple user records fetched', lookup)
-      return lookup.filter((user) => user._id !== user._authId)[0]
+      return lookup.filter((user) => user._id !== user._authID)[0]
     }
 
     const lookup2 = await this.db

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -161,12 +161,7 @@ export class UserStore extends ModuleStore {
 
     if (lookup.length > 1) {
       logger.warn('Multiple user records fetched', lookup)
-      return lookup
-        .sort(
-          (a, b) =>
-            new Date(a._created).getTime() - new Date(b._created).getTime(),
-        )
-        .filter((user) => user._lastActive)[0]
+      return lookup.filter((user) => user._id !== user._authId)[0]
     }
 
     const lookup2 = await this.db

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -359,6 +359,15 @@ export class UserStore extends ModuleStore {
     const displayName = authUser.displayName as string
     const userName = formatLowerNoSpecial(displayName)
     const dbRef = this.db.collection<IUser>(COLLECTION_NAME).doc(userName)
+
+    if (userName === authUser.uid) {
+      logger.error(
+        'attempted to create duplicate user record with authId',
+        userName,
+      )
+      throw new Error('attempted to create duplicate user')
+    }
+
     logger.debug('creating user profile', userName)
     if (!userName) {
       throw new Error('No Username Provided')
@@ -372,6 +381,7 @@ export class UserStore extends ModuleStore {
       displayName,
       userName,
       notifications: [],
+      profileCreated: new Date().toISOString(),
     }
     // update db
     await dbRef.set(user)

--- a/src/stores/common/__mocks__/module.store.ts
+++ b/src/stores/common/__mocks__/module.store.ts
@@ -5,6 +5,7 @@ export class MockDBStore {
   set = jest.fn().mockReturnThis()
   get = jest.fn().mockReturnThis()
   getWhere = jest.fn().mockReturnThis()
+  update = jest.fn().mockReturnThis()
 }
 
 export class ModuleStore {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This pr:

- Aims to reduce the number of operations that set the full document when updating the user profile.  The reason for this is to remove the number of possible causes of 'duplicate' user docs being created.
- It also introduces two additional properties to the user profile to track when and why a user profile doc was created.  These will be used to help determine the cause of the duplicate records being created and then be removed again at a later date.
- Prevents user docs being returned by the getUserProfile function if the authId and Id are the same

I would suggest reviewing each commit separately as should make more sense that way.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
