### PR TITLE
fix: handle misconfigured `REACT_APP_CDN_URL` param

### DIFF
--- a/packages/documentation/docs/Install.md
+++ b/packages/documentation/docs/Install.md
@@ -47,7 +47,7 @@ You will need to set up a CircleCI context for each target environment. This con
 - `REACT_APP_FIREBASE_STORAGE_BUCKET`
 - `REACT_APP_GA_TRACKING_ID`
 - `REACT_APP_PLATFORM_THEME`
-- `REACT_APP_CDN_URL` - `https://cdn-url.com` - this is the URL to the CDN where the assets are stored. This is used to load the assets from the CDN instead of the local server. It should **not** include a trailing slash. 
+- `REACT_APP_CDN_URL` - `https://cdn-url.com` - this is the URL to the CDN where the assets are stored. This is used to load the assets from the CDN instead of the local server. It should **not** include a trailing slash.
 - `REACT_APP_PLATFORM_PROFILES` - comma separated list of available profiles. Use `ProfileType` from modules/profile/index for guidance here. For example: `member,workspace`
 - `REACT_APP_SUPPORTED_MODULES` – comma separated list of available modules. See `/src/modules/index.ts` for the definitions.
 - `SITE_NAME`

--- a/packages/documentation/docs/Install.md
+++ b/packages/documentation/docs/Install.md
@@ -47,6 +47,7 @@ You will need to set up a CircleCI context for each target environment. This con
 - `REACT_APP_FIREBASE_STORAGE_BUCKET`
 - `REACT_APP_GA_TRACKING_ID`
 - `REACT_APP_PLATFORM_THEME`
+- `REACT_APP_CDN_URL` - `https://cdn-url.com` - this is the URL to the CDN where the assets are stored. This is used to load the assets from the CDN instead of the local server. It should **not** include a trailing slash. 
 - `REACT_APP_PLATFORM_PROFILES` - comma separated list of available profiles. Use `ProfileType` from modules/profile/index for guidance here. For example: `member,workspace`
 - `REACT_APP_SUPPORTED_MODULES` – comma separated list of available modules. See `/src/modules/index.ts` for the definitions.
 - `SITE_NAME`

--- a/src/utils/cdnImageUrl.test.ts
+++ b/src/utils/cdnImageUrl.test.ts
@@ -5,11 +5,27 @@ describe('cdnImageUrl', () => {
     jest.resetModules()
   })
 
-  it('should return well formed URL if trailing slash included', () => {
+  it('should ignore invalid URL', () => {
     // Mocking empty CDN_URL
     jest.doMock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
-      CDN_URL: 'https://cdn-url.com/',
+      CDN_URL: 'xsmasa.masas--',
+    }))
+
+    const { cdnImageUrl } = require('src/utils/cdnImageUrl')
+    const originalUrl =
+      'https://firebasestorage.googleapis.com/v0/b/some-bucket/image.jpg'
+
+    expect(cdnImageUrl(originalUrl)).toBe(originalUrl)
+  })
+
+  it('should return well formed URL if input is poorly formatted', () => {
+    // Mocking empty CDN_URL
+    jest.doMock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
+      FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
+      CDN_URL: ' https://cdn-url.com/ ',
     }))
 
     const { cdnImageUrl } = require('src/utils/cdnImageUrl')
@@ -22,6 +38,7 @@ describe('cdnImageUrl', () => {
   it('should return the original URL if CDN_URL or FIREBASE_CONFIG.storageBucket is not set', () => {
     // Mocking empty CDN_URL
     jest.doMock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
       CDN_URL: '',
     }))
@@ -35,6 +52,7 @@ describe('cdnImageUrl', () => {
 
   it('should replace the Firebase storage URL with CDN_URL', () => {
     jest.mock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
       CDN_URL: 'https://cdn-url.com',
     }))
@@ -50,6 +68,7 @@ describe('cdnImageUrl', () => {
 
   it('should handle resize params and existing query params', () => {
     jest.mock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
       CDN_URL: 'https://cdn-url.com',
     }))
@@ -68,6 +87,7 @@ describe('cdnImageUrl', () => {
 
   it('should handle resize params', () => {
     jest.mock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
       CDN_URL: 'https://cdn-url.com',
     }))
@@ -86,6 +106,7 @@ describe('cdnImageUrl', () => {
 
   it('should not modify a non-Firebase URL', () => {
     jest.mock('src/config/config', () => ({
+      getConfigurationOption: jest.fn(),
       FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
       CDN_URL: 'https://cdn-url.com',
     }))

--- a/src/utils/cdnImageUrl.test.ts
+++ b/src/utils/cdnImageUrl.test.ts
@@ -5,7 +5,6 @@ describe('cdnImageUrl', () => {
     jest.resetModules()
   })
 
-
   it('should return well formed URL if trailing slash included', () => {
     // Mocking empty CDN_URL
     jest.doMock('src/config/config', () => ({

--- a/src/utils/cdnImageUrl.test.ts
+++ b/src/utils/cdnImageUrl.test.ts
@@ -5,6 +5,21 @@ describe('cdnImageUrl', () => {
     jest.resetModules()
   })
 
+
+  it('should return well formed URL if trailing slash included', () => {
+    // Mocking empty CDN_URL
+    jest.doMock('src/config/config', () => ({
+      FIREBASE_CONFIG: { storageBucket: 'some-bucket' },
+      CDN_URL: 'https://cdn-url.com/',
+    }))
+
+    const { cdnImageUrl } = require('src/utils/cdnImageUrl')
+    const originalUrl =
+      'https://firebasestorage.googleapis.com/v0/b/some-bucket/image.jpg'
+
+    expect(cdnImageUrl(originalUrl)).toBe('https://cdn-url.com/image.jpg')
+  })
+
   it('should return the original URL if CDN_URL or FIREBASE_CONFIG.storageBucket is not set', () => {
     // Mocking empty CDN_URL
     jest.doMock('src/config/config', () => ({

--- a/src/utils/cdnImageUrl.ts
+++ b/src/utils/cdnImageUrl.ts
@@ -12,7 +12,7 @@ export const cdnImageUrl = (url: string, resizeArgs?: ResizeArgs) => {
   return (
     url.replace(
       `https://firebasestorage.googleapis.com/v0/b/${FIREBASE_CONFIG.storageBucket}`,
-      CDN_URL,
+      CDN_URL.replace(/\/$/, ''),
     ) + formatResizeArgsForUrl(resizeArgs, url)
   )
 }

--- a/src/utils/cdnImageUrl.ts
+++ b/src/utils/cdnImageUrl.ts
@@ -1,4 +1,5 @@
 import { CDN_URL, FIREBASE_CONFIG } from 'src/config/config'
+import { logger } from 'src/logger'
 
 type ResizeArgs = {
   width?: number
@@ -9,10 +10,19 @@ export const cdnImageUrl = (url: string, resizeArgs?: ResizeArgs) => {
     return url
   }
 
+  const sanitizedCdnUrl = CDN_URL.trim().replace(/\/$/, '')
+
+  try {
+    new URL(sanitizedCdnUrl)
+  } catch (e) {
+    logger.warn('Invalid CDN_URL', e)
+    return url
+  }
+
   return (
     url.replace(
       `https://firebasestorage.googleapis.com/v0/b/${FIREBASE_CONFIG.storageBucket}`,
-      CDN_URL.replace(/\/$/, ''),
+      sanitizedCdnUrl,
     ) + formatResizeArgsForUrl(resizeArgs, url)
   )
 }


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR fixes an issue where the application would fail to load if the REACT_APP_CDN_URL environment variable was misconfigured. The fix will handle trailing slashes being provided as part of the configured value. 

