### PR TITLE
fix: remove moderation from how to

### DIFF
--- a/src/models/common.models.tsx
+++ b/src/models/common.models.tsx
@@ -18,14 +18,9 @@ export type IModerationStatus =
   | 'rejected'
   | 'accepted'
 
-export interface IModerationFeedback {
-  feedbackTimestamp: ISODateString
-  feedbackComments: string
-  adminUsername: string
-}
 export interface IModeration {
   moderation: IModerationStatus
-  moderationFeedback?: IModerationFeedback[]
+  moderatorFeedback?: string
 }
 export interface IModerable extends IModeration {
   _createdBy?: string

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -23,6 +23,7 @@ export interface IHowto extends IHowtoFormInput {
   total_downloads?: number
   mentions: UserMention[]
   previousSlugs: string[]
+  moderatorFeedback?: string
 }
 
 /**

--- a/src/models/howto.models.tsx
+++ b/src/models/howto.models.tsx
@@ -23,7 +23,6 @@ export interface IHowto extends IHowtoFormInput {
   total_downloads?: number
   mentions: UserMention[]
   previousSlugs: string[]
-  moderatorFeedback?: string
 }
 
 /**

--- a/src/pages/Howto/Content/Howto/Howto.test.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.test.tsx
@@ -58,6 +58,40 @@ const factory = async (howtoStore?: Partial<HowtoStore>) =>
   )
 
 describe('Howto', () => {
+  describe('moderator feedback', () => {
+    it('displays feedback for items which are not accepted', async () => {
+      let wrapper
+      await act(async () => {
+        wrapper = await factory({
+          ...mockHowtoStore(),
+          activeHowto: FactoryHowto({
+            _createdBy: 'HowtoAuthor',
+            moderation: 'awaiting-moderation',
+            moderatorFeedback: 'Moderation comments',
+          } as any),
+        })
+      })
+
+      expect(wrapper.getByText('Moderation comments')).toBeInTheDocument()
+    })
+
+    it('hides feedback when how-to is accepted', async () => {
+      let wrapper
+      await act(async () => {
+        wrapper = await factory({
+          ...mockHowtoStore(),
+          activeHowto: FactoryHowto({
+            _createdBy: 'HowtoAuthor',
+            moderation: 'accepted',
+            moderatorFeedback: 'Moderation comments',
+          } as any),
+        })
+      })
+
+      expect(() => wrapper.getByText('Moderation comments')).toThrow()
+    })
+  })
+
   it('displays content statistics', async () => {
     let wrapper
     await act(async () => {

--- a/src/pages/Howto/Content/Howto/Howto.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.tsx
@@ -48,13 +48,6 @@ export class Howto extends React.Component<
   RouteComponentProps<IRouterCustomParams>,
   IState
 > {
-  private moderateHowto = async (accepted: boolean, feedback?: string) => {
-    const _id = this.store.activeHowto?._id
-    if (_id) {
-      await this.store.moderateHowto(_id, accepted, feedback)
-    }
-  }
-
   private onUsefulClick = async (
     howtoId: string,
     howToSlug: string,
@@ -149,7 +142,6 @@ export class Howto extends React.Component<
             commentsCount={this.store.commentsCount}
             votedUsefulCount={this.store.votedUsefulCount}
             hasUserVotedUseful={hasUserVotedUseful}
-            moderateHowto={this.moderateHowto}
             onUsefulClick={() =>
               this.onUsefulClick(howto._id, howto.slug, 'HowtoDescription')
             }

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -22,7 +22,6 @@ import {
   DownloadStaticFile,
   Username,
   DownloadFileFromLink,
-  Tooltip,
   ConfirmModal,
   ContentStatistics,
 } from 'oa-components'
@@ -230,7 +229,7 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
               </Fragment>
             )}
           </Flex>
-          {howto.moderationFeedback && howto.moderation === 'rejected' && (
+          {howto.moderatorFeedback && howto.moderation !== 'accepted' ? (
             <Flex
               mt={4}
               sx={{
@@ -250,27 +249,17 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
               <Heading variant="small" mb={2}>
                 Moderator Feedback
               </Heading>
-              {howto.moderationFeedback.map((feedback) => {
-                return (
-                  <Flex
-                    mb={2}
-                    pb={2}
-                    sx={{
-                      flexDirection: 'column',
-                    }}
-                    key={feedback.feedbackTimestamp}
-                  >
-                    <Text mb={1} sx={{ fontWeight: 'bold' }}>
-                      {format(feedback.feedbackTimestamp, 'DD-MM-YYYY HH:mm')}
-                    </Text>
-                    <Text key={feedback.feedbackTimestamp} sx={{ fontSize: 2 }}>
-                      {feedback.feedbackComments}
-                    </Text>
-                  </Flex>
-                )
-              })}
+              <Flex
+                mb={2}
+                pb={2}
+                sx={{
+                  flexDirection: 'column',
+                }}
+              >
+                <Text sx={{ fontSize: 2 }}>{howto.moderatorFeedback}</Text>
+              </Flex>
             </Flex>
-          )}
+          ) : null}
           <Box mt={3} mb={2}>
             <Flex sx={{ justifyContent: 'space-between', flexWrap: 'wrap' }}>
               <Flex sx={{ flexDirection: 'column' }}>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -198,36 +198,6 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
                   />
                 </Box>
               )}
-            {/* Check if how to should be moderated */}
-            {props.needsModeration && (
-              <Flex sx={{ justifyContent: 'space-between' }}>
-                <Button
-                  data-cy={'accept'}
-                  variant={'primary'}
-                  icon="check"
-                  mr={1}
-                  data-tip={'Accept'}
-                  onClick={() => props.moderateHowto(true)}
-                  showIconOnly={true}
-                />
-                <Button
-                  data-cy="reject-howto"
-                  variant={'outline'}
-                  icon="close"
-                  data-tip={'Request changes'}
-                  showIconOnly={true}
-                  onClick={() => {
-                    // Prompt used for testing purposes, will be removed once retool functionality in place
-                    const feedback =
-                      // eslint-disable-next-line no-alert
-                      prompt('Please provide detail of required changes') ||
-                      undefined
-                    props.moderateHowto(false, feedback)
-                  }}
-                />
-                <Tooltip />
-              </Flex>
-            )}
             {/* Check if logged in user is the creator of the how-to OR a super-admin */}
             {loggedInUser && isAllowedToEditContent(howto, loggedInUser) && (
               <Link to={'/how-to/' + howto.slug + '/edit'}>

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -56,7 +56,6 @@ interface IProps {
   votedUsefulCount?: number
   verified?: boolean
   hasUserVotedUseful: boolean
-  moderateHowto: (accepted: boolean, feedback?: string) => void
   onUsefulClick: () => void
 }
 

--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -10,6 +10,7 @@ import {
   Image,
   AspectImage,
   Divider,
+  Alert,
 } from 'theme-ui'
 import TimeNeeded from 'src/assets/icons/icon-time-needed.svg'
 import DifficultyLevel from 'src/assets/icons/icon-difficulty-level.svg'
@@ -229,35 +230,23 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             )}
           </Flex>
           {howto.moderatorFeedback && howto.moderation !== 'accepted' ? (
-            <Flex
-              mt={4}
+            <Alert
+              variant="info"
               sx={{
-                display: 'block',
-                fontSize: 1,
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                padding: 2,
-                borderRadius: 1,
-                borderBottomRightRadius: 1,
-                flexDirection: 'column',
-                border: '2px solid red',
-                paddingTop: 3,
+                my: 2,
               }}
             >
-              <Heading variant="small" mb={2}>
-                Moderator Feedback
-              </Heading>
-              <Flex
-                mb={2}
-                pb={2}
+              <Box
                 sx={{
-                  flexDirection: 'column',
+                  textAlign: 'left',
                 }}
               >
+                <Heading variant="small" mb={2}>
+                  Moderator Feedback
+                </Heading>
                 <Text sx={{ fontSize: 2 }}>{howto.moderatorFeedback}</Text>
-              </Flex>
-            </Flex>
+              </Box>
+            </Alert>
           ) : null}
           <Box mt={3} mb={2}>
             <Flex sx={{ justifyContent: 'space-between', flexWrap: 'wrap' }}>

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -11,10 +11,8 @@ import { logger } from 'src/logger'
 import type {
   IComment,
   UserMention,
-  IModerationUpdate,
   IVotedUsefulUpdate,
   IUser,
-  IModerationFeedback,
 } from 'src/models'
 import type {
   IHowToStepFormInput,
@@ -305,51 +303,6 @@ export class HowtoStore extends ModuleStore {
   @action
   public updateSelectedCategory(category: string) {
     this.selectedCategory = category
-  }
-
-  // Moderate Howto
-  @action
-  public async moderateHowto(
-    docId: string,
-    accepted: boolean,
-    feedback?: string,
-  ): Promise<void> {
-    if (!hasAdminRights(toJS(this.activeUser))) {
-      return
-    }
-    const dbRef = this.db
-      .collection<IModerationUpdate>(COLLECTION_NAME)
-      .doc(docId)
-
-    const howtoData = await toJS(dbRef.get('server'))
-    if (!howtoData) return
-
-    const moderationUpdate: IModerationUpdate = {
-      _id: docId,
-      moderation: accepted ? 'accepted' : 'rejected',
-    }
-
-    if (feedback) {
-      const newFeedback: IModerationFeedback[] = [
-        {
-          feedbackTimestamp: new Date().toISOString(),
-          feedbackComments: feedback,
-          adminUsername: this.activeUser?.userName || '',
-        },
-      ]
-
-      moderationUpdate.moderationFeedback = [
-        ...(howtoData.moderationFeedback || []),
-        ...newFeedback,
-      ]
-      moderationUpdate.moderation = 'improvements-needed'
-    }
-
-    await dbRef.update(moderationUpdate)
-
-    this.activeHowto = (await dbRef.get()) as IHowtoDB
-
-    return
   }
 
   public needsModeration(howto: IHowto) {


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

- chore: remove accept/deny buttons from how-to description
- fix: load how-to moderation comments from new property
- fix: remove unused moderation methods

Address https://github.com/ONEARMY/community-platform/issues/2876

Also restyles feedback to appear within standard Alert component using the info variant:

Before:

![Screenshot 2023-10-21 at 18 27 00](https://github.com/ONEARMY/community-platform/assets/472589/3875f86d-dd3e-4787-8fbe-eec33c1672b8)

After:

![Screenshot 2023-10-21 at 18 25 58](https://github.com/ONEARMY/community-platform/assets/472589/a4c6000d-4347-454f-afb3-4200c727d230)
