### PR TITLE
feat: restructure comment header

### DIFF
--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -1,11 +1,14 @@
 import { createRef, useEffect, useState } from 'react'
 import { Box, Flex, Text } from 'theme-ui'
+
 import { Button } from '../Button/Button'
 import { ConfirmModal } from '../ConfirmModal/ConfirmModal'
 import { EditComment } from '../EditComment/EditComment'
 import { LinkifyText } from '../LinkifyText/LinkifyText'
 import { Modal } from '../Modal/Modal'
 import { Username } from '../Username/Username'
+
+const SHORT_COMMENT = 129
 
 export interface CommentItemProps {
   text: string
@@ -48,6 +51,9 @@ export const CommentItem = (props: CommentItemProps) => {
     isEditable,
   } = props
 
+  const date = formatDate(_edited || _created)
+  const maxHeight = isShowMore ? 'max-content' : '128px'
+
   useEffect(() => {
     if (textRef.current) {
       setTextHeight(textRef.current.scrollHeight)
@@ -68,52 +74,84 @@ export const CommentItem = (props: CommentItemProps) => {
   return (
     <Box id={`comment:${_id}`} data-cy="comment">
       <Flex
-        p="3"
-        bg={'white'}
+        bg="white"
         sx={{
-          width: '100%',
+          borderRadius: 1,
           flexDirection: 'column',
-          borderRadius: '5px',
+          padding: 3,
         }}
       >
-        <Flex sx={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
-          <Username
-            user={{
-              userName: creatorName,
-              countryCode: creatorCountry,
-            }}
-            isVerified={!!isUserVerified}
-          />
-          <Flex sx={{ alignItems: 'center' }}>
-            <>
-              {_edited && (
-                <Text sx={{ fontSize: 0, color: 'grey' }} mr={2}>
-                  (Edited)
-                </Text>
-              )}
-              <Text sx={{ fontSize: 1 }}>
-                {formatDate(_edited || _created)}
-              </Text>
-            </>
+        <Flex
+          sx={{
+            alignItems: 'stretch',
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-start',
+          }}
+        >
+          <Flex sx={{ alignItems: 'baseline', gap: 2 }}>
+            <Username
+              user={{
+                userName: creatorName,
+                countryCode: creatorCountry,
+              }}
+              isVerified={!!isUserVerified}
+            />
+            {_edited && (
+              <Text sx={{ fontSize: 0, color: 'grey' }}>(Edited)</Text>
+            )}
+            <Text sx={{ fontSize: 1 }}>{date}</Text>
           </Flex>
+
+          {isEditable && (
+            <Flex
+              sx={{
+                flexGrow: 1,
+                gap: 2,
+                justifyContent: ['flex-start', 'flex-start', 'flex-end'],
+                opacity: 0.5,
+                width: ['100%', 'auto'],
+                ':hover': { opacity: 1 },
+              }}
+            >
+              <Button
+                data-cy="CommentItem: edit button"
+                variant="outline"
+                small={true}
+                icon="edit"
+                onClick={() => onEditRequest(_id)}
+              >
+                edit
+              </Button>
+              <Button
+                data-cy="CommentItem: delete button"
+                variant={'outline'}
+                small={true}
+                icon="delete"
+                onClick={() => setShowDeleteModal(true)}
+              >
+                delete
+              </Button>
+            </Flex>
+          )}
         </Flex>
         <Text
           data-cy="comment-text"
           mt={2}
           mb={2}
           sx={{
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            overflow: 'hidden',
-            maxHeight: isShowMore ? 'max-content' : '128px',
             fontFamily: 'body',
             lineHeight: 1.3,
+            maxHeight,
+            overflow: 'hidden',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
           }}
           ref={textRef}
         >
           <LinkifyText>{text}</LinkifyText>
         </Text>
-        {textHeight > 129 && (
+        {textHeight > SHORT_COMMENT && (
           <a
             onClick={showMore}
             style={{
@@ -125,31 +163,6 @@ export const CommentItem = (props: CommentItemProps) => {
             {isShowMore ? 'Show less' : 'Show more'}
           </a>
         )}
-        <Flex ml="auto">
-          {isEditable && (
-            <>
-              <Button
-                data-cy="CommentItem: edit button"
-                variant={'outline'}
-                small={true}
-                icon={'edit'}
-                onClick={() => onEditRequest(_id)}
-              >
-                edit
-              </Button>
-              <Button
-                data-cy="CommentItem: delete button"
-                variant={'outline'}
-                small={true}
-                icon="delete"
-                onClick={() => setShowDeleteModal(true)}
-                ml={2}
-              >
-                delete
-              </Button>
-            </>
-          )}
-        </Flex>
 
         <Modal width={600} isOpen={showEditModal}>
           <EditComment


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This is a very small but valuable change to move around the comment header area (and a little tidying). Moves the edit/delete actions to the top right and the date/edit info to the top left next to the username. A part of the updated comments design. 


## Screenshots/Videos
<img width="832" alt="Screenshot 2023-12-29 at 16 45 07" src="https://github.com/ONEARMY/community-platform/assets/16688508/8f264092-2548-41fb-93f6-140b421ef3ee">

<img width="832" alt="Screenshot 2023-12-29 at 16 47 05" src="https://github.com/ONEARMY/community-platform/assets/16688508/cd123f09-a578-4b2e-a199-89e2d788191f">


