### PR TITLE
Feat add two new filter options

### DIFF
--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -4,7 +4,10 @@ import { Icon, ModerationStatus, Tooltip, Username } from 'oa-components'
 import { isUserVerifiedWithStore } from 'src/common/isUserVerified'
 import { useCommonStores } from 'src/index'
 import { cdnImageUrl } from 'src/utils/cdnImageUrl'
-import { calculateTotalComments, getPublicUpdates } from 'src/utils/helpers'
+import {
+  calculateTotalUpdateComments,
+  getPublicUpdates,
+} from 'src/utils/helpers'
 import { Box, Card, Flex, Grid, Heading, Image, Text } from 'theme-ui'
 
 import defaultResearchThumbnail from '../../../assets/images/default-research-thumbnail.jpg'
@@ -133,7 +136,7 @@ const ResearchListItem = ({ item }: IProps) => {
                     <Icon glyph="star-active" ml={1} />
                   </Text>
                   <Text color="black" ml={3} sx={_commonStatisticStyle}>
-                    {calculateTotalComments(item)}
+                    {calculateTotalUpdateComments(item)}
                     <Icon glyph="comment" ml={1} />
                   </Text>
                   <Text
@@ -172,7 +175,7 @@ const ResearchListItem = ({ item }: IProps) => {
                 color="black"
                 sx={_commonStatisticStyle}
               >
-                {calculateTotalComments(item)}
+                {calculateTotalUpdateComments(item)}
                 <Icon glyph="comment" ml={1} />
               </Text>
               <Tooltip />

--- a/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
+++ b/src/stores/common/FilterSorterDecorator/FilterSorterDecorator.ts
@@ -31,6 +31,8 @@ export enum ItemSortingOption {
   Newest = 'Newest',
   MostUseful = 'MostUseful',
   Comments = 'MostComments',
+  LeastComments = 'LeastComments',
+  LatestComments = 'LatestComments',
   Updates = 'MostUpdates',
   TotalDownloads = 'TotalDownloads',
   Random = 'Random',
@@ -146,6 +148,59 @@ export class FilterSorterDecorator<T extends IItem> {
     })
   }
 
+  private sortByLeastComments(listItems: T[]) {
+    return this.sortByComments(listItems).reverse()
+  }
+
+  private sortByLatestComments(listItems: T[]) {
+    return [...listItems].sort((a, b) => {
+      if (a.comments && b.comments) {
+        if (a.comments.length === 0 && b.comments.length === 0) {
+          return 0
+        } else if (a.comments.length === 0) {
+          return 1
+        } else if (b.comments.length === 0) {
+          return -1
+        }
+
+        const latestCommentA = a.comments.sort((a, b) =>
+          a._created < b._created ? 1 : -1,
+        )[0]
+        const latestCommentB = b.comments.sort((a, b) =>
+          a._created < b._created ? 1 : -1,
+        )[0]
+        return latestCommentA._created < latestCommentB._created ? 1 : -1
+      } else if (a.updates && b.updates) {
+        const commentsA = a.updates
+          .map((update) => update.comments ?? [])
+          .flat()
+        const commentsB = b.updates
+          .map((update) => update.comments ?? [])
+          .flat()
+
+        if (commentsA.length === 0 && commentsB.length === 0) {
+          return 0
+        } else if (commentsA.length === 0) {
+          return 1
+        } else if (commentsB.length === 0) {
+          return -1
+        }
+
+        const latestCommentA = commentsA.sort((a, b) =>
+          a._created < b._created ? 1 : -1,
+        )[0]
+        const latestCommentB = commentsB.sort((a, b) =>
+          a._created < b._created ? 1 : -1,
+        )[0]
+
+        return latestCommentA._created < latestCommentB._created ? 1 : -1
+      } else {
+        // This is weird, but we can't compare comments and updates
+        return 0
+      }
+    })
+  }
+
   private sortByModerationStatus(listItems: T[], user?: IUser) {
     const isCreatedByUser = (item: T) =>
       user && item._createdBy === user.userName
@@ -204,6 +259,14 @@ export class FilterSorterDecorator<T extends IItem> {
 
         case ItemSortingOption.Comments:
           validItems = this.sortByComments(validItems)
+          break
+
+        case ItemSortingOption.LeastComments:
+          validItems = this.sortByLeastComments(validItems)
+          break
+
+        case ItemSortingOption.LatestComments:
+          validItems = this.sortByLatestComments(validItems)
           break
 
         case ItemSortingOption.Updates:

--- a/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
+++ b/src/stores/common/FilterSorterDecorator/FitlerSorterDecorator.test.ts
@@ -159,6 +159,18 @@ describe('FilterSorterDecorator', () => {
     expect(sortedItems[1].title).toBe(mockItems[0].title)
   })
 
+  test('sort by least comments', () => {
+    const sortedItems = decorator.sort(ItemSortingOption.LeastComments, mockItems)
+    expect(sortedItems[0].title).toBe(mockItems[0].title)
+    expect(sortedItems[1].title).toBe(mockItems[1].title)
+  })
+
+  test("sort by latest comments", () => {
+    const sortedItems = decorator.sort(ItemSortingOption.LatestComments, mockItems)
+    expect(sortedItems[0].title).toBe(mockItems[1].title)
+    expect(sortedItems[1].title).toBe(mockItems[0].title)
+  })
+
   test('sort by total_downloads', () => {
     const sortedItems = decorator.sort(
       ItemSortingOption.TotalDownloads,

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -3,7 +3,7 @@ import { FactoryUser } from 'src/test/factories/User'
 
 import {
   arrayToJson,
-  calculateTotalComments,
+  calculateTotalUpdateComments,
   capitalizeFirstLetter,
   filterModerableItems,
   formatLowerNoSpecial,
@@ -210,7 +210,7 @@ describe('src/utils/helpers', () => {
   describe('calculateTotalComments Function', () => {
     it('should return 0 when item has no updates', () => {
       const item = { item: {} } as any
-      expect(calculateTotalComments(item)).toBe(0)
+      expect(calculateTotalUpdateComments(item)).toBe(0)
     })
 
     it('should return 0 when updates have no comments', () => {
@@ -223,7 +223,7 @@ describe('src/utils/helpers', () => {
           }),
         ),
       } as IResearch.ItemDB | IItem
-      expect(calculateTotalComments(item)).toBe(0)
+      expect(calculateTotalUpdateComments(item)).toBe(0)
     })
 
     it('should return the correct amount of comments', () => {
@@ -236,7 +236,7 @@ describe('src/utils/helpers', () => {
           }),
         ),
       } as IResearch.ItemDB | IItem
-      expect(calculateTotalComments(item)).toBe(9)
+      expect(calculateTotalUpdateComments(item)).toBe(9)
     })
 
     it('should ignore deleted and draft updates', () => {
@@ -262,7 +262,7 @@ describe('src/utils/helpers', () => {
             }),
           ]),
       } as IResearch.ItemDB | IItem
-      expect(calculateTotalComments(item)).toBe(4)
+      expect(calculateTotalUpdateComments(item)).toBe(4)
     })
   })
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -168,7 +168,7 @@ export const isAllowedToPin = (pin: IMapPin, user?: IUser) => {
   }
 }
 
-export const calculateTotalComments = (
+export const calculateTotalUpdateComments = (
   item: IResearch.ItemDB | IItem,
 ): number => {
   if (item.updates) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

- Add two new filter options to FilterSorterDecorator: LatestComments and LeastComments.
    - LatestComments will order items by their most recent comment
    - LeastComments will order items based on items with the least amount of comments
- Renamed file FliterSorterDecorator.test.ts to its proper name of FilterSorterDecorator.test.ts
- Renamed function calculateTotalComments to calculateTotalUpdateComments to be more reflective of its functionality


## Git Conversation
https://github.com/ONEARMY/community-platform/issues/2968#issuecomment-1829520087
