### PR TITLE
fix: prevent header layout shift on login

### DIFF
--- a/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
+++ b/src/pages/common/Header/Menu/MenuMobile/MenuMobilePanel.tsx
@@ -6,14 +6,19 @@ import MenuMobileLink from 'src/pages/common/Header/Menu/MenuMobile/MenuMobileLi
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { getSupportedModules } from 'src/modules'
 import { inject } from 'mobx-react'
-import type { ThemeStore } from 'src/stores/Theme/theme.store'
+import type { UserStore } from 'src/stores/User/user.store'
 
-@inject('themeStore')
+interface IInjectedProps {
+  userStore: UserStore
+}
+@inject('userStore')
 export class MenuMobilePanel extends Component {
-  injected() {
-    return this.props as {
-      themeStore: ThemeStore
-    }
+  constructor(props: any) {
+    super(props)
+  }
+
+  get injected() {
+    return this.props as IInjectedProps
   }
 
   render() {
@@ -54,7 +59,7 @@ export class MenuMobilePanel extends Component {
                 link
               )
             })}
-            <Profile isMobile={true} />
+            <Profile isMobile={true} user={this.injected?.userStore?.user} />
           </Flex>
         </Box>
       </>

--- a/src/pages/common/Header/Menu/Notifications/NotificationsDesktop.tsx
+++ b/src/pages/common/Header/Menu/Notifications/NotificationsDesktop.tsx
@@ -2,6 +2,7 @@ import { NotificationList } from 'oa-components'
 import { useState } from 'react'
 import Foco from 'react-foco'
 import { Flex } from 'theme-ui'
+import '../Profile/profile.css'
 
 import { NotificationsIcon } from './NotificationsIcon'
 
@@ -20,7 +21,7 @@ export const NotificationsDesktop = (props: Props) => {
 
   return (
     <Foco onClickOutside={() => setMobileNotificationVisibility(false)}>
-      <div data-cy="notifications-desktop">
+      <div data-cy="notifications-desktop" className="util__fade-in">
         <NotificationsIcon
           onCLick={() =>
             setMobileNotificationVisibility(!showMobileNotifications)

--- a/src/pages/common/Header/Menu/Profile/Profile.tsx
+++ b/src/pages/common/Header/Menu/Profile/Profile.tsx
@@ -8,9 +8,11 @@ import MenuMobileLink from 'src/pages/common/Header/Menu/MenuMobile/MenuMobileLi
 import ProfileButtons from './ProfileButtons'
 import { COMMUNITY_PAGES_PROFILE } from 'src/pages/PageList'
 import { MemberBadge } from 'oa-components'
+import './profile.css'
 
 interface IState {
   showProfileModal: boolean
+  isLoading: boolean
 }
 
 interface IProps {
@@ -28,6 +30,7 @@ export default class Profile extends Component<IProps, IState> {
     super(props)
     this.state = {
       showProfileModal: false,
+      isLoading: true,
     }
   }
   get injected() {
@@ -41,6 +44,19 @@ export default class Profile extends Component<IProps, IState> {
   render() {
     const user = this.injected.userStore.user
     const { showProfileModal } = this.state
+    // eslint-disable-next-line no-console
+    console.log(`Profile`, { user })
+
+    if (typeof user === 'undefined' && this.state.isLoading) {
+      return (
+        <Box
+          sx={{
+            width: '143px',
+          }}
+        />
+      )
+    }
+
     return (
       <>
         {user ? (
@@ -71,7 +87,12 @@ export default class Profile extends Component<IProps, IState> {
               />
             </Box>
           ) : (
-            <div data-cy="user-menu">
+            <div
+              data-cy="user-menu"
+              style={{
+                width: '93px',
+              }}
+            >
               <Flex
                 onClick={() => this.toggleProfileModal()}
                 ml={1}

--- a/src/pages/common/Header/Menu/Profile/ProfileButtonItem.tsx
+++ b/src/pages/common/Header/Menu/Profile/ProfileButtonItem.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react'
-import styled from '@emotion/styled'
 import { Button } from 'oa-components'
 import { observer, inject } from 'mobx-react'
 import type { MobileMenuStore } from 'src/stores/MobileMenu/mobilemenu.store'
 import { Link } from 'react-router-dom'
 
-const ButtonSign = styled(Button as any)`
-  display: block;
-  cursor: pointer;
-`
 interface IProps {
   link: string
   text: string
@@ -41,7 +36,7 @@ export class ProfileButtonItem extends React.Component<IProps> {
     return (
       <>
         <Link to={this.props.link} style={{ minWidth: 'auto' }}>
-          <ButtonSign
+          <Button
             onClick={() => this.props.isMobile && menu.toggleMobilePanel()}
             variant={this.props.variant}
             {...(this.props.isMobile ? { large: true } : {})}
@@ -54,7 +49,7 @@ export class ProfileButtonItem extends React.Component<IProps> {
             }}
           >
             {this.props.text}
-          </ButtonSign>
+          </Button>
         </Link>
       </>
     )

--- a/src/pages/common/Header/Menu/Profile/ProfileButtons.tsx
+++ b/src/pages/common/Header/Menu/Profile/ProfileButtons.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex } from 'theme-ui'
 import ProfileButtonItem from './ProfileButtonItem'
+import './profile.css'
 
 interface IProps {
   isMobile?: boolean
@@ -16,6 +17,7 @@ const ProfileButtons = (props: IProps) => {
   if (props.isMobile) {
     return (
       <Flex
+        className="util__fade-in"
         sx={{
           width: '100%',
           justifyContent: 'center',

--- a/src/pages/common/Header/Menu/Profile/profile.css
+++ b/src/pages/common/Header/Menu/Profile/profile.css
@@ -1,0 +1,12 @@
+.util__fade-in {
+  animation: fadeIn 480ms;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -27,7 +27,7 @@ export const COLLECTION_NAME = 'users'
 export class UserStore extends ModuleStore {
   private authUnsubscribe: firebase.default.Unsubscribe
   @observable
-  public user: IUserPPDB | undefined
+  public user: IUserPPDB | null | undefined
 
   @observable
   public authUser: firebase.default.User | null
@@ -55,7 +55,7 @@ export class UserStore extends ModuleStore {
   }
 
   @action
-  private updateActiveUser(user?: IUserPPDB) {
+  private updateActiveUser(user?: IUserPPDB | null) {
     this.user = user
   }
 
@@ -443,7 +443,8 @@ export class UserStore extends ModuleStore {
           this.sendEmailVerification()
         }
       } else {
-        this.updateActiveUser(undefined)
+        // Explicitly update user to null when logged out
+        this.updateActiveUser(null)
       }
     })
   }


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Prevents menu items jumping around as the User state is loaded. Instead starts with blank placeholder element, which then presents LogIn/Join buttons when logged in or our state is determined.

## Screenshots/Videos

Before:

https://github.com/ONEARMY/community-platform/assets/472589/c96e05e5-95d0-4de9-8201-3cf1469eb5e3

After: 

https://github.com/ONEARMY/community-platform/assets/472589/2b9ed243-26d5-4792-aa94-75ff1c36d65e

