### PR TITLE
fix(emails): send submission emails on re-submitted resources

### DIFF
--- a/functions/src/emailNotifications/__snapshots__/createModerationEmails.spec.ts.snap
+++ b/functions/src/emailNotifications/__snapshots__/createModerationEmails.spec.ts.snap
@@ -1,5 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Create howto moderation emails Creates an email for a howto awaiting moderation 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
+    <style>
+      #body {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 14px;
+        color: #000000;
+      }
+      #body a {
+        color: inherit;
+      }
+      .border {
+        border: 3px solid black;
+        border-radius: 10px;
+        padding: 4% 0;
+        margin: 4% 0;
+        width: 550px;
+      }
+      table {
+        width: 100%;
+        border: 0;
+      }
+      .settings-table-container,
+      .project-image-table-container {
+        margin-bottom: 8%;
+      }
+
+      .greeting-container,
+      .main-container {
+        margin-bottom: 8%;
+      }
+      .greeting-container,
+      .main-container,
+      .closing-containter {
+        margin-left: 8%;
+        margin-right: 8%;
+      }
+      @media only screen and (max-width: 550px) {
+        .table-container {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body id="body">
+    <table class="email-table-container">
+      <tr>
+        <td align="center">
+          <div class="border">
+            <table class="project-image-table-container">
+              <tr>
+                <td align="center">
+                  <img
+                    width="144"
+                    alt=""
+                    src="http://cdn.mcauto-images-production.sendgrid.net/cb5a685b085b7e7c/f48e2455-6dbb-4102-bde9-2ee07d3008c4/859x860.png"
+                  />
+                </td>
+              </tr>
+            </table>
+
+            <div align="left" class="greeting-container">
+              <p>Hey User 1</p>
+              <p>Huzzah! Your How-To Mock Howto has been submitted.</p>
+            </div>
+            <div align="left" class="main-container">
+              <p>
+                Our team is currently reviewing it and will get back to you
+                within a few business days.
+              </p>
+              <p>
+                Thank you for taking the time, the community will benefit from
+                this knowledge and more plastic will be recycled thanks to YOU.
+              </p>
+            </div>
+            <div align="left" class="closing-containter">
+              <p>Cheers,</p>
+              <p>The Precious Plastic Team</p>
+            </div>
+          </div>
+          <table class="settings-table-container">
+            <tr>
+              <td align="center">
+                <div class="notifications">
+                  Manage your notifications
+                  <a href="https://community.preciousplastic.com/settings">
+                    here</a
+                  >
+                </div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"
+`;
+
 exports[`Create howto moderation emails Creates an email for an accepted howto 1`] = `
 "<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
@@ -79,7 +182,106 @@ exports[`Create howto moderation emails Creates an email for an accepted howto 1
             </div>
             <div align="left" class="closing-containter">
               <p>Thanks for sharing your knowledge!</p>
-              <p>Charlie your Precious Plastic Community Manager</p>
+              <p>The Precious Plastic Team</p>
+            </div>
+          </div>
+          <table class="settings-table-container">
+            <tr>
+              <td align="center">
+                <div class="notifications">
+                  Manage your notifications
+                  <a href="https://community.preciousplastic.com/settings">
+                    here</a
+                  >
+                </div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+"
+`;
+
+exports[`Create map pin moderation emails Creates an email for a map pin awaiting moderation 1`] = `
+"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
+    <style>
+      #body {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 14px;
+        color: #000000;
+      }
+      #body a {
+        color: inherit;
+      }
+      .border {
+        border: 3px solid black;
+        border-radius: 10px;
+        padding: 4% 0;
+        margin: 4% 0;
+        width: 550px;
+      }
+      table {
+        width: 100%;
+        border: 0;
+      }
+      .settings-table-container,
+      .project-image-table-container {
+        margin-bottom: 8%;
+      }
+
+      .greeting-container,
+      .main-container {
+        margin-bottom: 8%;
+      }
+      .greeting-container,
+      .main-container,
+      .closing-containter {
+        margin-left: 8%;
+        margin-right: 8%;
+      }
+      @media only screen and (max-width: 550px) {
+        .table-container {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body id="body">
+    <table class="email-table-container">
+      <tr>
+        <td align="center">
+          <div class="border">
+            <table class="project-image-table-container">
+              <tr>
+                <td align="center">
+                  <img
+                    width="144"
+                    alt=""
+                    src="http://cdn.mcauto-images-production.sendgrid.net/cb5a685b085b7e7c/f48e2455-6dbb-4102-bde9-2ee07d3008c4/859x860.png"
+                  />
+                </td>
+              </tr>
+            </table>
+
+            <div align="left" class="greeting-container">
+              <p>Hey User 1</p>
+              <p>Your map pin has been submitted.</p>
+            </div>
+            <div align="left" class="main-container">
+              <p>
+                Our team is currently reviewing it and will get back to you
+                within a few business days.
+              </p>
+            </div>
+            <div align="left" class="closing-containter">
+              <p>Cheers,</p>
+              <p>The Precious Plastic Team</p>
             </div>
           </div>
           <table class="settings-table-container">
@@ -183,7 +385,7 @@ exports[`Create map pin moderation emails Creates an email for an accepted map p
             </div>
             <div align="left" class="closing-containter">
               <p>Thanks,</p>
-              <p>Charlie your Precious Plastic Community Manager</p>
+              <p>The Precious Plastic Team</p>
             </div>
           </div>
           <table class="settings-table-container">

--- a/functions/src/emailNotifications/__snapshots__/createSubmissionEmails.spec.ts.snap
+++ b/functions/src/emailNotifications/__snapshots__/createSubmissionEmails.spec.ts.snap
@@ -80,7 +80,7 @@ exports[`Create howto submission emails Creates an email for a submitted howto 1
             </div>
             <div align="left" class="closing-containter">
               <p>Cheers,</p>
-              <p>Charlie your Precious Plastic Community Manager</p>
+              <p>The Precious Plastic Team</p>
             </div>
           </div>
           <table class="settings-table-container">
@@ -179,7 +179,7 @@ exports[`Create map pin submission emails Creates an email for a submitted map p
             </div>
             <div align="left" class="closing-containter">
               <p>Cheers,</p>
-              <p>Charlie your Precious Plastic Community Manager</p>
+              <p>The Precious Plastic Team</p>
             </div>
           </div>
           <table class="settings-table-container">

--- a/functions/src/emailNotifications/constants.ts
+++ b/functions/src/emailNotifications/constants.ts
@@ -6,5 +6,5 @@ export const PP_PROJECT_IMAGE = `http://cdn.mcauto-images-production.sendgrid.ne
 export const PK_PROJECT_NAME = 'Project Kamp'
 export const PP_PROJECT_NAME = 'Precious Plastic'
 
-export const PP_SIGNOFF = 'Charlie your Precious Plastic Community Manager'
-export const PK_SIGNOFF = 'Project Kamp'
+export const PP_SIGNOFF = 'The Precious Plastic Team'
+export const PK_SIGNOFF = 'The Project Kamp Team'

--- a/functions/src/emailNotifications/createModerationEmails.spec.ts
+++ b/functions/src/emailNotifications/createModerationEmails.spec.ts
@@ -121,7 +121,7 @@ describe('Create howto moderation emails', () => {
 
     await handleModerationUpdate(change, createHowtoModerationEmail)
 
-    // Only one approved howto email should have been created
+    // Only one submitted howto email should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
     expect(countSnapshot.data().count).toEqual(1)
 
@@ -231,7 +231,7 @@ describe('Create map pin moderation emails', () => {
 
     await handleModerationUpdate(change, createMapPinModerationEmail)
 
-    // Only one approved howto email should have been created
+    // Only one approved map pin email should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
     expect(countSnapshot.data().count).toEqual(1)
 
@@ -273,7 +273,7 @@ describe('Create map pin moderation emails', () => {
 
     await handleModerationUpdate(change, createMapPinModerationEmail)
 
-    // Only one approved howto email should have been created
+    // Only one submitted map pin email should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
     expect(countSnapshot.data().count).toEqual(1)
 

--- a/functions/src/emailNotifications/createModerationEmails.spec.ts
+++ b/functions/src/emailNotifications/createModerationEmails.spec.ts
@@ -1,12 +1,18 @@
 import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
 import { DB_ENDPOINTS, IUserDB } from '../models'
-import { HOW_TO_APPROVAL_SUBJECT, MAP_PIN_APPROVAL_SUBJECT } from './templates'
+import {
+  HOW_TO_APPROVAL_SUBJECT,
+  HOW_TO_SUBMISSION_SUBJECT,
+  MAP_PIN_APPROVAL_SUBJECT,
+  MAP_PIN_SUBMISSION_SUBJECT,
+} from './templates'
 import { setMockHowto } from '../emulator/seed/content-generate'
 import {
   createHowtoModerationEmail,
   createMapPinModerationEmail,
   handleModerationUpdate,
 } from './createModerationEmails'
+import { PP_SIGNOFF } from './constants'
 
 jest.mock('../Firebase/auth', () => ({
   firebaseAuth: {
@@ -34,7 +40,7 @@ const userFactory = (_id: string, user: Partial<IUserDB> = {}): IUserDB =>
 describe('Create howto moderation emails', () => {
   const db = FirebaseEmulatedTest.admin.firestore()
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()
     await FirebaseEmulatedTest.seedFirestoreDB('emails')
 
@@ -95,13 +101,52 @@ describe('Create howto moderation emails', () => {
         'https://community.preciousplastic.com/how-to/00_user_1_howto',
       )
       // Check that the email contains the correct PP signoff
-      expect(html).toContain('Charlie your Precious Plastic Community Manager')
+      expect(html).toContain(PP_SIGNOFF)
+      expect(to).toBe('test@test.com')
+    })
+  })
+
+  it('Creates an email for a howto awaiting moderation', async () => {
+    const howtoRejected = await setMockHowto({ uid: 'user_1' }, 'rejected')
+    const howtoAwaitingModeration = {
+      ...howtoRejected,
+      moderation: 'awaiting-moderation',
+    }
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      howtoRejected,
+      howtoAwaitingModeration,
+      'howtos',
+      howtoAwaitingModeration._id,
+    )
+
+    await handleModerationUpdate(change, createHowtoModerationEmail)
+
+    // Only one approved howto email should have been created
+    const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
+    expect(countSnapshot.data().count).toEqual(1)
+
+    const querySnapshot = await db.collection(DB_ENDPOINTS.emails).get()
+    querySnapshot.forEach((doc) => {
+      const {
+        message: { html, subject },
+        to,
+      } = doc.data()
+      expect(html).toMatchSnapshot()
+      expect(subject).toBe(HOW_TO_SUBMISSION_SUBJECT)
+      // Check that the email contains the correct user name
+      expect(html).toContain('Hey User 1')
+      // Check that the email contains the correct howto title
+      expect(html).toContain(
+        `Huzzah! Your How-To Mock Howto has been submitted.`,
+      )
+      // Check that the email contains the correct PP signoff
+      expect(html).toContain(PP_SIGNOFF)
       expect(to).toBe('test@test.com')
     })
   })
 
   // Remove this test once released to all users.
-  it('Does not creates email for people who are not beta testers', async () => {
+  it('Does not create an email for people who are not beta testers', async () => {
     const howtoApproved = await setMockHowto({ uid: 'user_2' })
     const howtoAwaitingModeration = {
       ...howtoApproved,
@@ -118,10 +163,10 @@ describe('Create howto moderation emails', () => {
 
     // No new emails should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
-    expect(countSnapshot.data().count).toEqual(1)
+    expect(countSnapshot.data().count).toEqual(0)
   })
 
-  it('Does not creates email for non-approved howtos', async () => {
+  it('Does not create an email for non-approved howtos', async () => {
     const howtoApproved = await setMockHowto({ uid: 'user_1' })
     const howtoDraft = {
       ...howtoApproved,
@@ -138,14 +183,14 @@ describe('Create howto moderation emails', () => {
 
     // No new emails should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
-    expect(countSnapshot.data().count).toEqual(1)
+    expect(countSnapshot.data().count).toEqual(0)
   })
 })
 
 describe('Create map pin moderation emails', () => {
   const db = FirebaseEmulatedTest.admin.firestore()
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()
     await FirebaseEmulatedTest.seedFirestoreDB('emails')
 
@@ -205,13 +250,53 @@ describe('Create map pin moderation emails', () => {
         `https://community.preciousplastic.com/map#${mapPinApproved._id}`,
       )
       // Check that the email contains the correct PP signoff
-      expect(html).toContain('Charlie your Precious Plastic Community Manager')
+      expect(html).toContain(PP_SIGNOFF)
+      expect(to).toBe('test@test.com')
+    })
+  })
+
+  it('Creates an email for a map pin awaiting moderation', async () => {
+    const mapPinRejected = {
+      _id: 'user_1',
+      moderation: 'rejected',
+    }
+    const mapPinAwaitingModeration = {
+      _id: 'user_1',
+      moderation: 'awaiting-moderation',
+    }
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      mapPinRejected,
+      mapPinAwaitingModeration,
+      'mappins',
+      mapPinAwaitingModeration._id,
+    )
+
+    await handleModerationUpdate(change, createMapPinModerationEmail)
+
+    // Only one approved howto email should have been created
+    const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
+    expect(countSnapshot.data().count).toEqual(1)
+
+    const querySnapshot = await db.collection(DB_ENDPOINTS.emails).get()
+    querySnapshot.forEach((doc) => {
+      const {
+        message: { html, subject },
+        to,
+      } = doc.data()
+      expect(html).toMatchSnapshot()
+      expect(subject).toBe(MAP_PIN_SUBMISSION_SUBJECT)
+      // Check that the email contains the correct user name
+      expect(html).toContain('Hey User 1')
+      // Check that the email contains the correct title
+      expect(html).toContain('Your map pin has been submitted.')
+      // Check that the email contains the correct PP signoff
+      expect(html).toContain(PP_SIGNOFF)
       expect(to).toBe('test@test.com')
     })
   })
 
   // Remove this test once released to all users.
-  it('Does not creates email for people who are not beta testers', async () => {
+  it('Does not create an email for people who are not beta testers', async () => {
     const mapPinApproved = {
       _id: 'user_2',
       moderation: 'accepted',
@@ -231,7 +316,7 @@ describe('Create map pin moderation emails', () => {
 
     // No new emails should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
-    expect(countSnapshot.data().count).toEqual(1)
+    expect(countSnapshot.data().count).toEqual(0)
   })
 
   it('Does not creates email for non-approved map pins', async () => {
@@ -254,6 +339,6 @@ describe('Create map pin moderation emails', () => {
 
     // No new emails should have been created
     const countSnapshot = await db.collection(DB_ENDPOINTS.emails).count().get()
-    expect(countSnapshot.data().count).toEqual(1)
+    expect(countSnapshot.data().count).toEqual(0)
   })
 })

--- a/functions/src/emailNotifications/createModerationEmails.ts
+++ b/functions/src/emailNotifications/createModerationEmails.ts
@@ -3,12 +3,7 @@ import { QueryDocumentSnapshot } from 'firebase-admin/firestore'
 import { IHowtoDB, IMapPin, IModerable } from '../../../src/models'
 import { db } from '../Firebase/firestoreDB'
 import { DB_ENDPOINTS } from '../models'
-import {
-  getHowToApprovalEmail,
-  getHowToSubmissionEmail,
-  getMapPinApprovalEmail,
-  getMapPinSubmissionEmail,
-} from './templates'
+import * as templates from './templates'
 import { getUserAndEmail } from './utils'
 import { Change } from 'firebase-functions/v1'
 import { withErrorAlerting } from '../alerting/errorAlerting'
@@ -34,13 +29,18 @@ export async function createHowtoModerationEmail(howto: IHowtoDB) {
     if (howto.moderation === 'accepted') {
       await db.collection(DB_ENDPOINTS.emails).add({
         to: toUserEmail,
-        message: getHowToApprovalEmail(toUser, howto),
+        message: templates.getHowToApprovalEmail(toUser, howto),
       })
     } else if (howto.moderation === 'awaiting-moderation') {
       // If a how to is resumbitted, send another submission confirmation email.
       await db.collection(DB_ENDPOINTS.emails).add({
         to: toUserEmail,
-        message: getHowToSubmissionEmail(toUser, howto),
+        message: templates.getHowToSubmissionEmail(toUser, howto),
+      })
+    } else if (howto.moderation === 'rejected') {
+      await db.collection(DB_ENDPOINTS.emails).add({
+        to: toUserEmail,
+        message: templates.getHowToRejectedEmail(toUser, howto),
       })
     }
   }
@@ -54,13 +54,18 @@ export async function createMapPinModerationEmail(mapPin: IMapPin) {
     if (mapPin.moderation === 'accepted') {
       await db.collection(DB_ENDPOINTS.emails).add({
         to: toUserEmail,
-        message: getMapPinApprovalEmail(toUser, mapPin),
+        message: templates.getMapPinApprovalEmail(toUser, mapPin),
       })
     } else if (mapPin.moderation === 'awaiting-moderation') {
       // If a pin is resumbitted, send another submission confirmation email.
       await db.collection(DB_ENDPOINTS.emails).add({
         to: toUserEmail,
-        message: getMapPinSubmissionEmail(toUser, mapPin),
+        message: templates.getMapPinSubmissionEmail(toUser, mapPin),
+      })
+    } else if (mapPin.moderation === 'rejected') {
+      await db.collection(DB_ENDPOINTS.emails).add({
+        to: toUserEmail,
+        message: templates.getMapPinRejectedEmail(toUser),
       })
     }
   }

--- a/functions/src/emailNotifications/createSubmissionEmails.spec.ts
+++ b/functions/src/emailNotifications/createSubmissionEmails.spec.ts
@@ -9,6 +9,7 @@ import {
   createHowtoSubmissionEmail,
   createMapPinSubmissionEmail,
 } from './createSubmissionEmails'
+import { PP_SIGNOFF } from './constants'
 
 jest.mock('../Firebase/auth', () => ({
   firebaseAuth: {
@@ -82,7 +83,7 @@ describe('Create howto submission emails', () => {
         `Huzzah! Your How-To Mock Howto has been submitted.`,
       )
       // Check that the email contains the correct PP signoff
-      expect(html).toContain('Charlie your Precious Plastic Community Manager')
+      expect(html).toContain(PP_SIGNOFF)
       expect(to).toBe('test@test.com')
     })
   })
@@ -157,7 +158,7 @@ describe('Create map pin submission emails', () => {
       // Check that the email contains the correct title
       expect(html).toContain('Your map pin has been submitted.')
       // Check that the email contains the correct PP signoff
-      expect(html).toContain('Charlie your Precious Plastic Community Manager')
+      expect(html).toContain(PP_SIGNOFF)
       expect(to).toBe('test@test.com')
     })
   })

--- a/functions/src/emailNotifications/createSubmissionEmails.ts
+++ b/functions/src/emailNotifications/createSubmissionEmails.ts
@@ -1,8 +1,10 @@
+import * as functions from 'firebase-functions'
 import { IHowtoDB, IMapPin } from '../../../src/models'
 import { db } from '../Firebase/firestoreDB'
 import { DB_ENDPOINTS } from '../models'
 import { getHowToSubmissionEmail, getMapPinSubmissionEmail } from './templates'
 import { getUserAndEmail } from './utils'
+import { withErrorAlerting } from '../alerting/errorAlerting'
 
 export async function createHowtoSubmissionEmail(howto: IHowtoDB) {
   const { toUser, toUserEmail } = await getUserAndEmail(howto._createdBy)
@@ -31,3 +33,15 @@ export async function createMapPinSubmissionEmail(mapPin: IMapPin) {
     }
   }
 }
+
+export const handleHowToSubmission = functions.firestore
+  .document(`${DB_ENDPOINTS.howtos}/{id}`)
+  .onCreate((snapshot, context) =>
+    withErrorAlerting(context, createHowtoSubmissionEmail, [snapshot.data()]),
+  )
+
+export const handleMapPinSubmission = functions.firestore
+  .document(`${DB_ENDPOINTS.mappins}/{id}`)
+  .onCreate((snapshot, context) =>
+    withErrorAlerting(context, createMapPinSubmissionEmail, [snapshot.data()]),
+  )

--- a/functions/src/emailNotifications/development/entry-server.mjs
+++ b/functions/src/emailNotifications/development/entry-server.mjs
@@ -22,6 +22,9 @@ export function render(url) {
         url: 'https://community.preciousplastic.com',
         signOff: PP_SIGNOFF,
       },
+      howto: {
+        title: 'Mock Howto Title',
+      },
     })
     return html
   }

--- a/functions/src/emailNotifications/index.ts
+++ b/functions/src/emailNotifications/index.ts
@@ -4,15 +4,8 @@ import { db } from '../Firebase/firestoreDB'
 import { DB_ENDPOINTS, IUserDB } from '../models'
 import { EmailNotificationFrequency } from 'oa-shared'
 import { withErrorAlerting } from '../alerting/errorAlerting'
-import {
-  createHowtoModerationEmail,
-  createMapPinModerationEmail,
-  handleModerationUpdate,
-} from './createModerationEmails'
-import {
-  createHowtoSubmissionEmail,
-  createMapPinSubmissionEmail,
-} from './createSubmissionEmails'
+import * as moderationEmails from './createModerationEmails'
+import * as submissionEmails from './createSubmissionEmails'
 import * as supporterBadgeEmails from './supporterBadgeEmails'
 
 const EMAIL_FUNCTION_MEMORY_LIMIT = '512MB'
@@ -88,38 +81,17 @@ exports.sendOnce = functions
   })
 
 /** Watch changes to all howto docs and trigger emails on moderation changes */
-exports.sendHowToModerationEmail = functions.firestore
-  .document(`${DB_ENDPOINTS.howtos}/{id}`)
-  .onUpdate((change, context) =>
-    withErrorAlerting(context, handleModerationUpdate, [
-      change,
-      createHowtoModerationEmail,
-    ]),
-  )
+exports.sendHowToModerationEmail = moderationEmails.handleHowToModerationUpdate
 
 /** Watch changes to all map pin docs and trigger emails on moderation changes */
-exports.sendMapPinModerationEmail = functions.firestore
-  .document(`${DB_ENDPOINTS.mappins}/{id}`)
-  .onUpdate((change, context) =>
-    withErrorAlerting(context, handleModerationUpdate, [
-      change,
-      createMapPinModerationEmail,
-    ]),
-  )
+exports.sendMapPinModerationEmail =
+  moderationEmails.handleMapPinModerationUpdate
 
 /** Watch new howto docs and trigger emails on creation */
-exports.sendHowToSubmissionEmail = functions.firestore
-  .document(`${DB_ENDPOINTS.howtos}/{id}`)
-  .onCreate((snapshot, context) =>
-    withErrorAlerting(context, createHowtoSubmissionEmail, [snapshot.data()]),
-  )
+exports.sendHowToSubmissionEmail = submissionEmails.handleHowToSubmission
 
 /** Watch new map pin docs and trigger emails on creation */
-exports.sendMapPinSubmissionEmail = functions.firestore
-  .document(`${DB_ENDPOINTS.mappins}/{id}`)
-  .onCreate((snapshot, context) =>
-    withErrorAlerting(context, createMapPinSubmissionEmail, [snapshot.data()]),
-  )
+exports.sendMapPinSubmissionEmail = submissionEmails.handleMapPinSubmission
 
 /** Watch new user docs and trigger emails on supporter */
 exports.sendSupporterEmail = (

--- a/functions/src/emailNotifications/templates.ts
+++ b/functions/src/emailNotifications/templates.ts
@@ -298,3 +298,25 @@ export const getUserSupporterBadgeRemovedEmail = (user: IUserDB): Email => ({
     site,
   }),
 })
+
+export const HOW_TO_REJECTED_SUBJECT = 'Your how-to has been rejected'
+export const getHowToRejectedEmail = (
+  user: IUserDB,
+  howto: IHowtoDB,
+): Email => ({
+  subject: HOW_TO_REJECTED_SUBJECT,
+  html: getEmailHtml('how-to-rejected', {
+    user,
+    howto,
+    site,
+  }),
+})
+
+export const MAP_PIN_REJECTED_SUBJECT = 'Your map pin has been rejected'
+export const getMapPinRejectedEmail = (user: IUserDB): Email => ({
+  subject: MAP_PIN_REJECTED_SUBJECT,
+  html: getEmailHtml('map-pin-rejected', {
+    user,
+    site,
+  }),
+})

--- a/functions/src/emailNotifications/templates/how-to-rejected.html
+++ b/functions/src/emailNotifications/templates/how-to-rejected.html
@@ -1,0 +1,15 @@
+{{#> layout}}
+
+<p>Hey {{user.displayName}},</p>
+
+<p>
+  Thank you for submitting your How-To, {{howto.title}}. We appreciate your
+  contribution and the time and effort you put into creating it.
+</p>
+<p>
+  However, after reviewing your submission, we feel that it does not contribute
+  to small-scale plastic recycling.
+</p>
+<p>Feel free to edit and re-submit it :)</p>
+
+{{/layout}}

--- a/functions/src/emailNotifications/templates/index.ts
+++ b/functions/src/emailNotifications/templates/index.ts
@@ -5,6 +5,8 @@ import path from 'path'
 type SupportedEmailTemplates =
   | 'supporter-badge-removed'
   | 'supporter-badge-added'
+  | 'how-to-rejected'
+  | 'map-pin-rejected'
 
 export function getEmailHtml(emailType: SupportedEmailTemplates, ctx: {}) {
   const layoutTmpl = Handlebars.compile(

--- a/functions/src/emailNotifications/templates/map-pin-rejected.html
+++ b/functions/src/emailNotifications/templates/map-pin-rejected.html
@@ -1,0 +1,19 @@
+{{#> layout}}
+
+<p>Hey {{user.displayName}},</p>
+
+<p>Thank you for applying to be on the Precious Plastic Map.</p>
+<p>
+  Based on the content provided in your profile, we were not able to see that:
+  <ol>
+    <li>Your work is related to recycling plastic, and/or</li>
+    <li>You work on small-scale recycling</li>
+  </ol>
+  Check the <a href="https://drive.google.com/file/d/1fXTtBbzgCO0EL6G9__aixwqc-Euqgqnd/view">profile guidelines</a>, and make sure the 2 points above are clear. If we have misunderstood, complete your profile and re-submit your request :) 
+</p>
+
+<p>
+  We hope to see your edits soon.
+</p>
+
+{{/layout}}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

when creating submission emails, i did not consider the case where a user re-submits a previously rejected (or needs improvements, or draft) how to or map pin. these should also trigger submission emails.

i also snuck in two other changes:
1. move the handler functions out of the index file and into the domain-specific files to consolidate to the logic, as done in #2688 
2. update the PP signoff, as requested in feedback



## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
