### PR TITLE
fix: howto updates if document is missing `previousSlugs` property

### DIFF
--- a/src/stores/Howto/howto.store.test.ts
+++ b/src/stores/Howto/howto.store.test.ts
@@ -288,6 +288,23 @@ describe('howto.store', () => {
   })
 
   describe('deleteHowTo', () => {
+    it('handles legacy docs without previousSlugs', async () => {
+      const howtoDoc = FactoryHowto({})
+      howtoDoc.previousSlugs = undefined
+      const { store, howToItem, setFn, getFn } = await factory([howtoDoc])
+
+      // Act
+      await store.deleteHowTo(howToItem._id)
+
+      // Assert
+      const [deletedHowTo] = setFn.mock.calls[0]
+
+      expect(setFn).toHaveBeenCalledTimes(1)
+      expect(getFn).toHaveBeenCalledTimes(2)
+      expect(getFn).toHaveBeenCalledWith('server')
+      expect(deletedHowTo._deleted).toBeTruthy()
+    })
+
     it('updates _deleted property after confirming delete', async () => {
       const { store, howToItem, setFn, getFn } = await factory()
 

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -349,14 +349,15 @@ export class HowtoStore extends ModuleStore {
     )
 
     mentions.push(...commentMentions, ...stepMentions)
-
-    if (!howToItem.previousSlugs.includes(howToItem.slug)) {
-      howToItem.previousSlugs.push(howToItem.slug)
+    const previousSlugs = howToItem.previousSlugs ?? []
+    if (!previousSlugs.includes(howToItem.slug)) {
+      previousSlugs.push(howToItem.slug)
     }
 
     await dbRef.set(
       {
         ...howToItem,
+        previousSlugs,
         description,
         comments,
         mentions,


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

Fix for broken logic in the shared method `updateHowtoItem`, which assumed that previousSlugs would always be present as a well formed array.
