### PR TITLE
chore: refactor remove use of hooks in ModuleStore class

### DIFF
--- a/src/pages/Question/index.tsx
+++ b/src/pages/Question/index.tsx
@@ -5,10 +5,12 @@ import {
   QuestionStore,
   QuestionStoreContext,
 } from 'src/stores/Question/question.store'
+import { useCommonStores } from '../../index'
 
 export const QuestionModuleContainer = () => {
+  const rootStore = useCommonStores()
   return (
-    <QuestionStoreContext.Provider value={new QuestionStore()}>
+    <QuestionStoreContext.Provider value={new QuestionStore(rootStore)}>
       <QuestionRoutes />
     </QuestionStoreContext.Provider>
   )

--- a/src/pages/Research/index.tsx
+++ b/src/pages/Research/index.tsx
@@ -5,13 +5,15 @@ import {
 } from 'src/stores/Research/research.store'
 import type { IPageMeta } from '../PageList'
 import ResearchRoutes from './research.routes'
+import { useCommonStores } from '../../index'
 
 /**
  * Wraps the research module routing elements with the research module provider
  */
 const ResearchModuleContainer = () => {
+  const rootStore = useCommonStores()
   return (
-    <ResearchStoreContext.Provider value={new ResearchStore()}>
+    <ResearchStoreContext.Provider value={new ResearchStore(rootStore)}>
       <ResearchRoutes />
     </ResearchStoreContext.Provider>
   )

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -1,6 +1,5 @@
 import isUrl from 'is-url'
 import { BehaviorSubject, Subscription } from 'rxjs'
-import { useCommonStores } from 'src/index'
 import { logger } from 'src/logger'
 import { includesAll } from 'src/utils/filters'
 import { stripSpecialCharacters } from 'src/utils/helpers'
@@ -56,9 +55,11 @@ export class ModuleStore {
     return value ? (isUrl(value) ? undefined : 'Invalid url') : 'Required'
   }
   // this can be subscribed to in individual stores
-  constructor(private rootStore?: RootStore, private basePath?: IDBEndpoint) {
-    if (!rootStore) {
-      this.rootStore = useCommonStores()
+  constructor(private rootStore: RootStore, private basePath?: IDBEndpoint) {
+    this.rootStore = rootStore
+
+    if (!this.rootStore) {
+      throw new Error('Root store is required')
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

As part of adopting https://www.npmjs.com/package/eslint-plugin-react-hooks in https://github.com/ONEARMY/community-platform/pull/3105, I am merging a subset of fixes declared here:
https://app.circleci.com/pipelines/github/ONEARMY/community-platform/7387/workflows/c97aaa26-c1bd-4640-92ff-419d76beee96/jobs/62234


> The react-hooks/exhaustive-deps rule in the ESLint plugin is beneficial as it ensures that all dependencies of React hooks like useEffect, useMemo, and useCallback are correctly specified. This rule helps prevent bugs related to missing dependencies, which can cause unexpected behavior in React components. By enforcing a comprehensive check on the dependencies array, it aids in maintaining the functional integrity and performance of React components, ensuring that they update correctly in response to state or prop changes.
> For more detailed information, you can refer to the [ESLint documentation on the npmjs.com page](https://www.npmjs.com/package/eslint-plugin-react-hooks).