### PR TITLE
feat: user image resize

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,11 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "rewrites": [
       {
         "source": "/api",
@@ -86,7 +90,9 @@
     ]
   },
   "functions": {
-    "predeploy": ["yarn workspace functions build"],
+    "predeploy": [
+      "yarn workspace functions build"
+    ],
     "source": "functions/dist",
     "runtime": "nodejs20"
   },
@@ -121,6 +127,7 @@
     "rules": "firebase.storage.rules"
   },
   "extensions": {
-    "firestore-send-email": "firebase/firestore-send-email@0.1.27"
+    "firestore-send-email": "firebase/firestore-send-email@0.1.27",
+    "storage-resize-images": "firebase/storage-resize-images@0.2.2"
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,6 +2,7 @@ import { dailyTasks } from './scheduled/tasks'
 
 import * as Admin from './admin'
 import * as UserUpdates from './userUpdates'
+import { userPhotoResizeSuccess } from './userPhotoResizeEvent'
 
 // the following endpoints are exposed for use by various triggers
 // see individual files for more information
@@ -15,6 +16,8 @@ exports.aggregations = require('./aggregations')
 exports.database = require('./database')
 
 exports.userUpdates = UserUpdates.handleUserUpdates
+exports.userPhotoResizeSuccess = userPhotoResizeSuccess
+
 // CC Note, 2020-04-40
 // folder-based naming conventions should be encourage from now on
 exports.adminGetUserEmail = Admin.getUserEmail

--- a/functions/src/userPhotoResizeEvent/index.ts
+++ b/functions/src/userPhotoResizeEvent/index.ts
@@ -1,0 +1,16 @@
+import { onCustomEventPublished } from 'firebase-functions/v2/eventarc'
+import { getFirestore } from 'firebase-admin/firestore'
+
+export const userPhotoResizeSuccess = onCustomEventPublished(
+  {
+    eventType: 'firebase.extensions.storage-resize-images.v1.complete',
+  },
+  (event) => {
+    const userId = event.subject.split('users/')[1].split('/')[0]
+
+    return getFirestore()
+      .collection('users')
+      .doc(userId)
+      .update({ coverImages: [event.data.outputs[0].outputFilePath] })
+  },
+)


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Installs this extension https://extensions.dev/extensions/firebase/storage-resize-images to resize user images.
Created a cloud function that reacts on resize success and updates the user coverImages with the new image.

For deployment, need also to add the **storage-resize-images.env** file that would look something like this:

> ALLOWED_EVENT_TYPES=firebase.extensions.storage-resize-images.v1.onSuccess
> DELETE_ORIGINAL_FILE=false
> DO_BACKFILL=true
> EVENTARC_CHANNEL=projects/${param:PROJECT_ID}/locations/europe-west4/channels/firebase
> firebaseextensions.v1beta.function/location=europe-west3
> FUNCTION_MEMORY=512
> IMAGE_TYPE=jpeg,webp,png,tiff,gif,avif,false
> IMG_BUCKET=upload
> IMG_SIZES=120x120
> INCLUDE_PATH_LIST=/users
> IS_ANIMATED=true
> MAKE_PUBLIC=true

Notes about env file:
**INCLUDE_PATH_LIST** is the path inside the bucket to resize
**DO_BACKFILL=true** will also resize all existing images
**DELETE_ORIGINAL_FILE** could be useful if we don't want to store the original
Unsure how to deal with this file, should it be committed?

It's possible to extend this functionality to other images, but should be aware of this (taken from the extension docs):
_You can install multiple instances of this extension for the same project to configure different resizing options for different paths. However, all changes made to the specified Cloud Storage bucket. That means all instances will be triggered every time a file is uploaded to the bucket. Therefore, it is recommended to use different buckets instead of different paths to prevent unnecessary function calls._

## Git Issues

Closes #1589
