### PR TITLE
fix(maps): delete workspaceType if not a workspace

### DIFF
--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -72,7 +72,7 @@ describe('userStore', () => {
       // Assert
       expect(store.db.set).toHaveBeenCalledWith(
         expect.not.objectContaining({
-          subType: 'extrusion',
+          workspaceType: 'extrusion',
         }),
       )
     })

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -1,13 +1,17 @@
 jest.mock('../common/module.store')
 import { FactoryUser } from 'src/test/factories/User'
 import { UserStore } from './user.store'
+import type { IUserPP } from 'src/models/userPreciousPlastic.models'
 
 describe('userStore', () => {
+  let store
+
+  beforeEach(() => {
+    store = new UserStore({} as any)
+  })
+
   describe('getUserProfile', () => {
     it('returns a single user object when 2 exist', async () => {
-      // Arrange
-      const store = new UserStore({} as any)
-
       // Lookup1
       store.db.getWhere.mockReturnValueOnce([
         FactoryUser({
@@ -46,6 +50,31 @@ describe('userStore', () => {
         links: expect.any(Array),
         notifications: expect.any(Array),
       })
+    })
+  })
+
+  describe('updateUserProfile', () => {
+    it('update user profile with type of member, previously was workspace', async () => {
+      const userProfile = FactoryUser({
+        _id: 'my-user-profile',
+        _authID: 'my-user-profile',
+        profileType: 'workspace',
+        workspaceType: 'extrusion',
+      })
+      // Act
+      await store.updateUserProfile(
+        FactoryUser({
+          ...userProfile,
+          profileType: 'member',
+        }) as Partial<IUserPP>,
+      )
+
+      // Assert
+      expect(store.db.set).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          subType: 'extrusion',
+        }),
+      )
     })
   })
 })

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -228,6 +228,9 @@ export class UserStore extends ModuleStore {
       ? (values as any)
       : { ...toJS(this.user), ...toJS(values) }
 
+    if (updatedUserProfile.profileType !== 'workspace')
+      delete updatedUserProfile['workspaceType']
+
     // TODO: Remove this once source of duplicate profiles determined
     if (!updatedUserProfile.profileCreationTrigger) {
       updatedUserProfile.profileCreationTrigger = trigger


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

When changing user type, for example from Workspace to Member, the `workspaceType` field stayed and affected the map filtering system.
added validation for user type and removing the `workspaceType` field if it's not needed.

## Git Issues

Closes #2798

## Screenshots/Videos


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of a monthly dev call (first Monday of the month, open to all!).

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
