### PR TITLE
fix: change embed images/video labels to one line

### DIFF
--- a/src/pages/Howto/Content/Common/HowtoFieldStep.tsx
+++ b/src/pages/Howto/Content/Common/HowtoFieldStep.tsx
@@ -256,9 +256,6 @@ class HowtoFieldStep extends PureComponent<IProps, IState> {
             </ImageInputFieldWrapper>
           </Flex>
           <Flex sx={{ flexDirection: 'column' }} mb={3}>
-            <Label sx={_labelStyle} htmlFor={`${step}.videoUrl`}>
-              {`${videoUrl.title} *`}
-            </Label>
             <Field
               name={`${step}.videoUrl`}
               data-cy="step-videoUrl"

--- a/src/pages/Howto/labels.ts
+++ b/src/pages/Howto/labels.ts
@@ -86,9 +86,8 @@ export const steps = {
     title: 'Step Description',
     placeholder: `Explain what you are doing. If it gets too long, consider breaking it into multiple steps (${HOWTO_STEP_DESCRIPTION_MIN_LENGTH}-${HOWTO_STEP_DESCRIPTION_MAX_LENGTH} characters)`,
   },
-  images: 'Upload image(s)',
+  images: 'Upload image(s) or a video',
   videoUrl: {
-    title: 'Or embed a YouTube video',
     placeholder: 'https://youtube.com/watch?v=',
     errors: {
       both: 'Do not include both images and video',


### PR DESCRIPTION
PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Description

_Simple fix to embed labels in how-to, to make things more clear_

## Git Issues

closes #2557 

## Screenshots/Videos

https://user-images.githubusercontent.com/37253846/264488684-dd99ffb2-01de-4abc-b2c3-a9ab06ebefae.png

---

