### PR TITLE
feat: add display of impact data

### DIFF
--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -5,17 +5,18 @@ import { UserMenuItem } from '../support/commands'
 import { MESSAGE_MAX_CHARACTERS } from '../../../../src/pages/User/constants'
 import { contact } from '../../../../src/pages/User/labels'
 
+import { missing } from '../../../../src/pages/User/impact/labels'
+
+const { admin, subscriber } = users
+const betaTester = users['beta-tester']
+const eventReader = users.event_reader
+const machine = users.settings_machine_new
+const userProfiletype = users.settings_workplace_new
+
 describe('[Profile]', () => {
   beforeEach(() => {
     cy.visit('/')
   })
-
-  const admin = users.admin
-  const betaTester = users['beta-tester']
-  const eventReader = users.event_reader
-  const machine = users.settings_machine_new
-  const subscriber = users.subscriber
-  const userProfiletype = users.settings_workplace_new
 
   describe('[By Anonymous]', () => {
     it('[Can view all public profile information]', () => {
@@ -38,6 +39,7 @@ describe('[Profile]', () => {
       cy.get('[data-cy=MemberProfile]').should('exist')
       cy.get('.beta-tester-feature').should('not.exist')
     })
+
     it('[Cannot edit another user profile]', () => {
       cy.login(subscriber.email, subscriber.password)
 
@@ -71,6 +73,18 @@ describe('[Profile]', () => {
       cy.step('Submit form')
       cy.get('[data-cy=contact-submit]').click()
       cy.contains(contact.successMessage).should('exist')
+    })
+
+    it('[Can see impact data for workspaces]', () => {
+      cy.login(betaTester.email, betaTester.password)
+
+      cy.step('Can go to impact data')
+      cy.visit(`/u/${userProfiletype.userName}`)
+      cy.get('[data-cy=ImpactTab]').click()
+      cy.get('[data-cy=ImpactPanel]').should('exist')
+      cy.contains(missing.owner.label)
+      cy.contains('2021')
+      cy.contains('3 full time employees')
     })
   })
 

--- a/shared/mocks/data/users.ts
+++ b/shared/mocks/data/users.ts
@@ -303,6 +303,41 @@ export const users = {
     collectedPlasticTypes: null,
     email: 'settings_workplace_new@test.com',
     password: 'test1234',
+    impact: [
+      {
+        year: 2022,
+        fields: [
+          {
+            label: 'plastic recycled',
+            value: 43000,
+            suffix: 'Kg of',
+            isVisible: true,
+          },
+          {
+            label: 'revenue',
+            value: 36000,
+            prefix: '$',
+            suffix: 'in',
+            isVisible: true,
+          },
+          {
+            label: 'full time employees',
+            value: 3,
+            isVisible: true,
+          },
+          {
+            label: 'volunteers',
+            value: 45,
+            isVisible: false,
+          },
+          {
+            label: 'machines built',
+            value: 2,
+            isVisible: true,
+          },
+        ],
+      },
+    ],
   },
   mapview_testing_rejected: {
     openingHours: [],

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -52,8 +52,26 @@ export interface IUser {
   profileCreationTrigger?: string
   // Used to generate an encrypted unsubscribe url in emails
   unsubscribeToken?: string
+  impact?: IUserImpact
   isContactableByPublic?: boolean
 }
+
+export type IUserImpact = IImpactData[] | []
+
+export interface IImpactData {
+  year: IImpactYear
+  fields: ImpactDataField[]
+}
+
+export interface ImpactDataField {
+  label: string
+  value: number
+  prefix?: string
+  suffix?: string
+  isVisible: boolean
+}
+
+export type IImpactYear = 2021 | 2022 | 2023
 
 export interface IUserBadges {
   verified: boolean

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -17,8 +17,16 @@ import {
   UserStatistics,
   ImageGallery,
 } from 'oa-components'
+
 import UserCreatedDocuments from './UserCreatedDocuments'
 import { useCommonStores } from 'src/index'
+import UserContactAndLinks from './UserContactAndLinks'
+import { ProfileType } from 'src/modules/profile/types'
+import { userStats } from 'src/common/hooks/userStats'
+import { Impact } from '../impact/Impact'
+import { heading } from '../impact/labels'
+import { UserContactForm } from 'src/pages/User/contact'
+import { AuthWrapper } from 'src/common/AuthWrapper'
 
 // Plastic types
 import HDPEIcon from 'src/assets/images/plastic-types/hdpe.svg'
@@ -28,12 +36,6 @@ import PETIcon from 'src/assets/images/plastic-types/pet.svg'
 import PPIcon from 'src/assets/images/plastic-types/pp.svg'
 import PSIcon from 'src/assets/images/plastic-types/ps.svg'
 import PVCIcon from 'src/assets/images/plastic-types/pvc.svg'
-
-import UserContactAndLinks from './UserContactAndLinks'
-import { ProfileType } from 'src/modules/profile/types'
-import { userStats } from 'src/common/hooks/userStats'
-import { UserContactForm } from 'src/pages/User/contact'
-import { AuthWrapper } from 'src/common/AuthWrapper'
 
 import type { UserCreatedDocs } from '.'
 
@@ -153,19 +155,30 @@ const getCoverImages = (user: IUserPP) => {
 }
 
 export const SpaceProfile = ({ user, docs }: IProps) => {
+  const {
+    about,
+    country,
+    displayName,
+    impact,
+    isContactableByPublic,
+    links,
+    location,
+    profileType,
+    userName,
+  } = user
+
   const coverImage = getCoverImages(user)
   const stats = userStats(user.userName)
 
-  const userLinks = user?.links.filter(
+  const userLinks = links.filter(
     (linkItem) => !['discord', 'forum'].includes(linkItem.label),
   )
 
   const userCountryCode =
-    user.location?.countryCode || user.country?.toLowerCase() || undefined
+    location?.countryCode || country?.toLowerCase() || undefined
 
   const { stores } = useCommonStores()
-  const showContactForm =
-    user.isContactableByPublic && !!stores.userStore.activeUser
+  const showContactForm = isContactableByPublic && !!stores.userStore.activeUser
 
   return (
     <Container
@@ -197,7 +210,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
         <Box sx={{ width: '100%' }}>
           <Box sx={{ display: ['block', 'block', 'none'] }}>
             <MobileBadge>
-              <MemberBadge profileType={user.profileType} />
+              <MemberBadge profileType={profileType} />
             </MobileBadge>
           </Box>
 
@@ -216,12 +229,12 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                 transform: 'translateY(-100px)',
               }}
             >
-              <MemberBadge size={150} profileType={user.profileType} />
+              <MemberBadge size={150} profileType={profileType} />
             </Box>
             <Box>
               <Username
                 user={{
-                  userName: user.userName,
+                  userName,
                   countryCode: userCountryCode,
                 }}
                 isVerified={stats.verified}
@@ -232,7 +245,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                 style={{ wordBreak: 'break-word' }}
                 data-cy="userDisplayName"
               >
-                {user.displayName}
+                {displayName}
               </Heading>
             </Box>
           </Box>
@@ -241,6 +254,11 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
             <TabsList>
               <Tab>Profile</Tab>
               <Tab>Contributions</Tab>
+              {impact && (
+                <AuthWrapper roleRequired={'beta-tester'}>
+                  <Tab data-cy="ImpactTab">{heading}</Tab>
+                </AuthWrapper>
+              )}
               <AuthWrapper roleRequired={'beta-tester'}>
                 {showContactForm && <Tab data-cy="contact-tab">Contact</Tab>}
               </AuthWrapper>
@@ -259,17 +277,17 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                       width: ['100%', '100%', '80%'],
                     }}
                   >
-                    {user.about && <Paragraph>{user.about}</Paragraph>}
+                    {about && <Paragraph>{about}</Paragraph>}
 
-                    {user.profileType === ProfileType.COLLECTION_POINT &&
+                    {profileType === ProfileType.COLLECTION_POINT &&
                       user.collectedPlasticTypes &&
                       renderPlasticTypes(user.collectedPlasticTypes)}
 
-                    {user.profileType === ProfileType.COLLECTION_POINT &&
+                    {profileType === ProfileType.COLLECTION_POINT &&
                       user.openingHours &&
                       renderOpeningHours(user.openingHours)}
 
-                    {user.profileType === ProfileType.MACHINE_BUILDER &&
+                    {profileType === ProfileType.MACHINE_BUILDER &&
                       user.machineBuilderXp &&
                       renderMachineBuilderXp(user.machineBuilderXp)}
 
@@ -282,8 +300,8 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                     }}
                   >
                     <UserStatistics
-                      userName={user.userName}
-                      country={user.location?.country}
+                      userName={userName}
+                      country={location?.country}
                       isVerified={stats.verified}
                       isSupporter={!!user.badges?.supporter}
                       howtoCount={docs?.howtos.length || 0}
@@ -297,6 +315,13 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
             <TabPanel>
               <UserCreatedDocuments docs={docs} />
             </TabPanel>
+            {impact && (
+              <AuthWrapper roleRequired={'beta-tester'}>
+                <TabPanel>
+                  <Impact impact={impact} user={user} />
+                </TabPanel>
+              </AuthWrapper>
+            )}
             <AuthWrapper roleRequired={'beta-tester'}>
               <TabPanel>
                 <UserContactForm user={user} />

--- a/src/pages/User/impact/Impact.test.tsx
+++ b/src/pages/User/impact/Impact.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'mobx-react'
+
+import { useCommonStores } from 'src/index'
+import { FactoryUser } from 'src/test/factories/User'
+import { missing } from './labels'
+import { IMPACT_YEARS } from './constants'
+import { Impact } from './Impact'
+
+import type { IImpactYear } from 'src/models'
+
+jest.mock('src/index', () => {
+  return {
+    useCommonStores: () => ({
+      stores: {
+        userStore: {
+          activeUser: jest.fn(),
+        },
+      },
+    }),
+  }
+})
+
+describe('Impact', () => {
+  it('renders all fields with data formatted correctly', async () => {
+    const impact = [
+      {
+        year: 2022 as IImpactYear,
+        fields: [
+          {
+            label: 'volunteers',
+            value: 45,
+            isVisible: true,
+          },
+          {
+            label: 'plastic recycled',
+            suffix: 'Kg of',
+            value: 23000,
+            isVisible: true,
+          },
+          {
+            label: 'revenue',
+            prefix: '$',
+            value: 54000,
+            isVisible: true,
+          },
+          {
+            label: 'machines built',
+            value: 13,
+            isVisible: false,
+          },
+        ],
+      },
+    ]
+    const user = FactoryUser({ impact })
+
+    render(
+      <Provider {...useCommonStores().stores}>
+        <Impact impact={impact} user={user} />
+      </Provider>,
+    )
+
+    await screen.findByText('45 volunteers')
+    await screen.findByText('23,000 Kg of plastic recycled')
+    await screen.findByText('$ 54,000 revenue')
+    const machineField = await screen.queryByText('13 machines built')
+    expect(machineField).toBe(null)
+
+    await IMPACT_YEARS.forEach(async (year) => await screen.findByText(year))
+    await screen.findAllByText(missing.owner.label)
+  })
+})

--- a/src/pages/User/impact/Impact.tsx
+++ b/src/pages/User/impact/Impact.tsx
@@ -1,0 +1,38 @@
+import { Flex } from 'theme-ui'
+
+import { ImpactItem } from './ImpactItem'
+import { IMPACT_YEARS } from './constants'
+
+import type { IUserImpact, IUserPP } from 'src/models'
+
+interface Props {
+  impact: IUserImpact
+  user: IUserPP
+}
+
+export const Impact = ({ impact, user }: Props) => {
+  const renderByYear = IMPACT_YEARS.map((year, index) => {
+    const found = impact.find((data) => data.year === year)
+    return (
+      <ImpactItem
+        fields={found && found.fields}
+        year={year}
+        key={index}
+        user={user}
+      />
+    )
+  })
+
+  const sx = {
+    flexFlow: 'row wrap',
+    my: 2,
+  }
+
+  return (
+    <Flex sx={sx} data-cy="ImpactPanel">
+      {renderByYear.map((year) => {
+        return year
+      })}
+    </Flex>
+  )
+}

--- a/src/pages/User/impact/ImpactEmoji.tsx
+++ b/src/pages/User/impact/ImpactEmoji.tsx
@@ -1,0 +1,26 @@
+import type { ImpactDataField } from 'src/models'
+
+interface Props {
+  label: ImpactDataField['label']
+}
+
+const EMOJI_MAP = {
+  'full time employees': '&#x1f46f',
+  'machines built': '&#x2699;&#xfe0f;',
+  'plastic recycled': '&#x1f52b',
+  revenue: '&#x1f4b8',
+  volunteers: '&#x1f3c5',
+}
+
+export const ImpactEmoji = ({ label }: Props) => {
+  const emoji = EMOJI_MAP[label]
+
+  if (!emoji) return null
+
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: emoji }}
+      style={{ display: 'inline' }}
+    />
+  )
+}

--- a/src/pages/User/impact/ImpactField.tsx
+++ b/src/pages/User/impact/ImpactField.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from 'theme-ui'
+
+import { numberWithCommas } from 'src/utils/helpers'
+import { ImpactEmoji } from './ImpactEmoji'
+
+import type { ImpactDataField } from 'src/models'
+
+interface Props {
+  field: ImpactDataField
+}
+
+export const ImpactField = ({ field }: Props) => {
+  const { label, prefix, suffix, value } = field
+
+  const sx = {
+    backgroundColor: 'white',
+    borderRadius: 1,
+    padding: 1,
+    mt: 2,
+  }
+
+  const text = `${prefix ? prefix : ''} ${numberWithCommas(value)} ${
+    suffix ? suffix : ''
+  } ${label}`
+
+  return (
+    <Box sx={sx}>
+      <Text variant="label">
+        <ImpactEmoji label={label} /> {text}
+      </Text>
+    </Box>
+  )
+}

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -1,0 +1,43 @@
+import { Box, Heading } from 'theme-ui'
+
+import { ImpactField } from './ImpactField'
+import { ImpactMissing } from './ImpactMissing'
+
+import type { ImpactDataField, IImpactYear, IUserPP } from 'src/models'
+
+interface Props {
+  year: IImpactYear
+  fields: ImpactDataField[] | undefined
+  user: IUserPP
+}
+
+export const ImpactItem = ({ fields, user, year }: Props) => {
+  const outterBox = {
+    flexBasis: ['100%', '100%', '50%'],
+    padding: 2,
+  }
+
+  const innerBox = {
+    backgroundColor: 'background',
+    borderRadius: 1,
+    height: '100%',
+    padding: 2,
+  }
+
+  const visibleFields = fields?.filter((field) => field.isVisible)
+
+  return (
+    <Box sx={outterBox} cy-data="ImpactItem">
+      <Box sx={innerBox}>
+        <Heading variant="small">{year}</Heading>
+        {visibleFields ? (
+          visibleFields.map((field, index) => {
+            return <ImpactField field={field} key={index} />
+          })
+        ) : (
+          <ImpactMissing year={year} user={user} />
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -1,0 +1,35 @@
+import { observer } from 'mobx-react'
+import { Button, ExternalLink } from 'oa-components'
+import { Flex, Text } from 'theme-ui'
+
+import { useCommonStores } from 'src/'
+import { missing } from './labels'
+import { IMPACT_REPORT_LINKS } from './constants'
+
+import type { IImpactYear, IUserPP } from 'src/models'
+
+interface Props {
+  year: IImpactYear
+  user: IUserPP
+}
+
+export const ImpactMissing = observer(({ user, year }: Props) => {
+  const { userStore } = useCommonStores().stores
+
+  const isPageOwner = userStore.activeUser && user
+
+  const button = `${year} ${missing.user.link}`
+  const href = IMPACT_REPORT_LINKS[year]
+  const label = isPageOwner ? missing.owner.label : missing.user.label
+
+  return (
+    <Flex sx={{ flexFlow: 'column', gap: 2, mt: 2 }}>
+      <Text>{label}</Text>
+      {!isPageOwner && (
+        <ExternalLink href={href}>
+          <Button>{button}</Button>
+        </ExternalLink>
+      )}
+    </Flex>
+  )
+})

--- a/src/pages/User/impact/constants.ts
+++ b/src/pages/User/impact/constants.ts
@@ -1,0 +1,9 @@
+import type { IImpactYear } from 'src/models'
+
+export const IMPACT_REPORT_LINKS = {
+  2023: 'http://preciousplastic.com/impact/2023.html',
+  2022: '',
+  2021: '',
+}
+
+export const IMPACT_YEARS: IImpactYear[] = [2023, 2022, 2021]

--- a/src/pages/User/impact/labels.ts
+++ b/src/pages/User/impact/labels.ts
@@ -1,0 +1,12 @@
+export const heading = 'Impact'
+
+export const missing = {
+  user: {
+    label:
+      "Looks like they haven't shared their Impact Data yet. Until they do you can have a pick of the global impact report! :)",
+    link: 'Impact Report',
+  },
+  owner: {
+    label: "Looks like you haven't added your Impact Data yet.",
+  },
+}

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,16 +1,17 @@
 import type { IModerable, IResearch } from 'src/models'
 import type { IItem } from 'src/stores/common/FilterSorterDecorator/FilterSorterDecorator'
 import {
-  stripSpecialCharacters,
-  formatLowerNoSpecial,
   arrayToJson,
+  calculateTotalComments,
   capitalizeFirstLetter,
   filterModerableItems,
+  formatLowerNoSpecial,
   hasAdminRights,
-  needsModeration,
   isAllowedToEditContent,
   isAllowedToPin,
-  calculateTotalComments,
+  needsModeration,
+  numberWithCommas,
+  stripSpecialCharacters,
 } from './helpers'
 import { FactoryUser } from 'src/test/factories/User'
 import { FactoryResearchItemUpdate } from 'src/test/factories/ResearchItem'
@@ -260,6 +261,13 @@ describe('src/utils/helpers', () => {
           ]),
       } as IResearch.ItemDB | IItem
       expect(calculateTotalComments(item)).toBe('4')
+    })
+  })
+
+  describe('numberWithCommas', () => {
+    it('adds a comma between every three digits', () => {
+      const expectation = '1,000'
+      expect(numberWithCommas(1000)).toEqual(expectation)
     })
   })
 })

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -40,6 +40,10 @@ export const arrayToJson = (arr: any[], keyField: string) => {
   return json
 }
 
+export const numberWithCommas = (number: number) => {
+  return new Intl.NumberFormat().format(number)
+}
+
 // Take a string and capitalises the first letter
 // hello world => Hello world
 export const capitalizeFirstLetter = (str: string) =>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This adds the large majority of the display for the impact data on workshop profiles.  

Missing: 
* As the tab layout changes haven't been implemented, the backgrounds are inverted in this.
* As no settings exist yet, the display of the tab is hidden unless impact data has been manually added to the database.
* As no settings exist yet, link to add impact data isn't present.
* TEMPORARILY: The links to the 2022 and 2021 impact reports - can I have these please.

## Git Issues

A large part of #3001.

## Screenshots/Videos

<img width="1049" alt="Screenshot 2023-11-17 at 13 54 31" src="https://github.com/ONEARMY/community-platform/assets/16688508/91af346c-af0f-46c3-899c-fca77ab9f40c">
<img width="1049" alt="Screenshot 2023-11-17 at 13 57 30" src="https://github.com/ONEARMY/community-platform/assets/16688508/bdc63214-f88b-4033-a276-badc35e40a3d">


