### PR TITLE
fix: research updates and comments count

### DIFF
--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -252,7 +252,7 @@ const ResearchArticle = observer((props: IProps) => {
 })
 
 const isUpdateVisible = (update: IResearch.UpdateDB) => {
-  return update.status !== 'draft' && update._deleted === false
+  return update.status !== 'draft' && !update._deleted
 }
 
 const transformToUserComment = (

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -198,7 +198,7 @@ const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
 const calculateTotalComments = (item: IResearch.ItemDB) => {
   if (item.updates) {
     const commentOnUpdates = item.updates.reduce((totalComments, update) => {
-      const updateCommentsLength = update.comments ? update.comments.length : 0
+      const updateCommentsLength = !update._deleted && update.comments ? update.comments.length : 0
       return totalComments + updateCommentsLength
     }, 0)
 
@@ -212,7 +212,7 @@ const getUpdateText = (item: IResearch.ItemDB) => {
   return item.updates?.length
     ? String(
         item.updates.filter(
-          (update) => update.status !== 'draft' && update._deleted !== true,
+          (update) => update.status !== 'draft' && !update._deleted,
         ).length,
       )
     : '0'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -143,7 +143,7 @@ export const isAllowedToDeleteContent = (doc: IEditableDoc, user?: IUser) => {
   return (
     roles.includes('admin') ||
     roles.includes('super-admin') ||
-    (doc._createdBy && doc._createdBy === user.userName)
+    (doc._createdBy! === user.userName)
   )
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR fixes the amount of updates and comments on researches. The comments from deleted updates were being considered and now they're ignored. Also fixed a small type problem on a function that was returning `boolean | ""` when it was supposed to return only `boolean`.

## Git Issues

Closes #2760

## Screenshots/Videos

Since the updates were not actually marked as `_deleted` (instead, this field was null), they should appear on the research page.
![image](https://github.com/ONEARMY/community-platform/assets/44332001/cd1e0ec1-540e-4a44-b0d9-119147c8a4a6)

As you can see, now all the 7 updates are being shown.

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).

Obs: My first contribution to the project, so sorry if I did something wrong. I read every docs I found, so I hope it's all according to the standard.
