### PR TITLE
feat(platform): add loader to research page

### DIFF
--- a/src/pages/Research/Content/ResearchList.tsx
+++ b/src/pages/Research/Content/ResearchList.tsx
@@ -8,13 +8,13 @@ import ResearchListItem from './ResearchListItem'
 import { SortFilterHeader } from 'src/pages/common/SortFilterHeader/SortFilterHeader'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { RESEARCH_EDITOR_ROLES } from '../constants'
-import * as React from "react";
+import * as React from 'react'
 
 const ResearchList = observer(() => {
   const store = useResearchStore()
   const theme = useTheme()
 
-  const { filteredResearches , isFetching } = store
+  const { filteredResearches, isFetching } = store
   return (
     <>
       <Flex my={[18, 26]}>
@@ -52,20 +52,22 @@ const ResearchList = observer(() => {
           </Box>
         </Flex>
       </Flex>
-        {isFetching && <Loader />}
-        {(!isFetching && filteredResearches?.length !== 0) && filteredResearches.map((item) => {
-            const votedUsefulCount = (item.votedUsefulBy || []).length
-            return (
-                <ResearchListItem
-                    key={item._id}
-                    item={{
-                        ...item,
-                        votedUsefulCount,
-                    }}
-                />
-            )
+      {isFetching && <Loader />}
+      {!isFetching &&
+        filteredResearches?.length !== 0 &&
+        filteredResearches.map((item) => {
+          const votedUsefulCount = (item.votedUsefulBy || []).length
+          return (
+            <ResearchListItem
+              key={item._id}
+              item={{
+                ...item,
+                votedUsefulCount,
+              }}
+            />
+          )
         })}
-        {(!isFetching && filteredResearches?.length === 0) && 'No research to show'}
+      {!isFetching && filteredResearches?.length === 0 && 'No research to show'}
       <AuthWrapper roleRequired={RESEARCH_EDITOR_ROLES}>
         <Box mb={[3, 3, 0]}>
           <Link to={store.activeUser ? '/research/create' : 'sign-up'}>

--- a/src/pages/Research/Content/ResearchList.tsx
+++ b/src/pages/Research/Content/ResearchList.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react'
 import { observer } from 'mobx-react'
-import { Button } from 'oa-components'
+import { Button, Loader } from 'oa-components'
 import { Link } from 'react-router-dom'
 import { useResearchStore } from 'src/stores/Research/research.store'
 import { Box, Flex, Heading } from 'theme-ui'
@@ -8,12 +8,13 @@ import ResearchListItem from './ResearchListItem'
 import { SortFilterHeader } from 'src/pages/common/SortFilterHeader/SortFilterHeader'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { RESEARCH_EDITOR_ROLES } from '../constants'
+import * as React from "react";
 
 const ResearchList = observer(() => {
   const store = useResearchStore()
   const theme = useTheme()
 
-  const { filteredResearches } = store
+  const { filteredResearches , isFetching } = store
   return (
     <>
       <Flex my={[18, 26]}>
@@ -51,20 +52,20 @@ const ResearchList = observer(() => {
           </Box>
         </Flex>
       </Flex>
-      {filteredResearches?.length !== 0
-        ? filteredResearches.map((item) => {
+        {isFetching && <Loader />}
+        {(!isFetching && filteredResearches?.length !== 0) && filteredResearches.map((item) => {
             const votedUsefulCount = (item.votedUsefulBy || []).length
             return (
-              <ResearchListItem
-                key={item._id}
-                item={{
-                  ...item,
-                  votedUsefulCount,
-                }}
-              />
+                <ResearchListItem
+                    key={item._id}
+                    item={{
+                        ...item,
+                        votedUsefulCount,
+                    }}
+                />
             )
-          })
-        : 'No research to show'}
+        })}
+        {(!isFetching && filteredResearches?.length === 0) && 'No research to show'}
       <AuthWrapper roleRequired={RESEARCH_EDITOR_ROLES}>
         <Box mb={[3, 3, 0]}>
           <Link to={store.activeUser ? '/research/create' : 'sign-up'}>

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -70,6 +70,8 @@ export class ResearchStore extends ModuleStore {
   public updateUploadStatus: IUpdateUploadStatus =
     getInitialUpdateUploadStatus()
 
+  isFetching = true
+
   constructor(rootStore: RootStore) {
     super(rootStore, COLLECTION_NAME)
     makeObservable(this)
@@ -98,6 +100,9 @@ export class ResearchStore extends ModuleStore {
           this.activeSorter,
           activeItems,
         )
+        if(docs.length) {
+          this.isFetching = false;
+        }
       })
     })
   }

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -100,8 +100,8 @@ export class ResearchStore extends ModuleStore {
           this.activeSorter,
           activeItems,
         )
-        if(docs.length) {
-          this.isFetching = false;
+        if (docs.length) {
+          this.isFetching = false
         }
       })
     })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

I added loader in research page for initial fetching. 
My solution also can be ported to other stores which have `this.allDocs$.subscribe((docs: IResearch.ItemDB[])` method for fetching data.

## Git Issues

Closes #2808

## Screenshots/Videos

![image](https://github.com/ONEARMY/community-platform/assets/15144546/b17e0fff-7878-4917-81a1-788b4197cccb)


