### PR TITLE
fix: remove word repetitions on forms HowTo, HowToStep and Research

### DIFF
--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -314,9 +314,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                 />
                               </Flex>
                               <Flex sx={{ flexDirection: 'column' }} mb={3}>
-                                <Label sx={_labelStyle}>
-                                  Select tags for your How-to*
-                                </Label>
+                                <Label sx={_labelStyle}>Select tags *</Label>
                                 <Field
                                   name="tags"
                                   component={TagsSelectField}
@@ -374,7 +372,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                               </Flex>
                               <Flex sx={{ flexDirection: 'column' }} mb={3}>
                                 <Label sx={_labelStyle} htmlFor="description">
-                                  Short description of your How-to *
+                                  Short description *
                                 </Label>
                                 <Field
                                   id="description"
@@ -398,7 +396,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                   }}
                                   maxLength={HOWTO_MAX_LENGTH}
                                   showCharacterCount
-                                  placeholder={`Introduction to your How-To (max ${HOWTO_MAX_LENGTH} characters)`}
+                                  placeholder={`Provide a short introduction (max ${HOWTO_MAX_LENGTH} characters)`}
                                 />
                               </Flex>
                               <Flex sx={{ mb: 2 }}>
@@ -417,7 +415,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
                                 )}
                               </Flex>
                               <Label sx={_labelStyle} htmlFor="description">
-                                Do you have supporting file to help others
+                                Do you have supporting files to help others
                                 replicate your How-to?
                               </Label>
                               <Flex

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -166,7 +166,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
               data-cy="step-title"
               modifiers={{ capitalize: true }}
               component={FieldInput}
-              placeholder={`Title of this step (max ${HOWTO_TITLE_MAX_LENGTH} characters)`}
+              placeholder={`Provide a title (max ${HOWTO_TITLE_MAX_LENGTH} characters)`}
               maxLength={HOWTO_TITLE_MAX_LENGTH}
               minLength={HOWTO_TITLE_MIN_LENGTH}
               validate={(value, allValues) =>
@@ -183,11 +183,11 @@ class HowtoStep extends PureComponent<IProps, IState> {
           </Flex>
           <Flex sx={{ flexDirection: 'column' }} mb={3}>
             <Label sx={_labelStyle} htmlFor={`${step}.text`}>
-              Description of this step *
+              Step Description *
             </Label>
             <Field
               name={`${step}.text`}
-              placeholder={`Explain what you are doing in this step. If it gets too long, consider breaking it into multiple steps (${HOWTO_STEP_DESCRIPTION_MIN_LENGTH}-${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters)`}
+              placeholder={`Explain what you are doing. If it gets too long, consider breaking it into multiple steps (${HOWTO_STEP_DESCRIPTION_MIN_LENGTH}-${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters)`}
               minLength={HOWTO_STEP_DESCRIPTION_MIN_LENGTH}
               maxLength={HOWTO_STEP_DESCRIPTION_MAX_LENGTH}
               data-cy="step-description"
@@ -211,7 +211,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
             />
           </Flex>
           <Label sx={_labelStyle} htmlFor={`${step}.text`}>
-            Upload image(s) for this step *
+            Upload image(s) *
           </Label>
           <Flex
             sx={{ flexDirection: ['column', 'row'], alignItems: 'center' }}

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -197,7 +197,7 @@ const ResearchForm = observer((props: IProps) => {
                           >
                             <Flex sx={{ flexDirection: 'column' }} mb={3}>
                               <ResearchFormLabel htmlFor="title">
-                                Title of your research. Can we...
+                                Research Title
                               </ResearchFormLabel>
                               <Field
                                 id="title"
@@ -252,7 +252,7 @@ const ResearchForm = observer((props: IProps) => {
                             </Flex>
                             <Flex sx={{ flexDirection: 'column' }} mb={3}>
                               <ResearchFormLabel>
-                                What category fits your research?
+                                Which categories fit your research?
                               </ResearchFormLabel>
                               <Field
                                 name="researchCategory"
@@ -271,9 +271,7 @@ const ResearchForm = observer((props: IProps) => {
                               />
                             </Flex>
                             <Flex sx={{ flexDirection: 'column' }} mb={3}>
-                              <ResearchFormLabel>
-                                Select tags for your research
-                              </ResearchFormLabel>
+                              <ResearchFormLabel>Select tags</ResearchFormLabel>
                               <Field
                                 name="tags"
                                 component={TagsSelectField}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes word repetitions on forms `HowTo`, `HowToStep` and `Research`. Also slightly improves labels semantic.

## Git Issues

Closes #2666 

## Screenshots/Videos

> I don't have screenshots as of now but will provide asap.

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
