### PR TITLE
test: adds e2e testing of howto category

### DIFF
--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -11,9 +11,13 @@ describe('[How To]', () => {
   beforeEach(() => {
     cy.visit('/how-to')
   })
+  type Category = 'brainstorm' | 'exhibition' | 'product'
   type Duration = '<1 week' | '1-2 weeks' | '3-4 weeks'
   type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Very Hard'
 
+  const selectCategory = (category: Category) => {
+    cy.selectTag(category, '[data-cy=category-select]')
+  }
   const selectTimeDuration = (duration: Duration) => {
     cy.selectTag(duration, '[data-cy=time-select]')
   }
@@ -101,6 +105,7 @@ describe('[How To]', () => {
     const expected = {
       _createdBy: 'howto_creator',
       _deleted: false,
+      category: 'product',
       description: 'After creating, the how-to will be deleted',
       difficulty_level: 'Medium',
       time: '1-2 weeks',
@@ -173,6 +178,7 @@ describe('[How To]', () => {
 
     it('[By Authenticated]', () => {
       const {
+        category,
         description,
         difficulty_level,
         fileLink,
@@ -238,6 +244,7 @@ describe('[How To]', () => {
       cy.step('Fill up the intro')
       cy.get('[data-cy=intro-title').clear().type(title).blur({ force: true })
       cy.selectTag('howto_testing')
+      selectCategory(category as Category)
       selectTimeDuration(time as Duration)
       selectDifficultLevel(difficulty_level as Difficulty)
 
@@ -339,6 +346,7 @@ describe('[How To]', () => {
     const expected = {
       _createdBy: 'howto_editor',
       _deleted: false,
+      category: 'exhibition',
       description: 'After editing, all changes are reverted',
       difficulty_level: 'Hard',
       files: [],
@@ -468,6 +476,7 @@ describe('[How To]', () => {
       cy.step('Update the intro')
       cy.get('[data-cy=intro-title]').clear().type(expected.title)
       cy.selectTag('howto_testing')
+      selectCategory(expected.category as Category)
       selectTimeDuration(expected.time as Duration)
       selectDifficultLevel(expected.difficulty_level as Difficulty)
       cy.get('[data-cy=intro-description]').clear().type(expected.description)

--- a/packages/cypress/src/support/CustomAssertations.ts
+++ b/packages/cypress/src/support/CustomAssertations.ts
@@ -37,6 +37,7 @@ const eqHowto = (chaiObj) => {
     const {
       _createdBy,
       _deleted,
+      category,
       description,
       difficulty_level,
       slug,
@@ -56,6 +57,7 @@ const eqHowto = (chaiObj) => {
       tags,
       previousSlugs,
     })
+    expect(subject.category.label, 'Category').to.eq(category)
 
     // We want to validate that uploaded filename matches that originally specified
     // by the user. The filename will include a timestamp to avoid collisions with


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In the tests that create and edit howtos, adds a step to select the category in addition to the other fields and then asserts on the final category.

## Git Issues

Closes #2743 

## Screenshots/Videos

Run locally, tests are succeeding:
![With category](https://github.com/ONEARMY/community-platform/assets/467965/f5899d66-d23b-4a0d-816d-9c313725c583)

But if `selectCategory` is commented out, they fail:
![without category](https://github.com/ONEARMY/community-platform/assets/467965/9dd83678-e389-4fe2-9662-6cca6caaad97)

The error in the first test is a little odd, as category is not set (just mentioning in case a different sort of assertion would be better):
![Assertion error](https://github.com/ONEARMY/community-platform/assets/467965/a6ddb2eb-e3d6-40b3-ae94-f942ac0eaed6)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
