### PR TITLE
bug: added wordBreak property to how-to step description

### DIFF
--- a/src/pages/Howto/Content/Howto/Step/Step.tsx
+++ b/src/pages/Howto/Content/Howto/Step/Step.tsx
@@ -65,6 +65,7 @@ export default class Step extends PureComponent<IProps> {
                       color={'grey'}
                       variant="paragraph"
                       sx={{
+                        wordBreak: 'break-word',
                         whiteSpace: 'pre-line',
                       }}
                     >


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Added wordBreak property in the How-to steps' descriptions.

## Git Issues

Closes [#2763](https://github.com/ONEARMY/community-platform/issues/2763)

## Screenshots/Videos

![Screen Shot 2023-09-14 at 11 53 01](https://github.com/ONEARMY/community-platform/assets/62727899/92308662-3040-4f8c-a833-915fab98e02a)

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
