### PR TITLE
refactor: convert discussion store to a service

### DIFF
--- a/src/pages/Question/index.tsx
+++ b/src/pages/Question/index.tsx
@@ -1,9 +1,5 @@
 import { MODULE } from 'src/modules'
 import {
-  DiscussionStore,
-  DiscussionStoreContext,
-} from 'src/stores/Discussions/discussions.store'
-import {
   QuestionStore,
   QuestionStoreContext,
 } from 'src/stores/Question/question.store'
@@ -17,9 +13,7 @@ export const QuestionModuleContainer = () => {
   const rootStore = useCommonStores()
   return (
     <QuestionStoreContext.Provider value={new QuestionStore(rootStore)}>
-      <DiscussionStoreContext.Provider value={new DiscussionStore(rootStore)}>
-        <QuestionRoutes />
-      </DiscussionStoreContext.Provider>
+      <QuestionRoutes />
     </QuestionStoreContext.Provider>
   )
 }

--- a/src/services/discussions.service.ts
+++ b/src/services/discussions.service.ts
@@ -1,0 +1,216 @@
+import { MAX_COMMENT_LENGTH } from 'src/constants'
+// import { updateDiscussionMetadata } from 'src/events/discussions.event'
+import { logger } from 'src/logger'
+import { firestore } from 'src/utils/firebase'
+import { getUserCountry } from 'src/utils/getUserCountry'
+import { hasAdminRights, randomID } from 'src/utils/helpers'
+
+import type { IUserPPDB } from 'src/models'
+import type {
+  IDiscussion,
+  IDiscussionComment,
+} from 'src/models/discussion.models'
+
+const DISCUSSIONS_COLLECTION = 'discussions'
+
+const fetchOrCreateDiscussionBySource = async (
+  sourceId: string,
+  sourceType: IDiscussion['sourceType'],
+) => {
+  const result = await firestore
+    .collection(DISCUSSIONS_COLLECTION)
+    .where('sourceId', '==', sourceId)
+    .get()
+  if (result?.docs.length > 0) {
+    return result.docs[0].data() as IDiscussion
+  }
+
+  // Create a new discussion
+  return (await uploadDiscussion(sourceId, sourceType)) || null
+}
+
+const uploadDiscussion = async (
+  sourceId: string,
+  sourceType: IDiscussion['sourceType'],
+): Promise<IDiscussion | undefined> => {
+  const newDiscussion: IDiscussion = {
+    _id: randomID(),
+    sourceId,
+    sourceType,
+    comments: [],
+  }
+
+  const dbRef = firestore
+    .collection(DISCUSSIONS_COLLECTION)
+    .doc(newDiscussion._id)
+
+  return _updateDiscussion(dbRef, newDiscussion)
+}
+
+const addComment = async (
+  discussion: IDiscussion,
+  text: string,
+  user: IUserPPDB,
+  commentId?: string,
+): Promise<IDiscussion | undefined> => {
+  try {
+    const comment = text.slice(0, MAX_COMMENT_LENGTH).trim()
+
+    if (user && comment) {
+      const dbRef = firestore
+        .collection(DISCUSSIONS_COLLECTION)
+        .doc(discussion._id)
+
+      const currentDiscussion = (await dbRef.get()).data() as IDiscussion
+
+      if (!currentDiscussion) {
+        throw new Error('Discussion not found')
+      }
+
+      const newComment: IDiscussionComment = {
+        _id: randomID(),
+        _created: new Date().toISOString(),
+        _creatorId: user._id,
+        creatorName: user.userName,
+        creatorCountry: getUserCountry(user),
+        text: comment,
+        parentCommentId: commentId || null,
+      }
+
+      currentDiscussion.comments.push(newComment)
+
+      return _updateDiscussion(dbRef, currentDiscussion)
+    }
+  } catch (err) {
+    logger.error(err)
+    throw new Error(err?.message)
+  }
+}
+
+const editComment = async (
+  discussion: IDiscussion,
+  commentId: string,
+  text: string,
+  user: IUserPPDB,
+): Promise<IDiscussion | undefined> => {
+  try {
+    const comment = text.slice(0, MAX_COMMENT_LENGTH).trim()
+
+    if (user && comment) {
+      const dbRef = firestore
+        .collection(DISCUSSIONS_COLLECTION)
+        .doc(discussion._id)
+
+      const currentDiscussion = (await dbRef.get()).data() as IDiscussion
+
+      if (currentDiscussion) {
+        const targetComment = currentDiscussion.comments.find(
+          (comment) => comment._id === commentId,
+        )
+
+        if (targetComment?._creatorId !== user._id) {
+          throw new Error('Comment not editable by user')
+        }
+
+        currentDiscussion.comments = _findAndUpdateComment(
+          user,
+          currentDiscussion.comments,
+          text,
+          commentId,
+        )
+
+        return _updateDiscussion(dbRef, currentDiscussion)
+      }
+    }
+  } catch (err) {
+    logger.error(err)
+    throw new Error(err?.message)
+  }
+}
+
+const deleteComment = async (
+  discussion: IDiscussion,
+  commentId: string,
+  user: IUserPPDB,
+): Promise<IDiscussion | undefined> => {
+  try {
+    if (user) {
+      const dbRef = firestore
+        .collection(DISCUSSIONS_COLLECTION)
+        .doc(discussion._id)
+
+      const currentDiscussion = (await dbRef.get()).data() as IDiscussion
+
+      if (currentDiscussion) {
+        const targetComment = currentDiscussion.comments.find(
+          (comment) => comment._id === commentId,
+        )
+
+        if (targetComment?._creatorId !== user._id) {
+          throw new Error('Comment not editable by user')
+        }
+
+        currentDiscussion.comments = _findAndDeleteComment(
+          user,
+          currentDiscussion.comments,
+          commentId,
+        )
+
+        return _updateDiscussion(dbRef, currentDiscussion)
+      }
+    }
+  } catch (err) {
+    logger.error(err)
+    throw new Error(err?.message)
+  }
+}
+
+const _findAndUpdateComment = (
+  user: IUserPPDB,
+  comments: IDiscussionComment[],
+  newCommentText: string,
+  commentId: string,
+) => {
+  return comments.map((comment) => {
+    if (
+      (comment._creatorId === user._id || hasAdminRights(user)) &&
+      comment._id == commentId
+    ) {
+      comment.text = newCommentText
+      comment._edited = new Date().toISOString()
+    }
+    return comment
+  })
+}
+
+const _updateDiscussion = async (
+  doc: firebase.default.firestore.DocumentReference<firebase.default.firestore.DocumentData>,
+  discussion: IDiscussion,
+) => {
+  await doc.set(JSON.parse(JSON.stringify(discussion)))
+
+  // updateDiscussionMetadata(discussion)
+
+  return (await doc.get()).data() as IDiscussion
+}
+
+const _findAndDeleteComment = (
+  user: IUserPPDB,
+  comments: IDiscussionComment[],
+  commentId: string,
+) => {
+  return comments.filter((comment) => {
+    return !(
+      (comment._creatorId === user._id || hasAdminRights(user)) &&
+      comment._id === commentId
+    )
+  })
+}
+
+export const discussionsService = {
+  fetchOrCreateDiscussionBySource,
+  uploadDiscussion,
+  addComment,
+  editComment,
+  deleteComment,
+}


### PR DESCRIPTION
@thisislawatts the goal of this PR is to understand how hard it is to migrate stores to services.
And it was straightforward... fetch and add are working. Maybe you could use this code on https://github.com/ONEARMY/community-platform/pull/3102?

Some notes:
- need to decide what's the best approach to access the activeUser, here I passed it as an argument from the main component.
- unsure if this is the best way to invoke firestore

About `<DiscussionContainer />` I think we should refactor it to contain all the discussion related CRUD methods, to avoid all this:
![image](https://github.com/ONEARMY/community-platform/assets/8073622/7dffebe9-0329-4e2a-919f-ddd7ac72a031)
But I understand it would only be possible when research and howto modules are also migrated. 