### PR TITLE
feat: add research list sort reset

### DIFF
--- a/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
+++ b/src/pages/common/SortFilterHeader/SortFilterHeader.tsx
@@ -105,8 +105,11 @@ export const SortFilterHeader = ({
             options={sortingOptions}
             placeholder="Sort by"
             value={sortState}
+            isClearable={true}
             onChange={(sortBy) => {
-              currentStore.updateActiveSorter(String(sortBy.value))
+              currentStore.updateActiveSorter(
+                String(sortBy ? sortBy.value : 'None'),
+              )
               setSortState(sortBy)
             }}
           />

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -133,6 +133,7 @@ export class FilterSorterDecorator<T extends IItem> {
           break
 
         default:
+          validItems = this.sortByLatestModified(validItems)
           break
       }
     }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Allows the reseting back to default state for the sort select menu in the research list, previously there was no way to achieve this. Improving the UX.

#2739 improves on this by adding the proposed new default view discussed in #2550.

## Git Issues

Closes #

## Screenshots/Videos

![image](https://github.com/ONEARMY/community-platform/assets/652368/598386b2-ab13-4094-936e-ae805af5d54c)


_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
