### PR TITLE
feat: filter research list by moderation status

### DIFF
--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -2,6 +2,7 @@ import type {
   DBDoc,
   IComment,
   IModerable,
+  IModerationStatus,
   ISelectedTags,
   ISharedFeatures,
   UserMention,
@@ -27,6 +28,7 @@ export namespace IResearch {
     _deleted: boolean
     collaborators: string[]
     subscribers?: UserIdList
+    moderation: IModerationStatus
   } & Omit<FormInput, 'collaborators'> &
     ISharedFeatures
 

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -118,7 +118,7 @@ export class ResearchStore extends ModuleStore {
 
     this.filterSorterDecorator.allItems = validResearches
 
-    return this.filterSorterDecorator.getSortedItems()
+    return this.filterSorterDecorator.getSortedItems(this.activeUser)
   }
 
   public formatResearchCommentList(comments: IComment[] = []): IComment[] {

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -158,12 +158,10 @@ export class FilterSorterDecorator<T extends IItem> {
           break
 
         default:
+          validItems = this.sortByModerationStatus(validItems, activeUser)
           break
       }
     }
-
-    validItems = this.sortByModerationStatus(validItems, activeUser)
-
     return validItems
   }
 

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -1,12 +1,13 @@
 import Fuse from 'fuse.js'
 import { action, observable } from 'mobx'
-import type { IComment } from 'src/models'
+import type { IComment, IModerationStatus, IUser } from 'src/models'
 import type { ICategory } from 'src/models/categories.model'
 
 export interface IItem {
   _modified: string
   _contentModifiedTimestamp: string
   _created: string
+  _createdBy: string
   title?: string
   votedUsefulBy?: string[]
   category?: ICategory
@@ -14,6 +15,7 @@ export interface IItem {
   updates?: {
     comments?: IComment[]
   }[]
+  moderation?: IModerationStatus
 }
 
 export enum ItemSortingOption {
@@ -106,8 +108,31 @@ export class FilterSorterDecorator<T extends IItem> {
     )
   }
 
+  private sortByModerationStatus(listItems: T[], user?: IUser) {
+    const _listItems = listItems || this.allItems
+    const isCreatedByUser = (item: T) =>
+      user && item._createdBy === user.userName
+    const isModerationMatch = (item: T) =>
+      item.moderation === 'draft' ||
+      item.moderation === 'awaiting-moderation' ||
+      item.moderation === 'rejected'
+
+    return _listItems.sort((a, b) => {
+      const aMatchesCondition = isCreatedByUser(a) && isModerationMatch(a)
+      const bMatchesCondition = isCreatedByUser(b) && isModerationMatch(b)
+
+      if (aMatchesCondition && !bMatchesCondition) {
+        return -1
+      } else if (!aMatchesCondition && bMatchesCondition) {
+        return 1
+      } else {
+        return 0
+      }
+    })
+  }
+
   @action
-  public getSortedItems(): T[] {
+  public getSortedItems(activeUser?: IUser): T[] {
     let validItems = this.allItems.slice()
 
     if (this.activeSorter) {
@@ -136,6 +161,8 @@ export class FilterSorterDecorator<T extends IItem> {
           break
       }
     }
+
+    validItems = this.sortByModerationStatus(validItems, activeUser)
 
     return validItems
   }

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -158,10 +158,12 @@ export class FilterSorterDecorator<T extends IItem> {
           break
 
         default:
-          validItems = this.sortByModerationStatus(validItems, activeUser)
           break
       }
     }
+
+    validItems = this.sortByModerationStatus(validItems, activeUser)
+
     return validItems
   }
 

--- a/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
+++ b/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
@@ -3,6 +3,7 @@ import {
   ItemSortingOption,
 } from './FilterSorterDecorator'
 import type { IItem } from './FilterSorterDecorator'
+import { FactoryUser } from 'src/test/factories/User'
 
 describe('FilterSorterDecorator', () => {
   let decorator: FilterSorterDecorator<IItem>
@@ -12,6 +13,8 @@ describe('FilterSorterDecorator', () => {
       _modified: '2022-01-01',
       _contentModifiedTimestamp: '2022-01-01',
       _created: '2022-01-01',
+      _createdBy: 'user3',
+      moderation: 'accepted',
       votedUsefulBy: ['user1', 'user2'],
       category: {
         _contentModifiedTimestamp: '2022-12-24T07:50:55.226Z',
@@ -58,6 +61,8 @@ describe('FilterSorterDecorator', () => {
       _modified: '2022-02-01',
       _contentModifiedTimestamp: '2022-02-01',
       _created: '2022-02-01',
+      _createdBy: 'user1',
+      moderation: 'accepted',
       votedUsefulBy: ['user3'],
       researchCategory: {
         _contentModifiedTimestamp: '2022-12-24T07:50:55.226Z',
@@ -154,6 +159,72 @@ describe('FilterSorterDecorator', () => {
     const sortedItems = decorator.getSortedItems()
     expect(sortedItems.length).toEqual(mockItems.length) // No sorting applied, should return original order
     expect(sortedItems[0].title).toEqual(mockItems[0].title)
+  })
+
+  describe('sorting multiple items by moderation status', () => {
+    const mockUser = FactoryUser({ userName: 'user2' })
+
+    const mockItemsWithModeration = mockItems.concat([
+      {
+        _modified: '2022-10-10',
+        _createdBy: 'user2',
+        title: 'Item 3',
+        _created: '2022-10-10',
+        moderation: 'accepted',
+      },
+      {
+        _modified: '2022-10-10',
+        _createdBy: 'user2',
+        title: 'Item 4',
+        _created: '2022-10-10',
+        moderation: 'draft',
+      },
+      {
+        _modified: '2022-10-10',
+        _createdBy: 'user2',
+        title: 'Item 5',
+        _created: '2022-01-01',
+        moderation: 'rejected',
+      },
+      {
+        _modified: '2022-10-10',
+        _createdBy: 'user2',
+        title: 'Item 6',
+        _created: '2022-10-10',
+        moderation: 'awaiting-moderation',
+      },
+      {
+        _modified: '2022-10-10',
+        _createdBy: 'user3',
+        title: 'Item 7',
+        _created: '2022-10-10',
+        moderation: 'accepted',
+      },
+    ])
+
+    decorator = new FilterSorterDecorator(mockItemsWithModeration)
+    const sortedItems = decorator.getSortedItems(mockUser)
+
+    it('sort items created by user2 at the start of the list if they have moderation', () => {
+      expect(sortedItems[0]._createdBy).toEqual('user2')
+      expect(sortedItems[1]._createdBy).toEqual('user2')
+      expect(sortedItems[2]._createdBy).toEqual('user2')
+    })
+
+    it('sort items created by user2 with moderation statuses first', () => {
+      expect(sortedItems[0].moderation).toEqual('draft')
+      expect(sortedItems[0].title).toEqual('Item 4')
+
+      expect(sortedItems[1].moderation).toEqual('rejected')
+      expect(sortedItems[1].title).toEqual('Item 5')
+
+      expect(sortedItems[2].moderation).toEqual('awaiting-moderation')
+      expect(sortedItems[2].title).toEqual('Item 6')
+    })
+
+    it('return list of the same size', () => {
+      expect(sortedItems.length).toEqual(mockItemsWithModeration.length)
+    })
   })
 
   //#endregion Sorting

--- a/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
+++ b/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
@@ -167,6 +167,7 @@ describe('FilterSorterDecorator', () => {
     const mockItemsWithModeration = mockItems.concat([
       {
         _modified: '2022-10-10',
+        _contentModifiedTimestamp: '2022-10-10',
         _createdBy: 'user2',
         title: 'Item 3',
         _created: '2022-10-10',
@@ -174,30 +175,34 @@ describe('FilterSorterDecorator', () => {
       },
       {
         _modified: '2022-10-10',
+        _contentModifiedTimestamp: '2022-10-10',
         _createdBy: 'user2',
         title: 'Item 4',
         _created: '2022-10-10',
         moderation: 'draft',
       },
       {
-        _modified: '2022-10-10',
+        _modified: '2022-01-01',
+        _contentModifiedTimestamp: '2022-01-01',
         _createdBy: 'user2',
         title: 'Item 5',
         _created: '2022-01-01',
         moderation: 'rejected',
       },
       {
-        _modified: '2022-10-10',
+        _modified: '2022-01-01',
+        _contentModifiedTimestamp: '2022-01-01',
         _createdBy: 'user2',
         title: 'Item 6',
-        _created: '2022-10-10',
+        _created: '2022-01-01',
         moderation: 'awaiting-moderation',
       },
       {
-        _modified: '2022-10-10',
+        _modified: '2022-01-01',
+        _contentModifiedTimestamp: '2022-01-01',
         _createdBy: 'user3',
         title: 'Item 7',
-        _created: '2022-10-10',
+        _created: '2022-01-01',
         moderation: 'accepted',
       },
     ])

--- a/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
+++ b/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
@@ -207,23 +207,16 @@ describe('FilterSorterDecorator', () => {
 
     it('sort items created by user2 at the start of the list if they have moderation', () => {
       expect(sortedItems[0]._createdBy).toEqual('user2')
-      expect(sortedItems[1]._createdBy).toEqual('user2')
-      expect(sortedItems[2]._createdBy).toEqual('user2')
-    })
-
-    it('sort items created by user2 with moderation statuses first', () => {
       expect(sortedItems[0].moderation).toEqual('draft')
       expect(sortedItems[0].title).toEqual('Item 4')
 
+      expect(sortedItems[1]._createdBy).toEqual('user2')
       expect(sortedItems[1].moderation).toEqual('rejected')
       expect(sortedItems[1].title).toEqual('Item 5')
 
+      expect(sortedItems[2]._createdBy).toEqual('user2')
       expect(sortedItems[2].moderation).toEqual('awaiting-moderation')
       expect(sortedItems[2].title).toEqual('Item 6')
-    })
-
-    it('return list of the same size', () => {
-      expect(sortedItems.length).toEqual(mockItemsWithModeration.length)
     })
   })
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_

Pins any research created by a user to the top of the research list if they have a moderation status of:
- rejected
- awaiting-moderation
- draft

Closes #2550 

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
