### PR TITLE
fix: focus alignment

### DIFF
--- a/src/pages/UserSettings/content/formSections/Fields/CustomRadio.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Fields/CustomRadio.field.tsx
@@ -132,7 +132,7 @@ class CustomRadioField extends Component<IProps, IState> {
                   marginTop: 1,
                   marginBottom: 1,
                   fontWeight: ['bold', 'bold', 'inherit'],
-                  textAlign: ['left', 'left', 'center'],
+                  textAlign: ['center'],
                 }}
               >
                 {textLabel}

--- a/src/pages/UserSettings/content/formSections/Focus.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Focus.section.tsx
@@ -27,7 +27,7 @@ const ProfileTypes = () => {
           </Flex>
           <Box>
             <Paragraph my={4}>{title}</Paragraph>
-            <Grid columns={['repeat(auto-fill, minmax(150px, 1fr))']} gap={2}>
+            <Grid columns={['repeat(auto-fill, minmax(125px, 1fr))']} gap={2}>
               {profileTypes.map((profile, index: number) => (
                 <Box key={index}>
                   <CustomRadioField


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Changes the minimum width of the repeated grid item so it will initially auto-fill all 5 items in one row. When downsizing the screen width it will act responsively.
Also I noticed that the text-align of the grid items below the images were not always centred. I therefore also removed the 'left' value from the text-align array.

## Git Issues

Closes #2993

## Screenshots/Videos

Before:

https://github.com/ONEARMY/community-platform/assets/131855633/08c4bff8-ec6c-4305-9738-b9058a824f66

After:

https://github.com/ONEARMY/community-platform/assets/131855633/c94a71db-3f9b-4e0e-afb1-5a93089b2fdb

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
