### PR TITLE
fix: keep items in research/howto list in place if equal to another

### DIFF
--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -81,7 +81,6 @@ export class FilterSorterDecorator<T extends IItem> {
       const valueA = a[propertyName]
       const valueB = b[propertyName]
 
-      // Check if it's an array and get its length
       const lengthA = Array.isArray(valueA) ? valueA.length : valueA ?? 0
       const lengthB = Array.isArray(valueB) ? valueB.length : valueB ?? 0
 
@@ -117,7 +116,7 @@ export class FilterSorterDecorator<T extends IItem> {
       const totalCommentsB = this.calculateTotalComments(b)
 
       if (totalCommentsA === totalCommentsB) {
-        return 1
+        return 0
       }
 
       return totalCommentsA < totalCommentsB ? 1 : -1

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -74,38 +74,54 @@ export class FilterSorterDecorator<T extends IItem> {
       : listItems
   }
 
-  private sortByLatestModified(listItems: T[]) {
+  private sortByProperty(listItems: T[], propertyName: keyof IItem): T[] {
     const _listItems = listItems || this.allItems
-    return _listItems.sort((a, b) =>
-      a._contentModifiedTimestamp < b._contentModifiedTimestamp ? 1 : -1,
-    )
+
+    return _listItems.sort((a, b) => {
+      const valueA = a[propertyName]
+      const valueB = b[propertyName]
+
+      // Check if it's an array and get its length
+      const lengthA = Array.isArray(valueA) ? valueA.length : valueA ?? 0
+      const lengthB = Array.isArray(valueB) ? valueB.length : valueB ?? 0
+
+      if (lengthA === lengthB) {
+        return 0
+      }
+
+      return lengthA < lengthB ? 1 : -1
+    })
+  }
+
+  private sortByLatestModified(listItems: T[]) {
+    return this.sortByProperty(listItems, '_contentModifiedTimestamp')
   }
 
   private sortByLatestCreated(listItems: T[]) {
-    const _listItems = listItems || this.allItems
-    return _listItems.sort((a, b) => (a._created < b._created ? 1 : -1))
+    return this.sortByProperty(listItems, '_created')
   }
 
   private sortByMostUseful(listItems: T[]) {
-    const _listItems = listItems || this.allItems
-    return _listItems.sort((a, b) =>
-      (a.votedUsefulBy || []).length < (b.votedUsefulBy || []).length ? 1 : -1,
-    )
+    return this.sortByProperty(listItems, 'votedUsefulBy')
   }
 
   private sortByUpdates(listItems: T[]) {
-    const _listItems = listItems || this.allItems
-    return _listItems.sort((a, b) =>
-      (a.updates || []).length < (b.updates || []).length ? 1 : -1,
-    )
+    return this.sortByProperty(listItems, 'updates')
   }
 
   private sortByComments(listItems: T[]) {
     const _listItems = listItems || this.allItems
 
-    return _listItems.sort((a, b) =>
-      this.calculateTotalComments(a) < this.calculateTotalComments(b) ? 1 : -1,
-    )
+    return _listItems.sort((a, b) => {
+      const totalCommentsA = this.calculateTotalComments(a)
+      const totalCommentsB = this.calculateTotalComments(b)
+
+      if (totalCommentsA === totalCommentsB) {
+        return 1
+      }
+
+      return totalCommentsA < totalCommentsB ? 1 : -1
+    })
   }
 
   private sortByModerationStatus(listItems: T[], user?: IUser) {
@@ -123,11 +139,13 @@ export class FilterSorterDecorator<T extends IItem> {
 
       if (aMatchesCondition && !bMatchesCondition) {
         return -1
-      } else if (!aMatchesCondition && bMatchesCondition) {
-        return 1
-      } else {
-        return 0
       }
+
+      if (!aMatchesCondition && bMatchesCondition) {
+        return 1
+      }
+
+      return 0
     })
   }
 

--- a/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
+++ b/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
@@ -161,6 +161,33 @@ describe('FilterSorterDecorator', () => {
     expect(sortedItems[0].title).toEqual(mockItems[0].title)
   })
 
+  test('sorted items stay in same order if they have equal values', () => {
+    const mockItems: IItem[] = [
+      {
+        _modified: '2022-10-10',
+        _contentModifiedTimestamp: '2022-10-10',
+        _createdBy: 'user1',
+        title: 'Item 1',
+        _created: '2022-10-10',
+        votedUsefulBy: ['user2'],
+      },
+      {
+        _modified: '2022-10-10',
+        _contentModifiedTimestamp: '2022-10-10',
+        _createdBy: 'user1',
+        title: 'Item 2',
+        _created: '2022-10-10',
+        votedUsefulBy: ['user2'],
+      },
+    ]
+
+    decorator = new FilterSorterDecorator(mockItems)
+
+    const sortedItems = decorator.sort('MostUseful')
+    expect(sortedItems[0].title).toEqual(mockItems[0].title)
+    expect(sortedItems[1].title).toEqual(mockItems[1].title)
+  })
+
   describe('sorting multiple items by moderation status', () => {
     const mockUser = FactoryUser({ userName: 'user2' })
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Prevents the shifting of items in the research/howto lists if they have values equal to that of another item. Previously if equal item b would always go before item a, causing the lists to constanly change. 

Issue was observed in #2752

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
