### PR TITLE
fix: howto unsaved changes warning after submit

### DIFF
--- a/src/pages/Howto/Content/Common/Howto.form.tsx
+++ b/src/pages/Howto/Content/Common/Howto.form.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import type { RouteComponentProps } from 'react-router'
 import { Form, Field } from 'react-final-form'
+import type { FormApi } from 'final-form'
 import styled from '@emotion/styled'
 import { FieldArray } from 'react-final-form-arrays'
 import arrayMutators from 'final-form-arrays'
@@ -131,7 +132,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
       return true
     }
   }
-  public onSubmit = async (formValues: IHowtoFormInput) => {
+  public onSubmit = async (formValues: IHowtoFormInput, form: FormApi) => {
     if (!this.checkFilesValid(formValues)) {
       return
     }
@@ -139,6 +140,7 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
     formValues.moderation = this.isDraft ? 'draft' : 'awaiting-moderation'
     logger.debug('submitting form', formValues)
     await this.store.uploadHowTo(formValues)
+    form.reset(formValues)
   }
   // automatically generate the slug when the title changes
   private calculatedFields = createDecorator({
@@ -205,8 +207,8 @@ export class HowtoForm extends React.PureComponent<IProps, IState> {
           />
         )}
         <Form
-          onSubmit={(v) => {
-            this.onSubmit(v as IHowtoFormInput)
+          onSubmit={(formValues, form) => {
+            this.onSubmit(formValues, form)
           }}
           initialValues={formValues}
           mutators={{


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

By reseting the form values to the values submitted, this fixes the howto form from incorrectly warning the user about unsaved changes.

## Git Issues

Closes #2317 