### PR TITLE
fix: research comments not showing

### DIFF
--- a/src/pages/Research/Content/ResearchArticle.test.tsx
+++ b/src/pages/Research/Content/ResearchArticle.test.tsx
@@ -11,6 +11,7 @@ import {
 import { FactoryUser } from 'src/test/factories/User'
 import ResearchArticle from './ResearchArticle'
 import { testingThemeStyles } from 'src/test/utils/themeUtils'
+import { FactoryComment } from 'src/test/factories/Comment'
 const Theme = testingThemeStyles
 
 const activeUser = FactoryUser({
@@ -42,7 +43,7 @@ describe('Research Article', () => {
     setActiveResearchItemBySlug: jest.fn().mockResolvedValue(true),
     addSubscriberToResearchArticle: jest.fn(),
     needsModeration: jest.fn(),
-    getActiveResearchUpdateComments: jest.fn(),
+    formatResearchCommentList: jest.fn(),
     incrementViewCount: jest.fn(),
   }
 
@@ -217,6 +218,52 @@ describe('Research Article', () => {
     // Assert
     expect(wrapper.getByText('Research Update #1')).toBeInTheDocument()
     expect(wrapper.queryByText('Research Update #2')).not.toBeInTheDocument()
+  })
+
+  it('shows comments for a research update', async () => {
+    // Arrange
+    ;(useResearchStore as jest.Mock).mockReturnValue({
+      ...mockResearchStore,
+      formatResearchCommentList: jest.fn().mockImplementation((c) => {
+        return c
+      }),
+      activeResearchItem: FactoryResearchItem({
+        updates: [
+          FactoryResearchItemUpdate({
+            title: 'Research Update #1',
+            status: 'published',
+            _deleted: false,
+          }),
+          FactoryResearchItemUpdate({
+            title: 'Research Update #2',
+            status: 'draft',
+            _deleted: false,
+          }),
+          FactoryResearchItemUpdate({
+            title: 'Research Update #3',
+            status: 'published',
+            _deleted: false,
+            comments: [
+              FactoryComment({
+                text: 'First test comment',
+              }),
+              FactoryComment({
+                text: 'Second test comment',
+              }),
+            ],
+          }),
+        ],
+      }),
+    })
+    // Act
+    let wrapper
+    await act(async () => {
+      wrapper = getWrapper()
+      wrapper.getByText('View 2 Comments').click()
+    })
+
+    // Assert
+    expect(wrapper.getByText('First test comment')).toBeInTheDocument()
   })
 })
 

--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -192,7 +192,7 @@ const ResearchArticle = observer((props: IProps) => {
                   isEditable={isEditable}
                   slug={item.slug}
                   comments={transformToUserComment(
-                    researchStore.getActiveResearchUpdateComments(index),
+                    researchStore.formatResearchCommentList(update.comments),
                     loggedInUser,
                     item,
                   )}

--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -47,7 +47,7 @@ class mockResearchStoreClass implements Partial<ResearchStore> {
   })
   researchUploadStatus = {} as any
   updateUploadStatus = {} as any
-  getActiveResearchUpdateComments = jest.fn()
+  formatResearchCommentList = jest.fn()
 
   get activeUser() {
     return {

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -116,9 +116,7 @@ export class ResearchStore extends ModuleStore {
     return this.filterSorterDecorator.getSortedItems()
   }
 
-  public getActiveResearchUpdateComments(pointer: number): IComment[] {
-    const comments = this.activeResearchItem?.updates[pointer]?.comments || []
-
+  public formatResearchCommentList(comments: IComment[] = []): IComment[] {
     return comments.map((comment: IComment) => {
       return {
         ...comment,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

The problem is that the comments were being looked up via a pointer
reference on an array of Research Updates. This look up would be inaccurate
when there are updates in the array which are not visible
due to their `status=draft`. The result is
that items would be loaded off of the wrong ResearchUpdate.

As the comment list is available on the Research Update document
there is no need to look it up. Instead it can be passed through
and formatted.
