### PR TITLE
feat: trim trailing whitespace in HowTo text fields

### DIFF
--- a/packages/components/src/FieldInput/FieldInput.tsx
+++ b/packages/components/src/FieldInput/FieldInput.tsx
@@ -16,6 +16,7 @@ export interface Props extends FieldProps {
 
 type InputModifiers = {
   capitalize?: boolean
+  trim?: boolean
 }
 
 const capitalizeFirstLetter = (str: string) =>
@@ -23,6 +24,9 @@ const capitalizeFirstLetter = (str: string) =>
 
 const processInputModifiers = (value: any, modifiers: InputModifiers = {}) => {
   if (typeof value !== 'string') return value
+  if (modifiers.trim) {
+    value = value.trim()
+  }
   if (modifiers.capitalize) {
     value = capitalizeFirstLetter(value)
   }

--- a/packages/components/src/FieldTextarea/FieldTextarea.tsx
+++ b/packages/components/src/FieldTextarea/FieldTextarea.tsx
@@ -13,11 +13,19 @@ export interface Props extends FieldProps {
   customOnBlur?: (event: any) => void
 }
 
+type InputModifiers = {
+  capitalize?: boolean
+  trim?: boolean
+}
+
 const capitalizeFirstLetter = (str: string) =>
   str.charAt(0).toUpperCase() + str.slice(1)
 
-const processInputModifiers = (value: any, modifiers: any = {}) => {
+const processInputModifiers = (value: any, modifiers: InputModifiers) => {
   if (typeof value !== 'string') return value
+  if (modifiers.trim) {
+    value = value.trim()
+  }
   if (modifiers.capitalize) {
     value = capitalizeFirstLetter(value)
   }

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -32,30 +32,16 @@ describe('[How To]', () => {
 
     cy.step(`Filling step ${stepNumber}`)
     cy.get(`[data-cy=step_${stepIndex}]:visible`).within(($step) => {
+      checkWhitespaceTrim('step-title')
+
       cy.get('[data-cy=step-title]')
         .clear()
         .invoke('val', title)
         .blur({ force: true })
 
-      cy.get('[data-cy=step-title]')
-        .clear()
-        .type('  Test for trailing whitespace  ')
-        .blur()
+      cy.get('[data-cy=step-title]').should('have.value', title)
 
-      cy.get('[data-cy=step-title]').should(
-        'have.value',
-        'Test for trailing whitespace',
-      )
-
-      cy.get('[data-cy=step-title]')
-        .clear()
-        .type(' Test  inner  whitespace  is  not  trimmed ')
-        .blur()
-
-      cy.get('[data-cy=step-title]').should(
-        'have.value',
-        'Test  inner  whitespace  is  not  trimmed',
-      )
+      checkWhitespaceTrim('step-description')
 
       cy.get('[data-cy=step-description]')
         .clear()
@@ -63,26 +49,6 @@ describe('[How To]', () => {
         .blur({ force: true })
 
       cy.get('[data-cy=step-description]').should('have.value', description)
-
-      cy.get('[data-cy=step-description]')
-        .clear()
-        .type('  Test for trailing whitespace  ')
-        .blur()
-
-      cy.get('[data-cy=step-description]').should(
-        'have.value',
-        'Test for trailing whitespace',
-      )
-
-      cy.get('[data-cy=step-description]')
-        .clear()
-        .type(' Test  inner  whitespace  is  not  trimmed ')
-        .blur()
-
-      cy.get('[data-cy=step-description]').should(
-        'have.value',
-        'Test  inner  whitespace  is  not  trimmed',
-      )
 
       if (videoUrl) {
         cy.step('Adding Video Url')
@@ -99,10 +65,6 @@ describe('[How To]', () => {
             })
         }
 
-        cy.get('[data-cy=step-title]')
-          .clear()
-          .invoke('val', title)
-          .blur({ force: true })
         images.forEach((image, index) => {
           cy.get(`[data-cy=step-image-${index}]`)
             .find(':file')
@@ -119,6 +81,20 @@ describe('[How To]', () => {
       .find('[data-cy=delete-step]')
       .click()
     cy.get('[data-cy=confirm]').click()
+  }
+
+  const checkWhitespaceTrim = (element: string) => {
+    cy.step(`Check whitespace trim for [${element}]`)
+    cy.get(`[data-cy=${element}]`)
+      .clear()
+      .invoke('val', '  Test for trailing whitespace  ')
+      .blur()
+
+    cy.get(`[data-cy=${element}]`).should(
+      'have.value',
+      'Test for trailing whitespace',
+    )
+    cy.get(`[data-cy=${element}]`).clear()
   }
 
   describe('[Create a how-to]', () => {
@@ -256,27 +232,7 @@ describe('[How To]', () => {
       cy.step('Back to completing the how-to')
       cy.get('[data-cy=edit]').click()
 
-      cy.step('Check title for trailing whitespace')
-      cy.get('[data-cy=intro-title]')
-        .clear()
-        .type(' Title with whitespace ')
-        .blur()
-      cy.get('[data-cy=intro-title]').should(
-        'have.value',
-        'Title with whitespace',
-      )
-      cy.get('[data-cy=intro-title]').clear()
-
-      cy.step('Check title for extra whitespace')
-      cy.get('[data-cy=intro-title]')
-        .clear()
-        .type(' Title  with  extra  whitespace ')
-        .blur()
-      cy.get('[data-cy=intro-title]').should(
-        'have.value',
-        'Title  with  extra  whitespace',
-      )
-      cy.get('[data-cy=intro-title]').clear()
+      checkWhitespaceTrim('intro-title')
 
       cy.step('Fill up the intro')
       cy.get('[data-cy=intro-title').clear().type(title).blur({ force: true })
@@ -284,27 +240,7 @@ describe('[How To]', () => {
       selectTimeDuration(time as Duration)
       selectDifficultLevel(difficulty_level as Difficulty)
 
-      cy.step('Check description for trailing whitespace')
-      cy.get('[data-cy=intro-description]')
-        .clear()
-        .type(' Description with trailing whitespace ')
-        .blur()
-      cy.get('[data-cy=intro-description]').should(
-        'have.value',
-        'Description with trailing whitespace',
-      )
-      cy.get('[data-cy=intro-description]').clear()
-
-      cy.step('Check description for extra whitespace')
-      cy.get('[data-cy=intro-description]')
-        .clear()
-        .type(' Description  with  extra  whitespace ')
-        .blur()
-      cy.get('[data-cy=intro-description]').should(
-        'have.value',
-        'Description  with  extra  whitespace',
-      )
-      cy.get('[data-cy=intro-description]').clear()
+      checkWhitespaceTrim('intro-description')
 
       cy.get('[data-cy=intro-description]').type(description)
       cy.get('[data-cy=fileLink]').type(fileLink)

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -37,10 +37,52 @@ describe('[How To]', () => {
         .invoke('val', title)
         .blur({ force: true })
 
+      cy.get('[data-cy=step-title]')
+        .clear()
+        .type('  Test for trailing whitespace  ')
+        .blur()
+
+      cy.get('[data-cy=step-title]').should(
+        'have.value',
+        'Test for trailing whitespace',
+      )
+
+      cy.get('[data-cy=step-title]')
+        .clear()
+        .type(' Test  inner  whitespace  is  not  trimmed ')
+        .blur()
+
+      cy.get('[data-cy=step-title]').should(
+        'have.value',
+        'Test  inner  whitespace  is  not  trimmed',
+      )
+
       cy.get('[data-cy=step-description]')
         .clear()
         .invoke('val', description)
         .blur({ force: true })
+
+      cy.get('[data-cy=step-description]').should('have.value', description)
+
+      cy.get('[data-cy=step-description]')
+        .clear()
+        .type('  Test for trailing whitespace  ')
+        .blur()
+
+      cy.get('[data-cy=step-description]').should(
+        'have.value',
+        'Test for trailing whitespace',
+      )
+
+      cy.get('[data-cy=step-description]')
+        .clear()
+        .type(' Test  inner  whitespace  is  not  trimmed ')
+        .blur()
+
+      cy.get('[data-cy=step-description]').should(
+        'have.value',
+        'Test  inner  whitespace  is  not  trimmed',
+      )
 
       if (videoUrl) {
         cy.step('Adding Video Url')
@@ -56,6 +98,11 @@ describe('[How To]', () => {
               cy.wrap($deleteButton).click()
             })
         }
+
+        cy.get('[data-cy=step-title]')
+          .clear()
+          .invoke('val', title)
+          .blur({ force: true })
         images.forEach((image, index) => {
           cy.get(`[data-cy=step-image-${index}]`)
             .find(':file')
@@ -209,11 +256,55 @@ describe('[How To]', () => {
       cy.step('Back to completing the how-to')
       cy.get('[data-cy=edit]').click()
 
+      cy.step('Check title for trailing whitespace')
+      cy.get('[data-cy=intro-title]')
+        .clear()
+        .type(' Title with whitespace ')
+        .blur()
+      cy.get('[data-cy=intro-title]').should(
+        'have.value',
+        'Title with whitespace',
+      )
+      cy.get('[data-cy=intro-title]').clear()
+
+      cy.step('Check title for extra whitespace')
+      cy.get('[data-cy=intro-title]')
+        .clear()
+        .type(' Title  with  extra  whitespace ')
+        .blur()
+      cy.get('[data-cy=intro-title]').should(
+        'have.value',
+        'Title  with  extra  whitespace',
+      )
+      cy.get('[data-cy=intro-title]').clear()
+
       cy.step('Fill up the intro')
       cy.get('[data-cy=intro-title').clear().type(title).blur({ force: true })
       cy.selectTag('howto_testing')
       selectTimeDuration(time as Duration)
       selectDifficultLevel(difficulty_level as Difficulty)
+
+      cy.step('Check description for trailing whitespace')
+      cy.get('[data-cy=intro-description]')
+        .clear()
+        .type(' Description with trailing whitespace ')
+        .blur()
+      cy.get('[data-cy=intro-description]').should(
+        'have.value',
+        'Description with trailing whitespace',
+      )
+      cy.get('[data-cy=intro-description]').clear()
+
+      cy.step('Check description for extra whitespace')
+      cy.get('[data-cy=intro-description]')
+        .clear()
+        .type(' Description  with  extra  whitespace ')
+        .blur()
+      cy.get('[data-cy=intro-description]').should(
+        'have.value',
+        'Description  with  extra  whitespace',
+      )
+      cy.get('[data-cy=intro-description]').clear()
 
       cy.get('[data-cy=intro-description]').type(description)
       cy.get('[data-cy=fileLink]').type(fileLink)

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -157,7 +157,8 @@ describe('[How To]', () => {
           ],
           text: faker.lorem
             .sentences(50)
-            .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH),
+            .slice(0, HOWTO_STEP_DESCRIPTION_MAX_LENGTH)
+            .trim(),
           title: 'A long title that is the total characters limit of',
         },
         {

--- a/src/pages/Howto/Content/Common/HowtoFieldDescription.tsx
+++ b/src/pages/Howto/Content/Common/HowtoFieldDescription.tsx
@@ -21,7 +21,7 @@ export const HowtoFieldDescription = () => {
           draftValidationWrapper(values, allValues, required)
         }
         validateFields={[]}
-        modifiers={{ capitalize: true }}
+        modifiers={{ capitalize: true, trim: true }}
         isEqual={COMPARISONS.textInput}
         component={FieldTextarea}
         style={{

--- a/src/pages/Howto/Content/Common/HowtoFieldStep.tsx
+++ b/src/pages/Howto/Content/Common/HowtoFieldStep.tsx
@@ -174,7 +174,7 @@ class HowtoFieldStep extends PureComponent<IProps, IState> {
               name={`${step}.title`}
               data-cy="step-title"
               data-testid="step-title"
-              modifiers={{ capitalize: true }}
+              modifiers={{ capitalize: true, trim: true }}
               component={FieldInput}
               placeholder={title.placeholder}
               maxLength={HOWTO_TITLE_MAX_LENGTH}
@@ -202,7 +202,7 @@ class HowtoFieldStep extends PureComponent<IProps, IState> {
               maxLength={HOWTO_STEP_DESCRIPTION_MAX_LENGTH}
               data-cy="step-description"
               data-testid="step-description"
-              modifiers={{ capitalize: true }}
+              modifiers={{ capitalize: true, trim: true }}
               component={FieldTextarea}
               style={{ resize: 'vertical', height: '300px' }}
               validate={(value, allValues) =>

--- a/src/pages/Howto/Content/Common/HowtoFieldTitle.tsx
+++ b/src/pages/Howto/Content/Common/HowtoFieldTitle.tsx
@@ -48,7 +48,7 @@ export const HowtoFieldTitle = (props: IProps) => {
         validateFields={[]}
         validate={(value, allValues) => titleValidation(value, allValues)}
         isEqual={COMPARISONS.textInput}
-        modifiers={{ capitalize: true }}
+        modifiers={{ capitalize: true, trim: true }}
         component={FieldInput}
         minLength={HOWTO_TITLE_MIN_LENGTH}
         maxLength={HOWTO_TITLE_MAX_LENGTH}


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_

Trim trailing whitespace from text fields in How-Tos

## Git Issues

Closes #2635 
## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
