### PR TITLE
feat: add user setting to update impact

### DIFF
--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -1,7 +1,9 @@
 import { DbCollectionName } from '../utils/TestUtils'
 import { UserMenuItem } from '../support/commands'
-import type { IUser } from '../../../../src/models/user.models'
 import { SingaporeStubResponse } from '../fixtures/searchResults'
+import { form } from '../../../../src/pages/UserSettings/labels'
+
+import type { IUser } from '../../../../src/models/user.models'
 
 interface Info {
   username: string
@@ -92,6 +94,33 @@ describe('[Settings]', () => {
           type: 'image/jpeg',
         },
       ],
+      impact: {
+        2022: [
+          {
+            label: 'plastic recycled',
+            value: 43000,
+            suffix: 'Kg of',
+            isVisible: true,
+          },
+          {
+            label: 'revenue',
+            value: 100000,
+            prefix: '$',
+            suffix: 'in',
+            isVisible: false,
+          },
+          {
+            label: 'full time employees',
+            value: 3,
+            isVisible: true,
+          },
+          {
+            label: 'volunteers',
+            value: 45,
+            isVisible: false,
+          },
+        ],
+      },
       isContactableByPublic: true,
       links: [
         {
@@ -154,6 +183,17 @@ describe('[Settings]', () => {
         searchKeyword: 'Singapo',
         locationName: expected.location.value,
       })
+
+      cy.step('Save impact data')
+      cy.get('[data-cy="impact-button-expand"]').click()
+      cy.get('[data-cy="impactForm-2022-button-edit"]').click()
+      cy.get('[data-cy="impactForm-2022-field-revenue-value"]')
+        .clear()
+        .type('100000')
+      cy.get('[data-cy="impactForm-2022-field-revenue-isVisible"]').click()
+      cy.get('[data-cy="impactForm-2022-field-machines built-value"]').clear()
+      cy.get('[data-cy="impactForm-2022-button-save"]').click()
+      cy.contains(form.saveSuccess)
 
       cy.step('Opt-in to being contacted by users')
       cy.get('[data-cy=isContactableByPublic]').should('not.be.checked')

--- a/shared/mocks/data/users.ts
+++ b/shared/mocks/data/users.ts
@@ -303,41 +303,39 @@ export const users = {
     collectedPlasticTypes: null,
     email: 'settings_workplace_new@test.com',
     password: 'test1234',
-    impact: [
-      {
-        year: 2022,
-        fields: [
-          {
-            label: 'plastic recycled',
-            value: 43000,
-            suffix: 'Kg of',
-            isVisible: true,
-          },
-          {
-            label: 'revenue',
-            value: 36000,
-            prefix: '$',
-            suffix: 'in',
-            isVisible: true,
-          },
-          {
-            label: 'full time employees',
-            value: 3,
-            isVisible: true,
-          },
-          {
-            label: 'volunteers',
-            value: 45,
-            isVisible: false,
-          },
-          {
-            label: 'machines built',
-            value: 2,
-            isVisible: true,
-          },
-        ],
-      },
-    ],
+    userRoles: ['beta-tester'],
+    impact: {
+      2022: [
+        {
+          label: 'plastic recycled',
+          value: 43000,
+          suffix: 'Kg of',
+          isVisible: true,
+        },
+        {
+          label: 'revenue',
+          value: 36000,
+          prefix: '$',
+          suffix: 'in',
+          isVisible: true,
+        },
+        {
+          label: 'full time employees',
+          value: 3,
+          isVisible: true,
+        },
+        {
+          label: 'volunteers',
+          value: 45,
+          isVisible: false,
+        },
+        {
+          label: 'machines built',
+          value: 2,
+          isVisible: true,
+        },
+      ],
+    },
   },
   mapview_testing_rejected: {
     openingHours: [],

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -56,20 +56,19 @@ export interface IUser {
   isContactableByPublic?: boolean
 }
 
-export type IUserImpact = IImpactData[] | []
-
-export interface IImpactData {
-  year: IImpactYear
-  fields: ImpactDataField[]
+export interface IUserImpact {
+  [key: number]: IImpactYearFieldList
 }
 
-export interface ImpactDataField {
+export interface IImpactDataField {
   label: string
   value: number
   prefix?: string
   suffix?: string
   isVisible: boolean
 }
+
+export type IImpactYearFieldList = IImpactDataField[]
 
 export type IImpactYear = 2021 | 2022 | 2023
 

--- a/src/pages/User/contact/UserContactError.tsx
+++ b/src/pages/User/contact/UserContactError.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable no-console */
 import { Text } from 'theme-ui'
 import { TextNotification } from 'oa-components'
 
-type SubmitResults = { type: 'success' | 'error'; message: string }
+export type SubmitResults = { type: 'success' | 'error'; message: string }
 
 interface Props {
   submitResults: SubmitResults | null

--- a/src/pages/User/impact/Impact.test.tsx
+++ b/src/pages/User/impact/Impact.test.tsx
@@ -7,8 +7,6 @@ import { missing } from './labels'
 import { IMPACT_YEARS } from './constants'
 import { Impact } from './Impact'
 
-import type { IImpactYear } from 'src/models'
-
 jest.mock('src/index', () => {
   return {
     useCommonStores: () => ({
@@ -23,35 +21,32 @@ jest.mock('src/index', () => {
 
 describe('Impact', () => {
   it('renders all fields with data formatted correctly', async () => {
-    const impact = [
-      {
-        year: 2022 as IImpactYear,
-        fields: [
-          {
-            label: 'volunteers',
-            value: 45,
-            isVisible: true,
-          },
-          {
-            label: 'plastic recycled',
-            suffix: 'Kg of',
-            value: 23000,
-            isVisible: true,
-          },
-          {
-            label: 'revenue',
-            prefix: '$',
-            value: 54000,
-            isVisible: true,
-          },
-          {
-            label: 'machines built',
-            value: 13,
-            isVisible: false,
-          },
-        ],
-      },
-    ]
+    const impact = {
+      2022: [
+        {
+          label: 'volunteers',
+          value: 45,
+          isVisible: true,
+        },
+        {
+          label: 'plastic recycled',
+          suffix: 'Kg of',
+          value: 23000,
+          isVisible: true,
+        },
+        {
+          label: 'revenue',
+          prefix: '$',
+          value: 54000,
+          isVisible: true,
+        },
+        {
+          label: 'machines built',
+          value: 13,
+          isVisible: false,
+        },
+      ],
+    }
     const user = FactoryUser({ impact })
 
     render(

--- a/src/pages/User/impact/Impact.tsx
+++ b/src/pages/User/impact/Impact.tsx
@@ -12,10 +12,11 @@ interface Props {
 
 export const Impact = ({ impact, user }: Props) => {
   const renderByYear = IMPACT_YEARS.map((year, index) => {
-    const found = impact.find((data) => data.year === year)
+    const foundYear = Object.keys(impact).find((key) => Number(key) === year)
+
     return (
       <ImpactItem
-        fields={found && found.fields}
+        fields={foundYear && impact[foundYear]}
         year={year}
         key={index}
         user={user}

--- a/src/pages/User/impact/ImpactEmoji.tsx
+++ b/src/pages/User/impact/ImpactEmoji.tsx
@@ -1,7 +1,7 @@
-import type { ImpactDataField } from 'src/models'
+import type { IImpactDataField } from 'src/models'
 
 interface Props {
-  label: ImpactDataField['label']
+  label: IImpactDataField['label']
 }
 
 const EMOJI_MAP = {

--- a/src/pages/User/impact/ImpactField.tsx
+++ b/src/pages/User/impact/ImpactField.tsx
@@ -3,10 +3,10 @@ import { Box, Text } from 'theme-ui'
 import { numberWithCommas } from 'src/utils/helpers'
 import { ImpactEmoji } from './ImpactEmoji'
 
-import type { ImpactDataField } from 'src/models'
+import type { IImpactDataField } from 'src/models'
 
 interface Props {
-  field: ImpactDataField
+  field: IImpactDataField
 }
 
 export const ImpactField = ({ field }: Props) => {

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -3,11 +3,11 @@ import { Box, Heading } from 'theme-ui'
 import { ImpactField } from './ImpactField'
 import { ImpactMissing } from './ImpactMissing'
 
-import type { ImpactDataField, IImpactYear, IUserPP } from 'src/models'
+import type { IImpactYearFieldList, IImpactYear, IUserPP } from 'src/models'
 
 interface Props {
   year: IImpactYear
-  fields: ImpactDataField[] | undefined
+  fields: IImpactYearFieldList | undefined
   user: IUserPP
 }
 

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -18,17 +18,21 @@ export const ImpactMissing = observer(({ user, year }: Props) => {
 
   const isPageOwner = userStore.activeUser && user
 
-  const button = `${year} ${missing.user.link}`
-  const href = IMPACT_REPORT_LINKS[year]
+  const userButton = `${year} ${missing.user.link}`
   const label = isPageOwner ? missing.owner.label : missing.user.label
 
   return (
     <Flex sx={{ flexFlow: 'column', gap: 2, mt: 2 }}>
       <Text>{label}</Text>
       {!isPageOwner && (
-        <ExternalLink href={href}>
-          <Button>{button}</Button>
+        <ExternalLink href={IMPACT_REPORT_LINKS[year]}>
+          <Button>{userButton}</Button>
         </ExternalLink>
+      )}
+      {isPageOwner && (
+        <a href="/settings">
+          <Button>{missing.owner.link}</Button>
+        </a>
       )}
     </Flex>
   )

--- a/src/pages/User/impact/labels.ts
+++ b/src/pages/User/impact/labels.ts
@@ -8,5 +8,6 @@ export const missing = {
   },
   owner: {
     label: "Looks like you haven't added your Impact Data yet.",
+    link: 'Enter impact data',
   },
 }

--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import arrayMutators from 'final-form-arrays'
 import { Form } from 'react-final-form'
 import { v4 as uuid } from 'uuid'
 
+import { AuthWrapper } from 'src/common/AuthWrapper'
 import { UserInfosSection } from './content/formSections/UserInfos.section'
 import { FocusSection } from './content/formSections/Focus.section'
 import { ExpertiseSection } from './content/formSections/Expertise.section'
@@ -20,6 +21,7 @@ import { ProfileGuidelines } from './content/PostingGuidelines'
 import { WorkspaceMapPinSection } from './content/formSections/WorkspaceMapPin.section'
 import { MemberMapPinSection } from './content/formSections/MemberMapPin.section'
 import { PublicContactSection } from './content/formSections/PublicContact.section'
+import { ImpactSection } from './content/formSections/Impact/Impact.section'
 
 import { buttons, headings } from './labels'
 import INITIAL_VALUES from './Template'
@@ -306,6 +308,13 @@ export class SettingsPage extends React.Component<IProps, IState> {
                         showLocationDropdown={this.state.showLocationDropdown}
                       />
                     </Flex>
+
+                    {!isMember && (
+                      <AuthWrapper roleRequired={'beta-tester'}>
+                        <ImpactSection />
+                      </AuthWrapper>
+                    )}
+
                     <EmailNotificationsSection
                       notificationSettings={values.notification_settings}
                     />

--- a/src/pages/UserSettings/content/formSections/Impact/Impact.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/Impact.section.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import { Heading, Box, Button, Text } from 'theme-ui'
+
+import { buttons, fields } from 'src/pages/UserSettings/labels'
+import { IMPACT_YEARS } from 'src/pages/User/impact/constants'
+import { FlexSectionContainer } from '../elements'
+import { ImpactYearSection } from './ImpactYear.section'
+
+export const ImpactSection = () => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false)
+  const { description, title } = fields.impact
+  const { expandClose, expandOpen } = buttons.impact
+
+  const buttonLabel = isExpanded ? expandClose : expandOpen
+
+  return (
+    <FlexSectionContainer>
+      <Heading dangerouslySetInnerHTML={{ __html: title }} variant="small" />
+      <Text mt={4} mb={4}>
+        {description}
+      </Text>
+      {isExpanded && (
+        <Box>
+          {IMPACT_YEARS.map((year) => {
+            return <ImpactYearSection year={year} key={year} />
+          })}
+        </Box>
+      )}
+      <Box mt={2}>
+        <Button
+          dangerouslySetInnerHTML={{ __html: buttonLabel }}
+          data-cy="impact-button-expand"
+          onClick={() => setIsExpanded(!isExpanded)}
+          variant="secondary"
+        />
+      </Box>
+    </FlexSectionContainer>
+  )
+}

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactQuestion.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactQuestion.field.tsx
@@ -1,0 +1,76 @@
+import { Box, Flex, Label, Text } from 'theme-ui'
+import { FieldInput, Icon } from 'oa-components'
+import { Field } from 'react-final-form'
+
+import type { IImpactQuestion } from './impactQuestions'
+
+interface Props {
+  id: string
+  field: IImpactQuestion
+}
+
+export const ImpactQuestionField = ({ id, field }: Props) => {
+  const initialValue =
+    typeof field.isVisible === 'boolean' ? field.isVisible : true
+
+  return (
+    <Box sx={{ marginBottom: 3 }}>
+      <Label htmlFor={`${field.label}.value`} sx={{ marginBottom: 1 }}>
+        {field.description}
+      </Label>
+      <Flex
+        sx={{
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Flex
+          sx={{
+            alignItems: 'center',
+            alignSelf: 'flex-start',
+            flexDirection: 'row',
+            gap: 2,
+          }}
+        >
+          {field.prefix && (
+            <Box>
+              <Text>{field.prefix}</Text>
+            </Box>
+          )}
+
+          <Box>
+            <Field
+              component={FieldInput}
+              data-cy={`${id}-field-${field.label}-value`}
+              name={`${field.label}.value`}
+              sx={{ background: 'white' }}
+              type="number"
+            />
+          </Box>
+
+          {field.suffix && (
+            <Box>
+              <Text>{field.suffix}</Text>
+            </Box>
+          )}
+
+          <Box>
+            <Text>{field.label}</Text>
+          </Box>
+        </Flex>
+
+        <Flex sx={{ alignSelf: 'flex-end', flexDirection: 'row' }}>
+          <Icon glyph="show" size={24} />
+          <Field
+            component="input"
+            data-cy={`${id}-field-${field.label}-isVisible`}
+            initialValue={initialValue}
+            name={`${field.label}.isVisible`}
+            type="checkbox"
+          />
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.field.tsx
@@ -1,0 +1,33 @@
+import { Button } from 'oa-components'
+
+import { buttons } from 'src/pages/UserSettings/labels'
+import { ImpactQuestionField } from './ImpactQuestion.field'
+import { impactQuestions } from './impactQuestions'
+
+interface Props {
+  id: string
+  handleSubmit: () => void
+  submitting: boolean
+}
+
+export const ImpactYearField = (props: Props) => {
+  const { id, handleSubmit, submitting } = props
+
+  return (
+    <>
+      {impactQuestions.map((field, index) => (
+        <ImpactQuestionField id={id} field={field} key={index} />
+      ))}
+
+      <Button
+        data-cy={`${id}-button-save`}
+        disabled={submitting}
+        type="submit"
+        onClick={handleSubmit}
+        form={id}
+      >
+        {buttons.impact.save}
+      </Button>
+    </>
+  )
+}

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+import { Box, Heading } from 'theme-ui'
+import { observer } from 'mobx-react'
+import { Form } from 'react-final-form'
+
+import { useCommonStores } from 'src/index'
+import { form } from 'src/pages/UserSettings/labels'
+import { ImpactYearField } from './ImpactYear.field'
+import { ImpactYearDisplayField } from './ImpactYearDisplay.field'
+import { transformImpactData, transformImpactInputs } from './utils'
+import { UserContactError } from 'src/pages/User/contact'
+
+import type { IImpactYearFieldList, IImpactYear } from 'src/models'
+import type { SubmitResults } from 'src/pages/User/contact/UserContactError'
+
+interface Props {
+  year: IImpactYear
+}
+
+export const ImpactYearSection = observer(({ year }: Props) => {
+  const [impact, setImpact] = useState<IImpactYearFieldList | undefined>(
+    undefined,
+  )
+  const [isEditMode, setIsEditMode] = useState<boolean>(false)
+  const [submitResults, setSubmitResults] = useState<SubmitResults | null>(null)
+
+  useEffect(() => {
+    const fetchImpact = () => {
+      const impact = userStore.user?.impact
+      if (impact && impact[year]) {
+        setImpact(impact[year])
+      }
+    }
+    fetchImpact()
+  }, [])
+
+  const { userStore } = useCommonStores().stores
+  const id = `impactForm-${year}`
+
+  const sx = {
+    backgroundColor: 'background',
+    borderRadius: 2,
+    marginBottom: 2,
+    padding: 2,
+  }
+
+  const onSubmit = async (values) => {
+    setSubmitResults(null)
+    try {
+      const fields = transformImpactInputs(values)
+      await userStore.updateUserImpact(fields, year)
+      setSubmitResults({ type: 'success', message: form.saveSuccess })
+      setIsEditMode(false)
+      setImpact(fields)
+    } catch (error) {
+      setSubmitResults({ type: 'error', message: error.message })
+    }
+  }
+
+  return (
+    <Box sx={sx}>
+      <a id="impact"></a>
+      <Heading variant="small">{year}</Heading>
+
+      <UserContactError submitResults={submitResults} />
+
+      <Form
+        onSubmit={onSubmit}
+        id={id}
+        initialValues={impact ? transformImpactData(impact) : undefined}
+        render={({ handleSubmit, values, submitting }) => {
+          return isEditMode ? (
+            <ImpactYearField
+              id={id}
+              handleSubmit={handleSubmit}
+              submitting={submitting}
+            />
+          ) : (
+            <ImpactYearDisplayField
+              fields={transformImpactInputs(values)}
+              id={id}
+              setIsEditMode={setIsEditMode}
+            />
+          )
+        }}
+      />
+    </Box>
+  )
+})

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYearDisplay.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYearDisplay.field.tsx
@@ -1,0 +1,54 @@
+import { Box, Flex, Text } from 'theme-ui'
+import { Button, Icon } from 'oa-components'
+import { observer } from 'mobx-react'
+
+import { buttons, missingData } from 'src/pages/UserSettings/labels'
+import { ImpactField } from 'src/pages/User/impact/ImpactField'
+
+import type { IImpactYearFieldList } from 'src/models'
+
+interface Props {
+  fields: IImpactYearFieldList | undefined
+  id: string
+  setIsEditMode: (boolean) => void
+}
+
+export const ImpactYearDisplayField = observer((props: Props) => {
+  const { fields, id, setIsEditMode } = props
+  const { create, edit } = buttons.impact
+
+  const buttonLabel = fields ? edit : create
+
+  return (
+    <Flex sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>
+      {fields && fields.length > 0 ? (
+        fields.map((field, index) => {
+          const glyph = field.isVisible ? 'show' : 'hide'
+          return (
+            <Box key={index} sx={{ width: '100%' }}>
+              <Flex
+                sx={{
+                  alignItems: 'center',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <ImpactField field={field} />
+                <Icon glyph={glyph} size={24} />
+              </Flex>
+            </Box>
+          )
+        })
+      ) : (
+        <Text>{missingData}</Text>
+      )}
+      <Button
+        data-cy={`${id}-button-edit`}
+        onClick={() => setIsEditMode(true)}
+        sx={{ marginTop: 3 }}
+      >
+        {buttonLabel}
+      </Button>
+    </Flex>
+  )
+})

--- a/src/pages/UserSettings/content/formSections/Impact/impactQuestions.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/impactQuestions.ts
@@ -1,0 +1,40 @@
+export interface IImpactQuestion {
+  description: string
+  label: string
+  isVisible: boolean
+  value?: number
+  suffix?: string
+  prefix?: string
+}
+
+export const impactQuestions: IImpactQuestion[] = [
+  {
+    description:
+      'How many KGs of plastic recycled have you recycled in that year?',
+    label: 'plastic recycled',
+    suffix: 'Kg of',
+    isVisible: true,
+  },
+  {
+    description:
+      'What was your revenue (in $)? By revenue we mean all money coming in.',
+    label: 'revenue',
+    prefix: '$',
+    isVisible: true,
+  },
+  {
+    description: 'How many people did your project employ (you included)?',
+    label: 'full time employees',
+    isVisible: true,
+  },
+  {
+    description: 'How many volunteers did you work with?',
+    label: 'volunteers',
+    isVisible: true,
+  },
+  {
+    description: 'How many machines did you build?',
+    label: 'machines built',
+    isVisible: true,
+  },
+]

--- a/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
@@ -1,0 +1,55 @@
+import { transformImpactData, transformImpactInputs } from './utils'
+
+describe('transformImpactData', () => {
+  it('returns data structured as field inputs', () => {
+    const description =
+      'What was your revenue (in $)? By revenue we mean all money coming in.'
+
+    const impactFields = [
+      {
+        description,
+        label: 'revenue',
+        prefix: '$',
+        value: 75000,
+        isVisible: true,
+      },
+    ]
+    const expected = {
+      revenue: {
+        description,
+        label: 'revenue',
+        prefix: '$',
+        value: 75000,
+        isVisible: true,
+      },
+    }
+    expect(transformImpactData(impactFields)).toEqual(expected)
+  })
+})
+
+describe('transformImpactData', () => {
+  it('returns data structured as impact data', () => {
+    const description =
+      'What was your revenue (in $)? By revenue we mean all money coming in.'
+
+    const inputFields = {
+      revenue: {
+        description,
+        label: 'revenue',
+        prefix: '$',
+        value: 75000,
+        isVisible: true,
+      },
+    }
+
+    const expected = [
+      {
+        label: 'revenue',
+        prefix: '$',
+        value: 75000,
+        isVisible: true,
+      },
+    ]
+    expect(transformImpactInputs(inputFields)).toEqual(expected)
+  })
+})

--- a/src/pages/UserSettings/content/formSections/Impact/utils.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.ts
@@ -1,0 +1,53 @@
+import { impactQuestions } from '../Impact/impactQuestions'
+
+import type { IImpactDataField, IImpactYearFieldList } from 'src/models'
+import type { IImpactQuestion } from '../Impact/impactQuestions'
+
+export interface ImpactDataFieldInputs {
+  [key: string]: IImpactQuestion
+}
+
+interface IInputs {
+  [key: string]: IImpactDataField
+}
+
+export const transformImpactData = (
+  fields: IImpactYearFieldList,
+): ImpactDataFieldInputs => {
+  const transformed = {} as ImpactDataFieldInputs
+
+  Object.values(fields).forEach((field) => {
+    const questionField = impactQuestions.find(
+      (question) => question.label === field.label,
+    )
+    return (transformed[field.label] = {
+      ...field,
+      description: questionField?.description,
+    } as IImpactQuestion)
+  })
+
+  return transformed
+}
+
+export const transformImpactInputs = (
+  inputs: IInputs,
+): IImpactYearFieldList => {
+  const fields = [] as IImpactYearFieldList
+
+  Object.keys(inputs).forEach((key) => {
+    const field = inputs[key]
+    const question = impactQuestions.find(({ label }) => label === key)
+    if (field && question && field.value) {
+      fields.push({
+        label: key,
+        value: field.value,
+        isVisible:
+          typeof field.isVisible === 'boolean' ? field.isVisible : true,
+        ...(question.prefix && { prefix: question.prefix }),
+        ...(question.suffix && { suffix: question.suffix }),
+      })
+    }
+  })
+
+  return fields
+}

--- a/src/pages/UserSettings/content/formSections/SettingsErrors.tsx
+++ b/src/pages/UserSettings/content/formSections/SettingsErrors.tsx
@@ -1,5 +1,5 @@
 import { ErrorsContainer } from 'src/common/Form/ErrorsContainer'
-import { defaultError, fields } from 'src/pages/UserSettings/labels'
+import { fields, form } from 'src/pages/UserSettings/labels'
 
 import type { IErrorsListSet, ITopLevelErrorsList } from 'src/common/Form/types'
 
@@ -7,7 +7,8 @@ const flattenErrors = (formErrors) => {
   const errors = {}
 
   Object.keys(formErrors).forEach((key) => {
-    if (typeof formErrors[key] !== 'string') return (errors[key] = defaultError)
+    if (typeof formErrors[key] !== 'string')
+      return (errors[key] = form.defaultError)
     errors[key] = formErrors[key]
   })
 

--- a/src/pages/UserSettings/labels.ts
+++ b/src/pages/UserSettings/labels.ts
@@ -9,6 +9,13 @@ export const buttons = {
     message: 'Are you sure you want to delete this link?',
     text: 'Delete',
   },
+  impact: {
+    create: 'Add data now',
+    edit: 'Edit data',
+    expandOpen: 'Expand and edit &#11107;',
+    expandClose: 'Close &#11105;',
+    save: 'Save impact data',
+  },
   guidelines: 'Check out our guidelines',
   link: {
     add: 'Add link',
@@ -20,8 +27,6 @@ export const buttons = {
   success: 'Profile saved successfully',
   submit: 'Submit',
 }
-
-export const defaultError = 'Make sure this field is filled correctly'
 
 export const fields: ILabels = {
   activities: {
@@ -60,6 +65,11 @@ export const fields: ILabels = {
   expertise: {
     description: 'Choose at least one expertise',
     title: 'What are you specialised in ?',
+  },
+  impact: {
+    description:
+      "Let's track our collective positive impact! Add data about your recycling work and show the world the power of a movement of small scale recyclers!",
+    title: 'Positive impact &#129305;',
   },
   links: {
     placeholder: 'Link',
@@ -110,6 +120,11 @@ export const fields: ILabels = {
   },
 }
 
+export const form = {
+  defaultError: 'Make sure this field is filled correctly',
+  saveSuccess: 'Yay! Impact data saved.',
+}
+
 export const headings = {
   accountSettings: 'Account settings',
   collection: 'Collection',
@@ -129,3 +144,5 @@ export const headings = {
     title: 'Your map pin',
   },
 }
+
+export const missingData = 'Do you have impact data for this year?'

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -12,6 +12,8 @@ import type {
   INotificationUpdate,
   IUser,
   IUserBadges,
+  IImpactYearFieldList,
+  IImpactYear,
 } from 'src/models/user.models'
 import type { IUserPP, IUserPPDB } from 'src/models/userPreciousPlastic.models'
 import type { IFirebaseUser } from 'src/utils/firebase'
@@ -271,6 +273,21 @@ export class UserStore extends ModuleStore {
       await this.mapsStore.setUserPin(updatedUserProfile)
     }
     this.setUpdateStatus('Complete')
+  }
+
+  @action
+  public async updateUserImpact(
+    fields: IImpactYearFieldList,
+    year: IImpactYear,
+  ) {
+    if (!this.user) {
+      throw new Error('User not found')
+    }
+
+    await this.db
+      .collection(COLLECTION_NAME)
+      .doc(this.user._id)
+      .update({ [`impact.${year}`]: fields })
   }
 
   public async unsubscribeUser(unsubscribeToken: string) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This adds a form to the workspace user settings page enabling users to create and update their impact data.

## Git Issues

Closes #3018 

## Screenshots/Videos


https://github.com/ONEARMY/community-platform/assets/16688508/59bbfac3-c7c3-4e6a-bf13-a4124c3869e2


