### PR TITLE
Update messages on impact data display

### DIFF
--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -70,7 +70,7 @@ export interface IImpactDataField {
 
 export type IImpactYearFieldList = IImpactDataField[]
 
-export type IImpactYear = 2021 | 2022 | 2023
+export type IImpactYear = 2019 | 2021 | 2022 | 2023
 
 export interface IUserBadges {
   verified: boolean

--- a/src/pages/User/impact/Impact.test.tsx
+++ b/src/pages/User/impact/Impact.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'mobx-react'
 
 import { useCommonStores } from 'src/index'
 import { FactoryUser } from 'src/test/factories/User'
-import { missing } from './labels'
+import { invisible, missing } from './labels'
 import { IMPACT_YEARS } from './constants'
 import { Impact } from './Impact'
 
@@ -20,48 +20,86 @@ jest.mock('src/index', () => {
 })
 
 describe('Impact', () => {
-  it('renders all fields with data formatted correctly', async () => {
-    const impact = {
-      2022: [
-        {
-          id: 'plastic',
-          suffix: 'Kg of',
-          value: 23000,
-          isVisible: true,
-        },
-        {
-          id: 'volunteers',
-          value: 45,
-          isVisible: true,
-        },
-        {
-          id: 'revenue',
-          prefix: '$',
-          value: 54000,
-          isVisible: true,
-        },
-        {
-          id: 'machines',
-          value: 13,
-          isVisible: false,
-        },
-      ],
-    }
-    const user = FactoryUser({ impact })
+  describe('[public]', () => {
+    it('renders all fields with data formatted correctly', async () => {
+      const impact = {
+        2022: [
+          {
+            id: 'plastic',
+            value: 23000,
+            isVisible: true,
+          },
+          {
+            id: 'revenue',
+            value: 54000,
+            isVisible: true,
+          },
+          {
+            id: 'volunteers',
+            value: 45,
+            isVisible: true,
+          },
+          {
+            id: 'machines',
+            value: 13,
+            isVisible: false,
+          },
+        ],
+        2021: [
+          {
+            id: 'machines',
+            value: 8,
+            isVisible: false,
+          },
+        ],
+      }
 
-    render(
-      <Provider {...useCommonStores().stores}>
-        <Impact impact={impact} user={user} />
-      </Provider>,
-    )
+      render(
+        <Provider {...useCommonStores().stores}>
+          <Impact impact={impact} user={undefined} />
+        </Provider>,
+      )
 
-    await screen.findByText('45 volunteers')
-    await screen.findByText('23,000 Kg of plastic recycled')
-    await screen.findByText('$ 54,000 revenue')
-    const machineField = await screen.queryByText('13 machines built')
-    expect(machineField).toBe(null)
+      await screen.findByText('45 volunteers')
+      await screen.findByText('23,000 Kg of plastic recycled')
+      await screen.findByText('$ 54,000 revenue')
+      const machineField = await screen.queryByText('13 machines built')
+      expect(machineField).toBe(null)
 
-    await IMPACT_YEARS.forEach(async (year) => await screen.findByText(year))
-    await screen.findAllByText(missing.owner.label)
+      await IMPACT_YEARS.forEach(async (year) => await screen.findByText(year))
+      await screen.findAllByText(missing.user.label)
+      await screen.findAllByText(invisible.user.label)
+    })
+  })
+
+  describe('[page owner]', () => {
+    it('renders all fields with data formatted correctly', async () => {
+      const impact = {
+        2022: [
+          {
+            id: 'volunteers',
+            value: 45,
+            isVisible: true,
+          },
+        ],
+        2021: [
+          {
+            id: 'volunteers',
+            value: 45,
+            isVisible: false,
+          },
+        ],
+      }
+      const user = FactoryUser({ impact })
+
+      render(
+        <Provider {...useCommonStores().stores}>
+          <Impact impact={impact} user={user} />
+        </Provider>,
+      )
+
+      await screen.findAllByText(missing.owner.label)
+      await screen.findAllByText(invisible.owner.label)
+    })
   })
 })

--- a/src/pages/User/impact/Impact.tsx
+++ b/src/pages/User/impact/Impact.tsx
@@ -7,7 +7,7 @@ import type { IUserImpact, IUserPP } from 'src/models'
 
 interface Props {
   impact: IUserImpact
-  user: IUserPP
+  user: IUserPP | undefined
 }
 
 export const Impact = ({ impact, user }: Props) => {

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -8,7 +8,7 @@ import type { IImpactYearFieldList, IImpactYear, IUserPP } from 'src/models'
 interface Props {
   year: IImpactYear
   fields: IImpactYearFieldList | undefined
-  user: IUserPP
+  user: IUserPP | undefined
 }
 
 export const ImpactItem = ({ fields, user, year }: Props) => {
@@ -24,16 +24,23 @@ export const ImpactItem = ({ fields, user, year }: Props) => {
     padding: 2,
   }
 
+  const visibleFields = fields?.filter((field) => field.isVisible)
+
   return (
     <Box sx={outterBox} cy-data="ImpactItem">
       <Box sx={innerBox}>
         <Heading variant="small">{year}</Heading>
-        {fields ? (
-          fields.map((field, index) => {
+        {visibleFields && visibleFields.length > 0 ? (
+          visibleFields.map((field, index) => {
             return <ImpactField field={field} key={index} />
           })
         ) : (
-          <ImpactMissing year={year} user={user} />
+          <ImpactMissing
+            fields={fields}
+            user={user}
+            visibleFields={visibleFields}
+            year={year}
+          />
         )}
       </Box>
     </Box>

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -3,23 +3,41 @@ import { Button, ExternalLink } from 'oa-components'
 import { Flex, Text } from 'theme-ui'
 
 import { useCommonStores } from 'src/'
-import { missing } from './labels'
+import { invisible, missing } from './labels'
 import { IMPACT_REPORT_LINKS } from './constants'
 
-import type { IImpactYear, IUserPP } from 'src/models'
+import type { IImpactYear, IImpactYearFieldList, IUserPP } from 'src/models'
 
 interface Props {
+  fields: IImpactYearFieldList | undefined
+  user: IUserPP | undefined
+  visibleFields: IImpactYearFieldList | undefined
   year: IImpactYear
-  user: IUserPP
 }
 
-export const ImpactMissing = observer(({ user, year }: Props) => {
+const isAllInvisible = (fields, visibleFields) => {
+  if (
+    visibleFields &&
+    visibleFields.length === 0 &&
+    fields &&
+    fields.length > 0
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export const ImpactMissing = observer((props: Props) => {
+  const { fields, user, visibleFields, year } = props
   const { userStore } = useCommonStores().stores
+
+  const labelSet = isAllInvisible(fields, visibleFields) ? invisible : missing
 
   const isPageOwner = userStore.activeUser && user
 
-  const userButton = `${year} ${missing.user.link}`
-  const label = isPageOwner ? missing.owner.label : missing.user.label
+  const userButton = `${year} ${labelSet.user.link}`
+  const label = isPageOwner ? labelSet.owner.label : labelSet.user.label
 
   return (
     <Flex sx={{ flexFlow: 'column', gap: 2, mt: 2 }}>
@@ -31,7 +49,7 @@ export const ImpactMissing = observer(({ user, year }: Props) => {
       )}
       {isPageOwner && (
         <a href="/settings">
-          <Button>{missing.owner.link}</Button>
+          <Button>{labelSet.owner.link}</Button>
         </a>
       )}
     </Flex>

--- a/src/pages/User/impact/constants.ts
+++ b/src/pages/User/impact/constants.ts
@@ -1,9 +1,10 @@
 import type { IImpactYear } from 'src/models'
 
 export const IMPACT_REPORT_LINKS = {
-  2023: 'http://preciousplastic.com/impact/2023.html',
-  2022: '',
-  2021: '',
+  2023: 'https://www.preciousplastic.com/impact/2023',
+  2022: 'https://www.preciousplastic.com/impact',
+  2021: 'https://www.preciousplastic.com/impact',
+  2019: 'https://www.preciousplastic.com/impact',
 }
 
-export const IMPACT_YEARS: IImpactYear[] = [2023, 2022, 2021]
+export const IMPACT_YEARS: IImpactYear[] = [2023, 2022, 2021, 2019]

--- a/src/pages/User/impact/labels.ts
+++ b/src/pages/User/impact/labels.ts
@@ -1,5 +1,17 @@
 export const heading = 'Impact'
 
+export const invisible = {
+  user: {
+    label:
+      "Their data is part of the global impact report (but they'd rather keep the specifics private).",
+    link: 'Impact Report',
+  },
+  owner: {
+    label: "You've set all your data for this year to be private.",
+    link: 'Update impact data',
+  },
+}
+
 export const missing = {
   user: {
     label:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This ensures that if:
1. A user adds impact data but chooses to hide all the fields, an appropriate message displays.
2. A user adds impact data and then deletes it, the missing data message displays.

## Screenshots/Videos

<img width="476" alt="Screenshot 2023-12-13 at 16 20 52" src="https://github.com/ONEARMY/community-platform/assets/16688508/572244d3-4a97-4da8-9795-76781b03c763">
<img width="476" alt="Screenshot 2023-12-13 at 16 20 10" src="https://github.com/ONEARMY/community-platform/assets/16688508/1c1d1614-a861-457b-b1ed-f8aca3b20159">



