### PR TITLE
chore: disable codecov/patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,6 @@ coverage:
       default:
         target: auto
         threshold: 1%
+    patch: off
 comment:
   require_changes: true


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

![Screenshot 2023-09-30 at 14 50 10](https://github.com/ONEARMY/community-platform/assets/472589/b0170168-c53d-49ff-a29b-8aad93587b52)

Disable patch status checks which often result in failure. There is probably a better way to configure this but will defer to future me or someone else to dig into it further.
https://docs.codecov.com/docs/commit-status#disabling-a-status