### PR TITLE
feat: change to save only minimal impact fields

### DIFF
--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -97,25 +97,22 @@ describe('[Settings]', () => {
       impact: {
         2022: [
           {
-            label: 'plastic recycled',
+            id: 'plastic',
             value: 43000,
-            suffix: 'Kg of',
             isVisible: true,
           },
           {
-            label: 'revenue',
+            id: 'revenue',
             value: 100000,
-            prefix: '$',
-            suffix: 'in',
             isVisible: false,
           },
           {
-            label: 'full time employees',
+            id: 'employees',
             value: 3,
             isVisible: true,
           },
           {
-            label: 'volunteers',
+            id: 'volunteers',
             value: 45,
             isVisible: false,
           },
@@ -191,7 +188,7 @@ describe('[Settings]', () => {
         .clear()
         .type('100000')
       cy.get('[data-cy="impactForm-2022-field-revenue-isVisible"]').click()
-      cy.get('[data-cy="impactForm-2022-field-machines built-value"]').clear()
+      cy.get('[data-cy="impactForm-2022-field-machines-value"]').clear()
       cy.get('[data-cy="impactForm-2022-button-save"]').click()
       cy.contains(form.saveSuccess)
 

--- a/shared/mocks/data/users.ts
+++ b/shared/mocks/data/users.ts
@@ -307,30 +307,27 @@ export const users = {
     impact: {
       2022: [
         {
-          label: 'plastic recycled',
+          id: 'plastic',
           value: 43000,
-          suffix: 'Kg of',
           isVisible: true,
         },
         {
-          label: 'revenue',
+          id: 'revenue',
           value: 36000,
-          prefix: '$',
-          suffix: 'in',
           isVisible: true,
         },
         {
-          label: 'full time employees',
+          id: 'employees',
           value: 3,
           isVisible: true,
         },
         {
-          label: 'volunteers',
+          id: 'volunteers',
           value: 45,
           isVisible: false,
         },
         {
-          label: 'machines built',
+          id: 'machines',
           value: 2,
           isVisible: true,
         },

--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -63,10 +63,8 @@ export interface IUserImpact {
 }
 
 export interface IImpactDataField {
-  label: string
+  id: string
   value: number
-  prefix?: string
-  suffix?: string
   isVisible: boolean
 }
 

--- a/src/pages/User/impact/Impact.test.tsx
+++ b/src/pages/User/impact/Impact.test.tsx
@@ -24,24 +24,24 @@ describe('Impact', () => {
     const impact = {
       2022: [
         {
-          label: 'volunteers',
-          value: 45,
-          isVisible: true,
-        },
-        {
-          label: 'plastic recycled',
+          id: 'plastic',
           suffix: 'Kg of',
           value: 23000,
           isVisible: true,
         },
         {
-          label: 'revenue',
+          id: 'volunteers',
+          value: 45,
+          isVisible: true,
+        },
+        {
+          id: 'revenue',
           prefix: '$',
           value: 54000,
           isVisible: true,
         },
         {
-          label: 'machines built',
+          id: 'machines',
           value: 13,
           isVisible: false,
         },

--- a/src/pages/User/impact/ImpactEmoji.tsx
+++ b/src/pages/User/impact/ImpactEmoji.tsx
@@ -1,25 +1,18 @@
 import type { IImpactDataField } from 'src/models'
+import { impactQuestions } from 'src/pages/UserSettings/content/formSections/Impact/impactQuestions'
 
 interface Props {
-  label: IImpactDataField['label']
+  id: IImpactDataField['id']
 }
 
-const EMOJI_MAP = {
-  'full time employees': '&#x1f46f',
-  'machines built': '&#x2699;&#xfe0f;',
-  'plastic recycled': '&#x1f52b',
-  revenue: '&#x1f4b8',
-  volunteers: '&#x1f3c5',
-}
+export const ImpactEmoji = ({ id }: Props) => {
+  const question = impactQuestions.find((question) => question.id === id)
 
-export const ImpactEmoji = ({ label }: Props) => {
-  const emoji = EMOJI_MAP[label]
-
-  if (!emoji) return null
+  if (!question || !question.emoji) return null
 
   return (
     <div
-      dangerouslySetInnerHTML={{ __html: emoji }}
+      dangerouslySetInnerHTML={{ __html: question.emoji }}
       style={{ display: 'inline' }}
     />
   )

--- a/src/pages/User/impact/ImpactField.test.tsx
+++ b/src/pages/User/impact/ImpactField.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+
+import { ImpactField } from './ImpactField'
+
+describe('ImpactField', () => {
+  it('renders field with expected question data', async () => {
+    const field = {
+      id: 'plastic',
+      value: 23000,
+      isVisible: true,
+    }
+
+    render(<ImpactField field={field} />)
+
+    await screen.findByText('23,000 Kg of plastic recycled')
+  })
+
+  it('renders nothing when field is not set to be visible', async () => {
+    const field = {
+      id: 'plastic',
+      value: 3,
+      isVisible: false,
+    }
+
+    const { container } = render(<ImpactField field={field} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it("renders nothing when field isn't found in question data", async () => {
+    const field = {
+      id: 'nothing',
+      value: 3,
+      isVisible: true,
+    }
+
+    const { container } = render(<ImpactField field={field} />)
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/src/pages/User/impact/ImpactField.tsx
+++ b/src/pages/User/impact/ImpactField.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'theme-ui'
 
 import { numberWithCommas } from 'src/utils/helpers'
+import { impactQuestions } from 'src/pages/UserSettings/content/formSections/Impact/impactQuestions'
 import { ImpactEmoji } from './ImpactEmoji'
 
 import type { IImpactDataField } from 'src/models'
@@ -10,7 +11,10 @@ interface Props {
 }
 
 export const ImpactField = ({ field }: Props) => {
-  const { label, prefix, suffix, value } = field
+  const { id, isVisible, value } = field
+
+  const impactQuestion = impactQuestions.find((question) => question.id === id)
+  if (!impactQuestion || !isVisible) return null
 
   const sx = {
     backgroundColor: 'background',
@@ -19,14 +23,15 @@ export const ImpactField = ({ field }: Props) => {
     mt: 2,
   }
 
-  const text = `${prefix ? prefix : ''} ${numberWithCommas(value)} ${
-    suffix ? suffix : ''
-  } ${label}`
+  const prefix = impactQuestion?.prefix || ''
+  const suffix = impactQuestion?.suffix || ''
+  const label = impactQuestion.label
+  const text = `${prefix} ${numberWithCommas(value)} ${suffix} ${label}`
 
   return (
     <Box sx={sx}>
       <Text variant="label">
-        <ImpactEmoji label={label} /> {text}
+        <ImpactEmoji id={id} /> {text}
       </Text>
     </Box>
   )

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -24,14 +24,12 @@ export const ImpactItem = ({ fields, user, year }: Props) => {
     padding: 2,
   }
 
-  const visibleFields = fields?.filter((field) => field.isVisible)
-
   return (
     <Box sx={outterBox} cy-data="ImpactItem">
       <Box sx={innerBox}>
         <Heading variant="small">{year}</Heading>
-        {visibleFields ? (
-          visibleFields.map((field, index) => {
+        {fields ? (
+          fields.map((field, index) => {
             return <ImpactField field={field} key={index} />
           })
         ) : (

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactQuestion.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactQuestion.field.tsx
@@ -5,17 +5,17 @@ import { Field } from 'react-final-form'
 import type { IImpactQuestion } from './impactQuestions'
 
 interface Props {
-  id: string
+  formId: string
   field: IImpactQuestion
 }
 
-export const ImpactQuestionField = ({ id, field }: Props) => {
+export const ImpactQuestionField = ({ field, formId }: Props) => {
   const initialValue =
     typeof field.isVisible === 'boolean' ? field.isVisible : true
 
   return (
     <Box sx={{ marginBottom: 3 }}>
-      <Label htmlFor={`${field.label}.value`} sx={{ marginBottom: 1 }}>
+      <Label htmlFor={`${field.id}.value`} sx={{ marginBottom: 1 }}>
         {field.description}
       </Label>
       <Flex
@@ -42,8 +42,8 @@ export const ImpactQuestionField = ({ id, field }: Props) => {
           <Box>
             <Field
               component={FieldInput}
-              data-cy={`${id}-field-${field.label}-value`}
-              name={`${field.label}.value`}
+              data-cy={`${formId}-field-${field.id}-value`}
+              name={`${field.id}.value`}
               sx={{ background: 'white' }}
               type="number"
             />
@@ -64,9 +64,9 @@ export const ImpactQuestionField = ({ id, field }: Props) => {
           <Icon glyph="show" size={24} />
           <Field
             component="input"
-            data-cy={`${id}-field-${field.label}-isVisible`}
+            data-cy={`${formId}-field-${field.id}-isVisible`}
             initialValue={initialValue}
-            name={`${field.label}.isVisible`}
+            name={`${field.id}.isVisible`}
             type="checkbox"
           />
         </Flex>

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.field.tsx
@@ -5,26 +5,26 @@ import { ImpactQuestionField } from './ImpactQuestion.field'
 import { impactQuestions } from './impactQuestions'
 
 interface Props {
-  id: string
+  formId: string
   handleSubmit: () => void
   submitting: boolean
 }
 
 export const ImpactYearField = (props: Props) => {
-  const { id, handleSubmit, submitting } = props
+  const { formId, handleSubmit, submitting } = props
 
   return (
     <>
       {impactQuestions.map((field, index) => (
-        <ImpactQuestionField id={id} field={field} key={index} />
+        <ImpactQuestionField field={field} formId={formId} key={index} />
       ))}
 
       <Button
-        data-cy={`${id}-button-save`}
+        data-cy={`${formId}-button-save`}
         disabled={submitting}
         type="submit"
         onClick={handleSubmit}
-        form={id}
+        form={formId}
       >
         {buttons.impact.save}
       </Button>

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
@@ -35,7 +35,7 @@ export const ImpactYearSection = observer(({ year }: Props) => {
   }, [])
 
   const { userStore } = useCommonStores().stores
-  const id = `impactForm-${year}`
+  const formId = `impactForm-${year}`
 
   const sx = {
     backgroundColor: 'background',
@@ -65,20 +65,20 @@ export const ImpactYearSection = observer(({ year }: Props) => {
       <UserContactError submitResults={submitResults} />
 
       <Form
-        onSubmit={onSubmit}
-        id={id}
+        id={formId}
         initialValues={impact ? transformImpactData(impact) : undefined}
+        onSubmit={onSubmit}
         render={({ handleSubmit, values, submitting }) => {
           return isEditMode ? (
             <ImpactYearField
-              id={id}
+              formId={formId}
               handleSubmit={handleSubmit}
               submitting={submitting}
             />
           ) : (
             <ImpactYearDisplayField
               fields={transformImpactInputs(values)}
-              id={id}
+              formId={formId}
               setIsEditMode={setIsEditMode}
             />
           )

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYearDisplay.field.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYearDisplay.field.tsx
@@ -9,12 +9,12 @@ import type { IImpactYearFieldList } from 'src/models'
 
 interface Props {
   fields: IImpactYearFieldList | undefined
-  id: string
+  formId: string
   setIsEditMode: (boolean) => void
 }
 
 export const ImpactYearDisplayField = observer((props: Props) => {
-  const { fields, id, setIsEditMode } = props
+  const { fields, formId, setIsEditMode } = props
   const { create, edit } = buttons.impact
 
   const buttonLabel = fields ? edit : create
@@ -33,7 +33,7 @@ export const ImpactYearDisplayField = observer((props: Props) => {
                   justifyContent: 'space-between',
                 }}
               >
-                <ImpactField field={field} />
+                <ImpactField field={{ ...field, isVisible: true }} />
                 <Icon glyph={glyph} size={24} />
               </Flex>
             </Box>
@@ -43,7 +43,7 @@ export const ImpactYearDisplayField = observer((props: Props) => {
         <Text>{missingData}</Text>
       )}
       <Button
-        data-cy={`${id}-button-edit`}
+        data-cy={`${formId}-button-edit`}
         onClick={() => setIsEditMode(true)}
         sx={{ marginTop: 3 }}
       >

--- a/src/pages/UserSettings/content/formSections/Impact/impactQuestions.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/impactQuestions.ts
@@ -1,4 +1,6 @@
 export interface IImpactQuestion {
+  id: string
+  emoji: string
   description: string
   label: string
   isVisible: boolean
@@ -9,6 +11,8 @@ export interface IImpactQuestion {
 
 export const impactQuestions: IImpactQuestion[] = [
   {
+    id: 'plastic',
+    emoji: '&#x1f52b',
     description:
       'How many KGs of plastic recycled have you recycled in that year?',
     label: 'plastic recycled',
@@ -16,6 +20,8 @@ export const impactQuestions: IImpactQuestion[] = [
     isVisible: true,
   },
   {
+    id: 'revenue',
+    emoji: '&#x1f4b8',
     description:
       'What was your revenue (in $)? By revenue we mean all money coming in.',
     label: 'revenue',
@@ -23,16 +29,22 @@ export const impactQuestions: IImpactQuestion[] = [
     isVisible: true,
   },
   {
+    id: 'employees',
+    emoji: '&#x1f46f',
     description: 'How many people did your project employ (you included)?',
     label: 'full time employees',
     isVisible: true,
   },
   {
+    id: 'volunteers',
+    emoji: '&#x1f3c5',
     description: 'How many volunteers did you work with?',
     label: 'volunteers',
     isVisible: true,
   },
   {
+    id: 'machines',
+    emoji: '&#x2699;&#xfe0f;',
     description: 'How many machines did you build?',
     label: 'machines built',
     isVisible: true,

--- a/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
@@ -7,46 +7,44 @@ describe('transformImpactData', () => {
 
     const impactFields = [
       {
-        description,
-        label: 'revenue',
-        prefix: '$',
+        id: 'revenue',
         value: 75000,
-        isVisible: true,
+        isVisible: false,
       },
     ]
     const expected = {
       revenue: {
+        id: 'revenue',
         description,
+        emoji: '&#x1f4b8',
         label: 'revenue',
         prefix: '$',
         value: 75000,
-        isVisible: true,
+        isVisible: false,
       },
     }
     expect(transformImpactData(impactFields)).toEqual(expected)
   })
 })
 
-describe('transformImpactData', () => {
+describe('transformImpactInputs', () => {
   it('returns data structured as impact data', () => {
-    const description =
-      'What was your revenue (in $)? By revenue we mean all money coming in.'
+    const description = 'How many machines did you build?'
 
     const inputFields = {
-      revenue: {
+      machines: {
+        id: 'machines',
         description,
-        label: 'revenue',
-        prefix: '$',
-        value: 75000,
+        label: 'machines built',
+        value: 20,
         isVisible: true,
       },
     }
 
     const expected = [
       {
-        label: 'revenue',
-        prefix: '$',
-        value: 75000,
+        id: 'machines',
+        value: 20,
         isVisible: true,
       },
     ]

--- a/src/pages/UserSettings/content/formSections/Impact/utils.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.ts
@@ -18,11 +18,11 @@ export const transformImpactData = (
 
   Object.values(fields).forEach((field) => {
     const questionField = impactQuestions.find(
-      (question) => question.label === field.label,
+      (question) => question.id === field.id,
     )
-    return (transformed[field.label] = {
+    return (transformed[field.id] = {
+      ...questionField,
       ...field,
-      description: questionField?.description,
     } as IImpactQuestion)
   })
 
@@ -36,15 +36,14 @@ export const transformImpactInputs = (
 
   Object.keys(inputs).forEach((key) => {
     const field = inputs[key]
-    const question = impactQuestions.find(({ label }) => label === key)
+    const question = impactQuestions.find(({ id }) => id === key)
+
     if (field && question && field.value) {
       fields.push({
-        label: key,
+        id: question.id,
         value: field.value,
         isVisible:
           typeof field.isVisible === 'boolean' ? field.isVisible : true,
-        ...(question.prefix && { prefix: question.prefix }),
-        ...(question.suffix && { suffix: question.suffix }),
       })
     }
   })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Previously, fields for impact data was being stored that was about presentation only and thus wrongly tied presentation to stored data (like a label) that might easily need changing. 
