### PR TITLE
fix: Show uploaded images on how to edit screen

### DIFF
--- a/src/common/Form/ImageInput/ImageInput.tsx
+++ b/src/common/Form/ImageInput/ImageInput.tsx
@@ -74,8 +74,8 @@ const UploadImageOverlay = (props: BoxProps): JSX.Element => (
     https://github.com/davejm/client-compress
 */
 // Input can either come from uploaded or local converted meta
-type IInputValue = IUploadedFileMeta | IUploadedFileMeta
-type IMultipleInputValue = (IConvertedFileMeta | IUploadedFileMeta)[]
+type IInputValue = IUploadedFileMeta | File
+type IMultipleInputValue = IInputValue[]
 
 interface IProps {
   // if multiple sends array, otherwise single object (or null on delete)
@@ -94,7 +94,7 @@ const defaultProps: IProps = {
 
 interface IState {
   convertedFiles: IConvertedFileMeta[]
-  uploadedFiles: IUploadedFileMeta[]
+  presentFiles: IMultipleInputValue
   inputFiles: File[]
   lightboxImg?: IConvertedFileMeta
   openLightbox?: boolean
@@ -102,18 +102,18 @@ interface IState {
 
 export class ImageInput extends React.Component<IProps, IState> {
   static defaultProps = defaultProps
-
   private fileInputRef = React.createRef<HTMLInputElement>()
 
   public handleFileUpload = (filesToUpload: Array<File>) => {
     this.setState({ inputFiles: filesToUpload })
   }
+
   constructor(props: IProps) {
     super(props)
     this.state = {
       inputFiles: [],
       convertedFiles: [],
-      uploadedFiles: this._getUploadedFiles(props.value),
+      presentFiles: this._getPresentFiles(props.value),
     }
   }
 
@@ -139,7 +139,7 @@ export class ImageInput extends React.Component<IProps, IState> {
     this.setState({
       inputFiles: [],
       convertedFiles: [],
-      uploadedFiles: [],
+      presentFiles: [],
     })
     this.props.onFilesChange(null)
   }
@@ -149,16 +149,19 @@ export class ImageInput extends React.Component<IProps, IState> {
       JSON.stringify(this.props.value) !== JSON.stringify(previousProps.value)
     ) {
       this.setState({
-        uploadedFiles: this._getUploadedFiles(this.props.value),
+        presentFiles: this._getPresentFiles(this.props.value),
       })
     }
   }
 
   render() {
-    const { inputFiles, uploadedFiles } = this.state
+    const { inputFiles, presentFiles } = this.state
     const { multiple } = this.props
-    const showUploadedImg = uploadedFiles.length > 0
-    const hasImages = uploadedFiles.length > 0 || inputFiles.length > 0
+
+    const hasImages = presentFiles.length > 0 || inputFiles.length > 0
+    const showUploadedImg = presentFiles.length > 0
+    const src = this._setSrc(presentFiles[0])
+
     return (
       <Box p={0} sx={{ height: '100%' }}>
         <Dropzone
@@ -175,7 +178,7 @@ export class ImageInput extends React.Component<IProps, IState> {
             >
               <input {...getInputProps()} />
 
-              {showUploadedImg && <Image src={uploadedFiles[0].downloadUrl} />}
+              {showUploadedImg && <Image src={src} />}
 
               {!showUploadedImg &&
                 inputFiles.map((file, index) => {
@@ -214,14 +217,33 @@ export class ImageInput extends React.Component<IProps, IState> {
       </Box>
     )
   }
+
   /**
    * As input can be both array or single object and either uploaded or converted meta,
    * require extra function to separate out to handle preview of previously uploaded
    */
-  private _getUploadedFiles(value: IProps['value'] = []) {
+  private _getPresentFiles(
+    value: IProps['value'] = [],
+  ): IState['presentFiles'] {
     const valArray = Array.isArray(value) ? value : [value]
-    return valArray.filter((v) =>
-      Object.prototype.hasOwnProperty.call(v, 'downloadUrl'),
-    ) as IUploadedFileMeta[]
+    return valArray.filter((value) => {
+      if (Object.prototype.hasOwnProperty.call(value, 'downloadUrl')) {
+        return value as IUploadedFileMeta
+      }
+      if (Object.prototype.hasOwnProperty.call(value, 'objectUrl')) {
+        return value as File
+      }
+    })
+  }
+
+  private _setSrc(file): string {
+    if (file === undefined) return ''
+    if (file.downloadUrl as IUploadedFileMeta) {
+      return file.downloadUrl
+    }
+    if (file.photoData as File) {
+      return URL.createObjectURL(file.photoData)
+    }
+    return ''
   }
 }

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -86,7 +86,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
    * @param value - How to step description field value
    */
   render() {
-    const { step, index } = this.props
+    const { step, images, index } = this.props
     const _labelStyle = {
       fontSize: 2,
       marginBottom: 2,
@@ -223,6 +223,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[0]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
+                image={images[0]}
               />
             </ImageInputFieldWrapper>
             <ImageInputFieldWrapper data-cy="step-image-1">
@@ -231,6 +232,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[1]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
+                image={images[1]}
               />
             </ImageInputFieldWrapper>
             <ImageInputFieldWrapper data-cy="step-image-2">
@@ -239,6 +241,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[2]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
+                image={images[2]}
               />
             </ImageInputFieldWrapper>
           </Flex>

--- a/src/pages/Howto/Content/Common/HowtoStep.form.tsx
+++ b/src/pages/Howto/Content/Common/HowtoStep.form.tsx
@@ -86,7 +86,7 @@ class HowtoStep extends PureComponent<IProps, IState> {
    * @param value - How to step description field value
    */
   render() {
-    const { step, images, index } = this.props
+    const { step, index } = this.props
     const _labelStyle = {
       fontSize: 2,
       marginBottom: 2,
@@ -223,7 +223,6 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[0]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
-                image={images[0]}
               />
             </ImageInputFieldWrapper>
             <ImageInputFieldWrapper data-cy="step-image-1">
@@ -232,7 +231,6 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[1]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
-                image={images[1]}
               />
             </ImageInputFieldWrapper>
             <ImageInputFieldWrapper data-cy="step-image-2">
@@ -241,7 +239,6 @@ class HowtoStep extends PureComponent<IProps, IState> {
                 name={`${step}.images[2]`}
                 component={ImageInputField}
                 isEqual={COMPARISONS.image}
-                image={images[2]}
               />
             </ImageInputFieldWrapper>
           </Flex>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

It passes down the uploaded image props to the edit steps form so that they now appear to users after they leave the page.

## Git Issues

Closes #2701 