### PR TITLE
fix: revert to nodejs18 runtime

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -88,7 +88,7 @@
   "functions": {
     "predeploy": ["yarn workspace functions build"],
     "source": "functions/dist",
-    "runtime": "nodejs20"
+    "runtime": "nodejs18"
   },
   "emulators": {
     "ui": {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

1e6a58d5c changed the runtime for firebase to node 20, but this is causing errors when trying to deploy functions locally in order to test them: `Error: Cannot deploy function with runtime nodejs20`

This is an issue seeing as the emulator is currently blocked, making it impossible to test the functions.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
