### PR TITLE
Fix #2315 - Possible to reuse previous slugs causing old links to break

### DIFF
--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -176,6 +176,15 @@ describe('[How To]', () => {
         'Titles must be unique, please try being more specific',
       ).should('exist')
 
+      cy.step('Warn if title is identical with a previously existing one')
+      cy.get('[data-cy=intro-title]')
+        .clear()
+        .type('Make glassy beams')
+        .blur({ force: true })
+      cy.contains(
+        'Titles must be unique, please try being more specific',
+      ).should('exist')
+
       cy.step('Warn if title has less than minimum required characters')
       cy.get('[data-cy=intro-title]').clear().type('qwer').blur({ force: true })
       cy.contains(

--- a/packages/cypress/src/integration/research/read.spec.ts
+++ b/packages/cypress/src/integration/research/read.spec.ts
@@ -2,7 +2,7 @@ describe('[Research]', () => {
   const SKIP_TIMEOUT = { timeout: 300 }
   const totalResearchCount = 2
   const researchArticleUrl = '/research/qwerty'
-  const authoredResearchArticleUrl = '/research/A%20test%20research'
+  const authoredResearchArticleUrl = '/research/a-test-research'
 
   beforeEach(() => {
     cy.visit('/research')
@@ -84,7 +84,7 @@ describe('[Research]', () => {
         cy.get('[data-cy="go-back"]:eq(0)').as('topBackButton').click()
 
         cy.step('Views show on second research article')
-        cy.visit('/research/A%20test%20research')
+        cy.visit('/research/a-test-research')
         cy.get('[data-cy="ViewsCounter"]').should('exist')
       })
     })

--- a/shared/mocks/data/howtos.ts
+++ b/shared/mocks/data/howtos.ts
@@ -2506,7 +2506,7 @@ export const howtos = {
     _modified: '2019-09-18T21:53:33.211Z',
     _created: '2019-09-18T14:49:54.311Z',
     slug: 'make-glass-like-beams',
-    previousSlugs: ['make-glass-like-beams'],
+    previousSlugs: ['make-glass-like-beams', 'make-glassy-beams'],
     _deleted: false,
     time: '< 1 week',
   },

--- a/shared/mocks/data/research.ts
+++ b/shared/mocks/data/research.ts
@@ -9,6 +9,7 @@ export const research = {
     description: 'qwertyefew',
     moderation: 'accepted',
     slug: 'qwerty',
+    previousSlugs: ['qwerty'],
     tags: {
       h1wCs0o9j60lkw3AYPB1: true,
     },
@@ -397,7 +398,8 @@ export const research = {
     creatorCountry: 'it',
     description: 'A test!',
     moderation: 'accepted',
-    slug: 'A test research',
+    slug: 'a-test-research',
+    previousSlugs: ['a-test-research'],
     tags: {
       h1wCs0o9j60lkw3AYPB1: true,
     },
@@ -413,6 +415,7 @@ export const research = {
     description: 'A deleted research test!',
     moderation: 'accepted',
     slug: 'a-deleted-test-research',
+    previousSlugs: ['a-deleted-test-research'],
     tags: {
       h1wCs0o9j60lkw3AYPB1: true,
     },

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.test.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.test.tsx
@@ -19,7 +19,7 @@ jest.mock('src/stores/Research/research.store', () => {
         Database: false,
         Complete: false,
       },
-      validateTitleForSlug: jest.fn(),
+      isTitleThatReusesSlug: jest.fn(),
     }),
   }
 })
@@ -64,7 +64,7 @@ describe('Research update form', () => {
       const formValues = FactoryResearchItemUpdate({
         images: [new File(['hello'], 'hello.png')],
         files: [new File(['test file content'], 'test-file.zip')],
-        fileLink: 'www.filedonwload.test',
+        fileLink: 'www.filedownload.test',
       })
 
       // Act

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -31,50 +31,20 @@ export class ModuleStore {
   /****************************************************************************
    *            Data Validation Methods
    * **************************************************************************/
-  public checkIsUnique = async (
-    endpoint: IDBEndpoint,
-    field: string,
-    value: string,
-    originalId?: string,
-  ) => {
-    const matches = await this.db
-      .collection(endpoint)
-      .getWhere(field, '==', value)
-    if (
-      typeof originalId !== 'undefined' &&
-      matches.length === 1 &&
-      matches[0]._id === originalId
-    ) {
-      return true
-    }
-    return matches.length > 0 ? false : true
-  }
-  /** Validator method to pass to react-final-form. Takes a given title,
-   *  converts to corresponding slug and checks uniqueness.
-   *  Provide originalId to prevent matching against own entry.
-   *  NOTE - return value represents the error, so FALSE actually means valid
-   */
-  public validateTitleForSlug = async (
+  public isTitleThatReusesSlug = async (
     title: string,
     endpoint: IDBEndpoint,
     originalId?: string,
   ) => {
-    if (title) {
-      const slug = stripSpecialCharacters(title).toLowerCase()
-      const unique = await this.checkIsUnique(
-        endpoint,
-        'slug',
-        slug,
-        originalId,
-      )
-      return unique
-        ? false
-        : 'Titles must be unique, please try being more specific'
-    } else {
-      // if no title submitted, simply return message to say that it is required
-      return 'Required'
-    }
+    const slug = stripSpecialCharacters(title).toLowerCase()
+
+    const matches = await this.db
+      .collection(endpoint)
+      .getWhere('previousSlugs', 'array-contains', slug)
+    const otherMatches = matches.filter((match) => match._id !== originalId)
+    return otherMatches.length > 0
   }
+
   public validateUrl = async (value: any) => {
     return value ? (isUrl(value) ? undefined : 'Invalid url') : 'Required'
   }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -66,12 +66,29 @@ const isEmail = (email: string) => {
   return re.test(String(email).toLowerCase())
 }
 
+/** Validator method to pass to react-final-form. Takes a given title,
+ *  converts to corresponding slug and checks uniqueness.
+ *  Provide originalId to prevent matching against own entry.
+ *  NOTE - return value represents the error, so FALSE actually means valid
+ */
 const validateTitle =
   (parentType, id, documentType: documentTypes, store: storeTypes) =>
-  async (value: any) => {
+  async (title?: string) => {
     const originalId = parentType === 'edit' ? id : undefined
 
-    return await store.validateTitleForSlug(value, documentType, originalId)
+    if (!title) {
+      // if no title submitted, simply return message to say that it is required
+      return 'Required'
+    }
+
+    const titleReusesSlug = await store.isTitleThatReusesSlug(
+      title,
+      documentType,
+      originalId,
+    )
+    return (
+      titleReusesSlug && 'Titles must be unique, please try being more specific'
+    )
   }
 
 const draftValidationWrapper = (value, allValues, validator) => {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Adds a check on previousSlugs on title validation.

## Git Issues

Closes #2315 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
