### PR TITLE
fix: handle empty images

### DIFF
--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -22,7 +22,15 @@ import { useCommonStores } from 'src/index'
 import { ProfileType } from 'src/modules/profile/types'
 import { UserContactForm } from 'src/pages/User/contact'
 import { formatImagesForGallery } from 'src/utils/formatImageListForGallery'
-import { Box, Container, Flex, Heading, Image, Paragraph } from 'theme-ui'
+import {
+  AspectRatio,
+  Box,
+  Container,
+  Flex,
+  Heading,
+  Image,
+  Paragraph,
+} from 'theme-ui'
 
 import { Impact } from '../impact/Impact'
 import { heading } from '../impact/labels'
@@ -191,11 +199,27 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
       data-cy="SpaceProfile"
     >
       <Box sx={{ lineHeight: 0 }}>
-        <ImageGallery
-          images={formatImagesForGallery(coverImage)}
-          hideThumbnails={true}
-          showNextPrevButton={true}
-        />
+        {coverImage.length ? (
+          <ImageGallery
+            images={formatImagesForGallery(coverImage)}
+            hideThumbnails={true}
+            showNextPrevButton={true}
+          />
+        ) : (
+          <AspectRatio ratio={24 / 3}>
+            <Flex
+              sx={{
+                width: '100%',
+                height: '100%',
+                background: '#ddd',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              No images available.
+            </Flex>
+          </AspectRatio>
+        )}
       </Box>
       <Flex
         sx={{

--- a/src/pages/User/user.routes.test.tsx
+++ b/src/pages/User/user.routes.test.tsx
@@ -1,0 +1,128 @@
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '@emotion/react'
+import { act, render } from '@testing-library/react'
+import { Provider } from 'mobx-react'
+import { useCommonStores } from 'src/index'
+import { FactoryUser } from 'src/test/factories/User'
+import { testingThemeStyles } from 'src/test/utils/themeUtils'
+
+import UserProfileRoutes from './user.routes'
+
+const Theme = testingThemeStyles
+
+// eslint-disable-next-line prefer-const
+let mockGetUserProfile = jest.fn().mockResolvedValue(FactoryUser)
+const mockGetPin = jest.fn()
+const mockUpdateUserBadge = jest.fn()
+
+jest.mock('src/index', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  useCommonStores: () => ({
+    stores: {
+      userStore: {
+        getUserProfile: mockGetUserProfile,
+        updateUserBadge: mockUpdateUserBadge,
+        getUserCreatedDocs: jest.fn(),
+      },
+      aggregationsStore: {
+        updateAggregation: jest.fn(),
+        stopAggregationUpdates: jest.fn(),
+        getAggregationValue: jest.fn(),
+        aggregations: {
+          users_totalUseful: {
+            HowtoAuthor: 0,
+          },
+          users_verified: {
+            HowtoAuthor: true,
+          },
+        },
+      },
+      themeStore: {
+        currentTheme: {
+          styles: {
+            communityProgramURL: '',
+          },
+        },
+      },
+      mapsStore: {
+        getPin: mockGetPin,
+      },
+      tagsStore: {},
+    },
+  }),
+}))
+
+describe('User', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('displays user page', async () => {
+    const user = FactoryUser()
+
+    // Act
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(user)
+    })
+
+    // Assert
+    expect(wrapper.getByText(user.displayName)).toBeInTheDocument()
+  })
+
+  it('displays user not found page', async () => {
+    // Act
+    let wrapper
+    await act(async () => {
+      wrapper = await getWrapper(null, '/u/does-not-exist')
+    })
+
+    // Assert
+    expect(wrapper.getByText('User not found')).toBeInTheDocument()
+  })
+
+  describe('workspace', () => {
+    it('handles workspace with no images', async () => {
+      const user = FactoryUser({
+        profileType: 'workspace',
+        coverImages: [],
+      })
+
+      // Act
+      let wrapper
+      await act(async () => {
+        wrapper = await getWrapper(user)
+      })
+
+      // Assert
+      expect(wrapper.getByText('No images available.')).toBeInTheDocument()
+    })
+  })
+})
+
+const getWrapper = async (user, url?) => {
+  mockGetUserProfile.mockResolvedValue(user)
+
+  return render(
+    <Provider
+      {...useCommonStores().stores}
+      userStore={{
+        user,
+        updateStatus: { Complete: true },
+        getUserEmail: jest.fn(),
+        getUserProfile: jest.fn().mockResolvedValue(user),
+        getUserCreatedDocs: jest.fn(),
+      }}
+    >
+      <ThemeProvider theme={Theme}>
+        <MemoryRouter
+          initialEntries={[url || `/u/${user.userName}`]}
+          basename="/u"
+        >
+          <UserProfileRoutes />
+        </MemoryRouter>
+      </ThemeProvider>
+    </Provider>,
+  )
+}


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Introduce tests for rendering User profile pages, introducing edge case where User has no Cover Images uploaded. Adds graceful fallback for this scenario.

Note the screengrabs below are for two different users, this is due to the bug being visible in prod (before) then fixed locally in (after).

Before:
![Screenshot 2023-11-22 at 20 46 29](https://github.com/ONEARMY/community-platform/assets/472589/53ad2888-91e1-4d54-bd5b-54119b86161f)

After:
![Screenshot 2023-11-22 at 20 46 19](https://github.com/ONEARMY/community-platform/assets/472589/bf81a2b7-fcaf-403c-bb01-57289bf954cc)
