### PR TITLE
fix: /how-to search component label

### DIFF
--- a/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
+++ b/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
@@ -1,10 +1,14 @@
 import { useHistory } from 'react-router'
 import type { RouteComponentProps } from 'react-router'
-import { FieldContainer } from 'src/common/Form/FieldContainer'
-import { CategoriesSelect } from 'src/pages/Howto/Category/CategoriesSelect'
 import { Flex, Input } from 'theme-ui'
 import { useState } from 'react'
 import { Select } from 'oa-components'
+
+import { FieldContainer } from 'src/common/Form/FieldContainer'
+import { CategoriesSelect } from 'src/pages/Howto/Category/CategoriesSelect'
+
+import type { HowtoStore } from 'src/stores/Howto/howto.store'
+import type { ResearchStore } from 'src/stores/Research/research.store'
 
 import { capitalizeFirstLetter } from 'src/utils/helpers'
 
@@ -30,9 +34,16 @@ const updateQueryParams = (
     search,
   })
 }
-export const SortFilterHeader = (props) => {
-  const currentStore = props.store
-  const type = props.type
+
+interface SortFilterHeaderProps {
+  store: HowtoStore | ResearchStore
+  type: 'how-to' | 'research'
+}
+
+export const SortFilterHeader = ({
+  type,
+  store: currentStore,
+}: SortFilterHeaderProps) => {
   const history = useHistory()
 
   const sortingOptions = currentStore.availableItemSortingOption?.map(

--- a/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
+++ b/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
@@ -6,6 +6,8 @@ import { Flex, Input } from 'theme-ui'
 import { useState } from 'react'
 import { Select } from 'oa-components'
 
+import { capitalizeFirstLetter } from 'src/utils/helpers'
+
 const updateQueryParams = (
   url: string,
   key: string,
@@ -97,9 +99,7 @@ export const SortFilterHeader = (props) => {
           variant="inputOutline"
           data-cy={`${type}-search-box`}
           value={searchValue}
-          placeholder={`Search for a ${(
-            type.charAt(0).toUpperCase() + type.slice(1)
-          ).split('-')}`}
+          placeholder={`Search for a ${capitalizeFirstLetter(type)}`}
           onChange={(evt) => {
             const value = evt.target.value
             updateQueryParams(window.location.href, 'search', value, history)


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Fix `/how-to` search component label. Previously it was `Search for a How,to`, this was caused by additional`.split('-')` at the end of a function to turn the first letter of strings into uppercase, which lead to an array that was never joined by a proper separator again. I fixed this by removing the `.split` and using the helper function `capitalizeFirstLetter` to achieve the desired resut.

I also added types to the props of `SortFilterHeader` component and organized the imports of the same file.

## Git Issues

Closes #2664

## Screenshots/Videos

![Captura de Tela 2023-08-01 às 00 03 53](https://github.com/ONEARMY/community-platform/assets/61033391/5e6ab9c0-b7a3-4f19-9f2f-a639fa493a41)

![Captura de Tela 2023-07-31 às 23 47 17](https://github.com/ONEARMY/community-platform/assets/61033391/6199daab-c589-4e48-9b7e-8b1376f0d08b)


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
