### PR TITLE
chore(ci): remove cache warmup step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,14 +199,6 @@ examples:
 #  Jobs - Independently specified lists of tasks and environments for execution
 ######################################################################################################
 jobs:
-  # Install workspace node_modules and persist to cache for use in other jobs
-  warmup-cache:
-    docker: *docker
-    resource_class: medium+
-    steps:
-      - setup_repo
-      - *save_yarn_cache
-
   spellcheck:
     docker: *docker
     resource_class: small
@@ -450,8 +442,6 @@ workflows:
   main_workflow:
     # by default jobs will run concurrently, so specify requires if want to run sequentially
     jobs:
-      - warmup-cache:
-          name: Warmup Cache
       - spellcheck:
           name: Check documentation spelling
           filters:
@@ -467,7 +457,6 @@ workflows:
       - lint:
           name: Lint code
           requires:
-            - 'Warmup Cache'
             - 'Check documentation spelling'
             - 'Lint commits'
           filters:


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Developer experience (improves developer workflows for contributing to the project)

## Description

This step introduces a ~40sec blocker to running the code linting step.
We should not need to prime our caches in this way.
