### PR TITLE
fix(deps): switch to using native lazy loading image

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "react-foco": "^1.3.1",
     "react-ga4": "^1.4.1",
     "react-hamburger-menu": "^1.1.1",
-    "react-lazy-load-image-component": "^1.5.1",
     "react-leaflet": "^2.5.0",
     "react-leaflet-markercluster": "^2.0.0-rc3",
     "react-router": "^5.2.0",

--- a/src/pages/Howto/Content/HowtoList/HowToCard.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowToCard.tsx
@@ -5,12 +5,11 @@ import {
   Username,
   Tooltip,
 } from 'oa-components'
-import { LazyLoadImage } from 'react-lazy-load-image-component'
 import { Link as RouterLink } from 'react-router-dom'
 import { isUserVerified } from 'src/common/isUserVerified'
 import type { IHowtoDB } from 'src/models/howto.models'
 import { capitalizeFirstLetter } from 'src/utils/helpers'
-import { Card, Flex, Heading, Text, Box } from 'theme-ui'
+import { Card, Flex, Heading, Text, Box, Image } from 'theme-ui'
 
 interface IProps {
   howto: IHowtoDB & { taglist: any }
@@ -46,13 +45,13 @@ export const HowToCard = (props: IProps) => {
               fontSize: 0,
             }}
           >
-            <LazyLoadImage
+            <Image
               style={{
                 width: '100%',
                 height: 'calc(((350px) / 3) * 2)',
                 objectFit: 'cover',
               }}
-              threshold={500}
+              loading="lazy"
               src={howto.cover_image?.downloadUrl}
               crossOrigin=""
             />

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -1,12 +1,11 @@
 import { format } from 'date-fns'
 import { Icon, ModerationStatus, Username, Tooltip } from 'oa-components'
-import { LazyLoadImage } from 'react-lazy-load-image-component'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import { Link } from 'react-router-dom'
 import { isUserVerified } from 'src/common/isUserVerified'
 import type { IResearch } from 'src/models/research.models'
 import { calculateTotalComments, getPublicUpdates } from 'src/utils/helpers'
-import { Card, Flex, Grid, Heading, Text, Box } from 'theme-ui'
+import { Card, Image, Flex, Grid, Heading, Text, Box } from 'theme-ui'
 import defaultResearchThumbnail from '../../../assets/images/default-research-thumbnail.jpg'
 
 interface IProps {
@@ -39,7 +38,7 @@ const ResearchListItem = ({ item }: IProps) => {
                 display: ['none', 'block'],
               }}
             >
-              <LazyLoadImage
+              <Image
                 style={{
                   width: `calc(100% + 32px)`,
                   aspectRatio: '1 / 1',
@@ -47,7 +46,7 @@ const ResearchListItem = ({ item }: IProps) => {
                   margin: '-15px',
                   verticalAlign: 'top',
                 }}
-                threshold={500}
+                loading="lazy"
                 src={getItemThumbnail(item)}
                 crossOrigin=""
               />

--- a/yarn.lock
+++ b/yarn.lock
@@ -27306,7 +27306,6 @@ __metadata:
     react-foco: ^1.3.1
     react-ga4: ^1.4.1
     react-hamburger-menu: ^1.1.1
-    react-lazy-load-image-component: ^1.5.1
     react-leaflet: ^2.5.0
     react-leaflet-markercluster: ^2.0.0-rc3
     react-router: ^5.2.0
@@ -30197,19 +30196,6 @@ __metadata:
     react: ^17.0.0 || ^16.3.0 || ^15.5.4
     react-dom: ^17.0.0 || ^16.3.0 || ^15.5.4
   checksum: 5718bcd9210ad5b06eb9469cf8b9b44be9498845a7702e621343618e8251f26357e6e1c865532cf170db6165df1cb30202787e057309d8848c220bc600ec0d1a
-  languageName: node
-  linkType: hard
-
-"react-lazy-load-image-component@npm:^1.5.1":
-  version: 1.5.6
-  resolution: "react-lazy-load-image-component@npm:1.5.6"
-  dependencies:
-    lodash.debounce: ^4.0.8
-    lodash.throttle: ^4.1.1
-  peerDependencies:
-    react: ^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x
-    react-dom: ^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x
-  checksum: 2db8dd56e5926c4831e58b05650e310fd8eabc24607716ad7ffda3e0f6b325434edb098ad27068ea8db7f42fec37bc17eaffbaf562a322e6f1ace16dcc3d5422
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

Switch to native lazy loading attribute. Removing react-lazy-load-image-component in favor of loading="lazy" makes sense for simplicity, readability, performance, and maintenance reasons. It has widespread support in modern browsers.