### PR TITLE
fix: logic for showing page owner impact info

### DIFF
--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -81,7 +81,7 @@ describe('[Profile]', () => {
       cy.visit(`/u/${userProfiletype.userName}`)
       cy.get('[data-cy=ImpactTab]').click()
       cy.get('[data-cy=ImpactPanel]').should('exist')
-      cy.contains(missing.owner.label)
+      cy.contains(missing.user.label)
       cy.contains('2021')
       cy.contains('3 full time employees')
     })

--- a/src/pages/User/impact/Impact.test.tsx
+++ b/src/pages/User/impact/Impact.test.tsx
@@ -12,7 +12,7 @@ jest.mock('src/index', () => {
     useCommonStores: () => ({
       stores: {
         userStore: {
-          activeUser: jest.fn(),
+          activeUser: { userName: 'activeUser' },
         },
       },
     }),
@@ -93,7 +93,7 @@ describe('Impact', () => {
           },
         ],
       }
-      const user = FactoryUser({ impact })
+      const user = FactoryUser({ impact, userName: 'activeUser' })
 
       render(
         <Provider {...useCommonStores().stores}>

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -30,11 +30,10 @@ const isAllInvisible = (fields, visibleFields) => {
 }
 
 const isPageOwnerCheck = (activeUser, user) => {
-  if (activeUser && user && toJS(activeUser).userName === user.userName) {
-    return true
-  }
+  const usersPresent = activeUser && user
+  const usersTheSame = toJS(activeUser)?.userName === user?.userName
 
-  return false
+  return usersPresent && usersTheSame ? true : false
 }
 
 export const ImpactMissing = observer((props: Props) => {

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -1,3 +1,4 @@
+import { toJS } from 'mobx'
 import { observer } from 'mobx-react'
 import { Button, ExternalLink } from 'oa-components'
 import { useCommonStores } from 'src/index'
@@ -28,13 +29,21 @@ const isAllInvisible = (fields, visibleFields) => {
   return false
 }
 
+const isPageOwnerCheck = (activeUser, user) => {
+  if (activeUser && user && toJS(activeUser).userName === user.userName) {
+    return true
+  }
+
+  return false
+}
+
 export const ImpactMissing = observer((props: Props) => {
   const { fields, user, visibleFields, year } = props
   const { userStore } = useCommonStores().stores
 
   const labelSet = isAllInvisible(fields, visibleFields) ? invisible : missing
 
-  const isPageOwner = userStore.activeUser && user
+  const isPageOwner = isPageOwnerCheck(userStore.activeUser, user)
 
   const userButton = `${year} ${labelSet.user.link}`
   const label = isPageOwner ? labelSet.owner.label : labelSet.user.label


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Previously, users were seeing the 'edit your impact' information on other users profile pages when they should have just got the 'see all the impact data' information. 
