### PR TITLE
fix: remove bullet from map pin needs improvement email

### DIFF
--- a/functions/src/emailNotifications/development/entry-server.mjs
+++ b/functions/src/emailNotifications/development/entry-server.mjs
@@ -34,7 +34,7 @@ export function render(url) {
         comments: 'Mock Howto Moderation Comments',
         slug: 'mock-howto-title',
       },
-      mappin: {
+      mapPin: {
         comments: 'Mock Mappin Moderation Comments',
         _id: 'mock-mappin-id',
       },

--- a/functions/src/emailNotifications/templates.ts
+++ b/functions/src/emailNotifications/templates.ts
@@ -158,10 +158,10 @@ export const getHowToApprovalEmail = (
 export const MAP_PIN_APPROVAL_SUBJECT = 'Your map pin has been approved!'
 export const getMapPinApprovalEmail = (
   user: IUserDB,
-  mappin: IMapPin,
+  mapPin: IMapPin,
 ): Email => {
   return {
-    html: getEmailHtml('map-pin-approval', { user, mappin, site }),
+    html: getEmailHtml('map-pin-approval', { user, mapPin, site }),
     subject: MAP_PIN_APPROVAL_SUBJECT,
   }
 }
@@ -184,10 +184,10 @@ export const getHowToSubmissionEmail = (
 export const MAP_PIN_SUBMISSION_SUBJECT = 'Your map pin has been submitted'
 export const getMapPinSubmissionEmail = (
   user: IUserDB,
-  mappin: IMapPin,
+  mapPin: IMapPin,
 ): Email => {
   return {
-    html: getEmailHtml('map-pin-submission', { user, mappin, site }),
+    html: getEmailHtml('map-pin-submission', { user, mapPin, site }),
     subject: MAP_PIN_SUBMISSION_SUBJECT,
   }
 }

--- a/functions/src/emailNotifications/templates/map-pin-approval.html
+++ b/functions/src/emailNotifications/templates/map-pin-approval.html
@@ -5,7 +5,7 @@
 
 <p>
   It is visible on the community platform map
-  <a href="{{site.url}}/map#{{mappin._id}}">here</a>.
+  <a href="{{site.url}}/map#{{mapPin._id}}">here</a>.
 </p>
 
 {{/layout}}

--- a/functions/src/emailNotifications/templates/map-pin-needs-improvements.html
+++ b/functions/src/emailNotifications/templates/map-pin-needs-improvements.html
@@ -8,8 +8,7 @@
 
 {{#if mapPin.comments}}
 <p>Please review the following & re-submit your map pin:</p>
-<li>{{mapPin.comments}}</li>
-{{/if}}
+{{mapPin.comments}} {{/if}}
 
 <p>
   Check out the


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

feedback from @sigolenej that the bullet was not needed in the map pin feedback email, as at the moment the feedback is just submitted as one blob of text. convo [here](https://discord.com/channels/586676777334865928/1156363133905010799/1162239327795945492).

also noticed inconsistencies in the casing of "mappin" and "mapPin". we use both in the codebase, but "mapPin" is more correct IMO and we are using that pattern elsewhere in these functions.

## Git Issues

Closes #

## Screenshots/Videos

<img width="735" alt="Screen Shot 2023-10-14 at 7 31 08 PM" src="https://github.com/ONEARMY/community-platform/assets/37253846/97672cd0-6edf-4684-b873-7cde5cc4a5c4">


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
