### PR TITLE
chore: use consistent ThemeProvider

### DIFF
--- a/src/pages/Howto/Content/Howto/Howto.test.tsx
+++ b/src/pages/Howto/Content/Howto/Howto.test.tsx
@@ -1,5 +1,5 @@
 import { render, act } from '@testing-library/react'
-import { ThemeProvider } from '@theme-ui/core'
+import { ThemeProvider } from '@emotion/react'
 import { Provider } from 'mobx-react'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'

--- a/src/pages/Question/question.routes.test.tsx
+++ b/src/pages/Question/question.routes.test.tsx
@@ -3,7 +3,7 @@ jest.mock('../../stores/common/module.store')
 import '@testing-library/jest-dom'
 import QuestionRoutes from './question.routes'
 import { cleanup, render, waitFor, act } from '@testing-library/react'
-import { ThemeProvider } from '@theme-ui/core'
+import { ThemeProvider } from '@emotion/react'
 import { createMemoryHistory } from 'history'
 import { Provider } from 'mobx-react'
 import { Router } from 'react-router-dom'

--- a/src/pages/Research/Content/ResearchArticle.test.tsx
+++ b/src/pages/Research/Content/ResearchArticle.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from '@testing-library/react'
-import { ThemeProvider } from '@theme-ui/core'
+import { ThemeProvider } from '@emotion/react'
 import { Provider } from 'mobx-react'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'

--- a/src/pages/Research/Content/ResearchUpdate.test.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.test.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { ThemeProvider } from '@theme-ui/core'
+import { ThemeProvider } from '@emotion/react'
 import { render } from '@testing-library/react'
 import ResearchUpdate from './ResearchUpdate'
 import { faker } from '@faker-js/faker'

--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import ResearchRoutes from './research.routes'
 import { cleanup, render, waitFor, act } from '@testing-library/react'
-import { ThemeProvider } from '@theme-ui/core'
+import { ThemeProvider } from '@emotion/react'
 import { createMemoryHistory } from 'history'
 import { Provider } from 'mobx-react'
 import { Router } from 'react-router-dom'


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

When attempting to move the test suites across to vitest I encountered some odd errors due to a mixture of ThemeProviders being used. Consistently using `@emotion/react` resolved this issue. 