### PR TITLE
fix: replace margins with paddings in research comments box section

### DIFF
--- a/src/pages/Research/Content/ResearchComments/ResearchComments.tsx
+++ b/src/pages/Research/Content/ResearchComments/ResearchComments.tsx
@@ -20,8 +20,9 @@ interface IProps {
 
 const BoxMain = styled(Box)`
   padding-bottom: 15px;
-  margin-left: 20px;
-  margin-right: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 20px;
   margin-top: 20px;
 `
 
@@ -129,13 +130,7 @@ export const ResearchComments = ({
   }
 
   return (
-    <BoxMain
-      paddingTop={viewComments ? '15px' : '0'}
-      paddingLeft={viewComments ? '25px' : '0'}
-      paddingRight={viewComments ? '25px' : '0'}
-      backgroundColor={viewComments ? '#e2edf7' : 'inherit'}
-      marginBottom={viewComments ? '20px' : '0'}
-    >
+    <BoxMain backgroundColor={viewComments ? '#e2edf7' : 'inherit'}>
       <Button
         variant="subtle"
         sx={{


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Replacing the research comments box margin with paddings, so there is no white margin around the section.

## Git Issues

Closes #2681 

## Screenshots/Videos

![image](https://github.com/ONEARMY/community-platform/assets/2430734/50b0b963-b4f3-4f2b-b4bc-7cc73a9f5407)

![image](https://github.com/ONEARMY/community-platform/assets/2430734/3bf277b8-37c6-4274-87a5-35f0692e02e0)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
