### PR TITLE
feat: add helper for loading images from CDN

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -154,5 +154,6 @@ export const SENTRY_CONFIG: ISentryConfig = {
   environment: siteVariant,
 }
 
+export const CDN_URL = _c('REACT_APP_CDN_URL', '')
 export const VERSION = _c('REACT_APP_PROJECT_VERSION', '')
 export const GA_TRACKING_ID = _c('REACT_APP_GA_TRACKING_ID')

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -23,6 +23,7 @@ export const _supportedConfigurationOptions = [
   'REACT_APP_SUPPORTED_MODULES',
   'REACT_APP_PLATFORM_THEME',
   'REACT_APP_PLATFORM_PROFILES',
+  'REACT_APP_CDN_URL',
 ] as const
 
 export type ConfigurationOption = typeof _supportedConfigurationOptions[number]

--- a/src/pages/Howto/Content/HowtoList/HowToCard.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowToCard.tsx
@@ -8,6 +8,7 @@ import {
 import { Link as RouterLink } from 'react-router-dom'
 import { isUserVerified } from 'src/common/isUserVerified'
 import type { IHowtoDB } from 'src/models/howto.models'
+import { cdnImageUrl } from 'src/utils/cdnImageUrl'
 import { capitalizeFirstLetter } from 'src/utils/helpers'
 import { Card, Flex, Heading, Text, Box, Image } from 'theme-ui'
 
@@ -52,7 +53,9 @@ export const HowToCard = (props: IProps) => {
                 objectFit: 'cover',
               }}
               loading="lazy"
-              src={howto.cover_image?.downloadUrl}
+              src={
+                cdnImageUrl(howto.cover_image?.downloadUrl || '') + '&width=500'
+              }
               crossOrigin=""
             />
           </Flex>

--- a/src/utils/cdnImageUrl.test.ts
+++ b/src/utils/cdnImageUrl.test.ts
@@ -1,0 +1,49 @@
+const STORAGE_BUCKET = 'some-bucket'
+
+describe('cdnImageUrl', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('should return the original URL if CDN_URL or FIREBASE_CONFIG.storageBucket is not set', () => {
+    // Mocking empty CDN_URL
+    jest.doMock('src/config/config', () => ({
+      FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
+      CDN_URL: '',
+    }))
+
+    const { cdnImageUrl } = require('src/utils/cdnImageUrl')
+    const originalUrl =
+      'https://firebasestorage.googleapis.com/v0/b/some-bucket/image.jpg'
+
+    expect(cdnImageUrl(originalUrl)).toBe(originalUrl)
+  })
+
+  it('should replace the Firebase storage URL with CDN_URL', () => {
+    jest.mock('src/config/config', () => ({
+      FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
+      CDN_URL: 'https://cdn-url.com',
+    }))
+
+    const { cdnImageUrl } = require('src/utils/cdnImageUrl')
+
+    expect(
+      cdnImageUrl(
+        `https://firebasestorage.googleapis.com/v0/b/${STORAGE_BUCKET}/image.jpg`,
+      ),
+    ).toBe(`https://cdn-url.com/image.jpg`)
+  })
+
+  it('should not modify a non-Firebase URL', () => {
+    jest.mock('src/config/config', () => ({
+      FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
+      CDN_URL: 'https://cdn-url.com',
+    }))
+
+    const { cdnImageUrl } = require('src/utils/cdnImageUrl')
+
+    expect(cdnImageUrl('https://some-other-url.com/image.jpg')).toBe(
+      'https://some-other-url.com/image.jpg',
+    )
+  })
+})

--- a/src/utils/cdnImageUrl.ts
+++ b/src/utils/cdnImageUrl.ts
@@ -1,0 +1,12 @@
+import { FIREBASE_CONFIG, CDN_URL } from 'src/config/config'
+
+export const cdnImageUrl = (url: string) => {
+  if (!CDN_URL || !FIREBASE_CONFIG.storageBucket) {
+    return url
+  }
+
+  return url.replace(
+    `https://firebasestorage.googleapis.com/v0/b/${FIREBASE_CONFIG.storageBucket}`,
+    CDN_URL,
+  )
+}


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Introduced support for a new environment variable `REACT_APP_CDN_URL`.

This can be used via the `cdnImageUrl` function. It is meant to take a URL pointing to an image in a Firebase Storage bucket and replace the Firebase Storage URL prefix with a CDN URL prefix. If either the CDN URL or the storage bucket name is not available, it simply returns the original URL.

This then supports integration with 3rd party tools such as KeyCDN and Imgix which provide image processing functionality. Previously we had looked at working with a Firebase Extension for this but it threw some odd errors under test so abandoned that implementation. 