### PR TITLE
feat: hide member focus section if less than two activities

### DIFF
--- a/src/pages/UserSettings/content/formSections/Focus.section.test.tsx
+++ b/src/pages/UserSettings/content/formSections/Focus.section.test.tsx
@@ -1,0 +1,54 @@
+import { ThemeProvider } from '@emotion/react'
+import { render, screen } from '@testing-library/react'
+import { getSupportedProfileTypes } from 'src/modules/profile'
+import { FocusSection } from 'src/pages/UserSettings/content/formSections/Focus.section'
+import { headings } from 'src/pages/UserSettings/labels'
+import { SettingsProvider } from 'src/test/components'
+
+const supportedProfileTypes = getSupportedProfileTypes().map(
+  ({ label }) => label,
+)
+
+describe('Focus', () => {
+  it('render focus section if more than one activity available', async () => {
+    const badges = supportedProfileTypes.reduce(
+      (a, v) => ({
+        ...a,
+        [v]: {
+          lowDetail: '',
+          normal: '',
+        },
+      }),
+      {},
+    )
+
+    render(
+      <ThemeProvider theme={{ badges }}>
+        <SettingsProvider>
+          <FocusSection />
+        </SettingsProvider>
+      </ThemeProvider>,
+    )
+
+    expect(screen.queryByText(headings.focus)).toBeInTheDocument()
+  })
+
+  it('does not render focus section if less than two activities available', async () => {
+    const badges = {
+      [supportedProfileTypes[0]]: {
+        lowDetail: '',
+        normal: '',
+      },
+    }
+
+    render(
+      <ThemeProvider theme={{ badges }}>
+        <SettingsProvider>
+          <FocusSection />
+        </SettingsProvider>
+      </ThemeProvider>,
+    )
+
+    expect(screen.queryByText(headings.focus)).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/UserSettings/content/formSections/Focus.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Focus.section.tsx
@@ -17,6 +17,10 @@ const ProfileTypes = () => {
     Object.keys(theme.badges).includes(label),
   )
 
+  if (profileTypes.length < 2) {
+    return null
+  }
+
   return (
     <Field
       name="profileType"


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Feature: Improve display of member focus #3056

FocusSection component is hidden if user has less than two activities

## Git Issues

Closes #3056

## Screenshots/Videos

![Screenshot 2023-12-12 at 17 22 54](https://github.com/ONEARMY/community-platform/assets/76262712/99e23f40-3d0a-493c-8763-51c7ec3cd433)
![Screenshot 2023-12-12 at 17 23 10](https://github.com/ONEARMY/community-platform/assets/76262712/23c1afd9-1bb2-43ed-b4fc-43d2a55a4bfd)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
