### PR TITLE
fix: fix errors running functions locally

### DIFF
--- a/functions/src/alerting/errorAlerting.ts
+++ b/functions/src/alerting/errorAlerting.ts
@@ -3,10 +3,16 @@ import { CONFIG } from '../config/config'
 import { EventContext } from 'firebase-functions/v1'
 
 const DISCORD_ALERT_CHANNEL_WEBHOOK_URL =
-  CONFIG.integrations.discord_alert_channel_webhook
+  CONFIG?.integrations?.discord_alert_channel_webhook
 
 const sendErrorAlert = async (functionName: string, error: Error) => {
   console.error(`Error in ${functionName}`, error)
+  if (!DISCORD_ALERT_CHANNEL_WEBHOOK_URL) {
+    console.error(
+      `No DISCORD_ALERT_CHANNEL_WEBHOOK_URL set, skipping sending alert`,
+    )
+    return
+  }
   await axios
     .post(DISCORD_ALERT_CHANNEL_WEBHOOK_URL, {
       content: `Caught error in ${functionName}: ${JSON.stringify(error)}`,
@@ -16,10 +22,11 @@ const sendErrorAlert = async (functionName: string, error: Error) => {
 
 export const withErrorAlerting = async (
   context: EventContext,
-  fn: () => any,
+  fn: (...params: any) => any,
+  params?: any[],
 ) => {
   try {
-    fn()
+    fn(...params)
   } catch (error) {
     sendErrorAlert(context.eventId, error)
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -28,4 +28,7 @@ if (process.env.FUNCTIONS_EMULATOR === 'true') {
   exports.emulator = require('./emulator')
 }
 
-exports.logToCloudLogging = require('./logging/logging')
+// Only log to cloud if not running locally
+if (process.env.FUNCTIONS_EMULATOR !== 'true') {
+  exports.logToCloudLogging = require('./logging/logging')
+}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

working on the new email stuff, i realized that functions are not running in the local emulator environment. they fail to compile with this error:
```
[emulators] ⬢  functions: Failed to load function definition from source: FirebaseError: Failed to load function definition from source: Failed to generate manifest from function source: Error: Cannot find module '@google-cloud/logging'
[emulators] Require stack:
[emulators] - /app/functions/dist/index.js
[emulators] - /app/functions/dist/node_modules/firebase-functions/lib/runtime/loader.js
[emulators] - /app/functions/dist/node_modules/firebase-functions/lib/bin/firebase-functions.js
[emulators] 
```

there seems to be an issue with the google cloud logging locally that we don't encounter in prod. by disabling local logging the issue goes away and the functions build successfully. afaik there isn't a use case for local cloud logging, anyway.

the discord alerts also fail in environments without the config field set. again, no real use for this in non-prod environments, so i added a check that the hook is defined before trying to send alert. 

finally, i updated the `withErrorAlerting` function to accept params, which i will use in the moderation emails work. 

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
