### PR TITLE
fix: reset map pin moderation on update for non-members

### DIFF
--- a/src/stores/Maps/maps.store.test.ts
+++ b/src/stores/Maps/maps.store.test.ts
@@ -32,7 +32,7 @@ describe('maps.store', () => {
       )
     })
 
-    it('updates a member pin with requiring approval', async () => {
+    it('updates a member pin without requiring approval', async () => {
       // Act
       await store.setUserPin({
         profileType: 'member',
@@ -88,6 +88,84 @@ describe('maps.store', () => {
       expect(store.db.set).toHaveBeenCalledWith(
         expect.objectContaining({
           moderation: 'awaiting-moderation',
+        }),
+      )
+    })
+
+    it('sets a non member pin as awaiting moderation if pin type changes', async () => {
+      // Arrange
+      store.db.get = jest.fn().mockResolvedValue({
+        profileType: 'member',
+        moderation: 'accepted',
+      })
+
+      // Act
+      await store.setUserPin({
+        profileType: 'workspace',
+        location: {
+          latlng: {
+            lat: 0,
+            lng: 0,
+          },
+        },
+      })
+
+      // Assert
+      expect(store.db.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          moderation: 'awaiting-moderation',
+        }),
+      )
+    })
+
+    it('sets a non member pin as awaiting moderation if not previously accepted', async () => {
+      // Arrange
+      store.db.get = jest.fn().mockResolvedValue({
+        profileType: 'workspace',
+        moderation: 'rejected',
+      })
+
+      // Act
+      await store.setUserPin({
+        profileType: 'workspace',
+        location: {
+          latlng: {
+            lat: 0,
+            lng: 0,
+          },
+        },
+      })
+
+      // Assert
+      expect(store.db.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          moderation: 'awaiting-moderation',
+        }),
+      )
+    })
+
+    it('sets a non member pin as accepted if previously accepted', async () => {
+      // Arrange
+      store.db.get = jest.fn().mockResolvedValue({
+        type: 'workspace',
+        moderation: 'accepted',
+      })
+
+      // Act
+      await store.setUserPin({
+        profileType: 'workspace',
+        location: {
+          latlng: {
+            lat: 0,
+            lng: 0,
+          },
+        },
+      })
+
+      // Assert
+      expect(store.db.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          moderation: 'accepted',
         }),
       )
     })

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -166,15 +166,21 @@ export class MapsStore extends ModuleStore {
   public async setUserPin(user: IUserPP) {
     const type = user.profileType || 'member'
     const existingPin = await this.getPin(user.userName, 'server')
-    const existingModeration = existingPin?.moderation || 'awaiting-moderation'
+    const existingModeration = existingPin?.moderation
+    const existingPinType = existingPin?.type
 
     let moderation: IModerationStatus = existingModeration
 
+    // Member pins do not require moderation.
     if (type === 'member') {
       moderation = 'accepted'
     }
 
-    if (type !== 'member' && existingModeration === 'rejected') {
+    // Require re-moderation for non-member pins if pin type changes or if pin was not previously accepted.
+    if (
+      type !== 'member' &&
+      (existingModeration !== 'accepted' || existingPinType !== type)
+    ) {
       moderation = 'awaiting-moderation'
     }
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

in #2521 we decided to maintain moderation status for accepted map pins. however, we should still require moderation for all non-accepted map pins that get updated (not just rejected) as well as map pins that are updated to be a different type. 

## Git Issues

Closes #2817

## Screenshots/Videos



---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
