### PR TITLE
feat(patreon): add message for patreon users who do not support the project

### DIFF
--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -5,7 +5,6 @@ import arrayMutators from 'final-form-arrays'
 import { toJS } from 'mobx'
 import { observer } from 'mobx-react'
 import { Button, TextNotification } from 'oa-components'
-import { AuthWrapper } from 'src/common/AuthWrapper'
 import { UnsavedChangesDialog } from 'src/common/Form/UnsavedChangesDialog'
 import { useCommonStores } from 'src/index'
 import { logger } from 'src/logger'
@@ -307,9 +306,7 @@ export const SettingsPage = observer((props: IProps) => {
                       isContactableByPublic={values.isContactableByPublic}
                     />
                   )}
-                  <AuthWrapper roleRequired={'beta-tester'}>
-                    <PatreonIntegration user={user} />
-                  </AuthWrapper>
+                  <PatreonIntegration user={user} />
                 </form>
                 <AccountSettingsSection />
               </Box>

--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -308,7 +308,7 @@ export const SettingsPage = observer((props: IProps) => {
                     />
                   )}
                   <AuthWrapper roleRequired={'beta-tester'}>
-                    <PatreonIntegration />
+                    <PatreonIntegration user={user} />
                   </AuthWrapper>
                 </form>
                 <AccountSettingsSection />

--- a/src/pages/UserSettings/content/formSections/PatreonIntegration.test.tsx
+++ b/src/pages/UserSettings/content/formSections/PatreonIntegration.test.tsx
@@ -1,63 +1,158 @@
 import '@testing-library/jest-dom'
 
-import * as React from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 
-import { PatreonIntegration } from './PatreonIntegration' // Adjust the import path accordingly
+import {
+  BECOME_A_SUPPORTER_MESSAGE,
+  CONNECT_BUTTON_TEXT,
+  HEADING,
+  ONE_ARMY_PATREON_URL,
+  PatreonIntegration,
+  REMOVE_BUTTON_TEXT,
+  SUCCESS_MESSAGE,
+  SUPPORTER_MESSAGE,
+  UPDATE_BUTTON_TEXT,
+} from './PatreonIntegration'
+
+import type { IUserPP } from 'src/models'
+
+const mockUser = {
+  userName: 'test',
+} as IUserPP
+
+const MOCK_PATREON_TIER_TITLE = 'Patreon Tier Title'
+const mockPatreonSupporter = {
+  ...mockUser,
+  badges: {
+    supporter: true,
+  },
+  patreon: {
+    attributes: {
+      thumb_url: 'https://patreon.com',
+    },
+    membership: {
+      tiers: [
+        {
+          id: '123',
+          attributes: {
+            title: MOCK_PATREON_TIER_TITLE,
+            image_url: 'https://patreon.com',
+          },
+        },
+      ],
+    },
+  },
+} as unknown as IUserPP
+
+const WRONG_PATREON_TIER_TITLE = 'Wrong Patreon Tier Title'
+const mockPatreonNotSupporter = {
+  ...mockUser,
+  badges: {
+    supporter: false,
+  },
+  patreon: {
+    attributes: {
+      thumb_url: 'https://patreon.com',
+      tiers: [
+        {
+          id: '456',
+          attributes: {
+            title: WRONG_PATREON_TIER_TITLE,
+            image_url: 'https://patreon.com',
+          },
+        },
+      ],
+    },
+    membership: {
+      tiers: [],
+    },
+  },
+} as unknown as IUserPP
+
+const mockRemovePatreonConnection = jest.fn()
 
 jest.mock('src/index', () => ({
   useCommonStores: () => ({
     stores: {
       userStore: {
-        user: {
-          userName: 'testUser',
-          patreon: {
-            attributes: {
-              thumb_url: 'testThumbUrl',
-            },
-            membership: {
-              tiers: [
-                {
-                  id: 'testTierId',
-                  attributes: {
-                    image_url: 'testImageUrl',
-                    title: 'Test Tier',
-                  },
-                },
-              ],
-            },
-          },
-        },
-        removePatreonConnection: jest.fn(),
+        removePatreonConnection: mockRemovePatreonConnection,
       },
     },
   }),
 }))
 
 describe('PatreonIntegration', () => {
-  it('renders correctly', () => {
-    render(<PatreonIntegration />)
-    expect(screen.getByText('❤️ Become a Supporter')).toBeInTheDocument()
-  })
-
-  it('displays the connected Patreon account information', () => {
-    render(<PatreonIntegration />)
-    expect(
-      screen.getByText('Successfully linked Patreon account!'),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Update Patreon Data')).toBeInTheDocument()
-    expect(screen.getByText('Remove Connection')).toBeInTheDocument()
-  })
-
-  it('calls removePatreonConnection when "Remove Connection" button is clicked', async () => {
-    render(<PatreonIntegration />)
-    await act(async () => {
-      fireEvent.click(screen.getByText('Remove Connection'))
+  describe('not connected', () => {
+    beforeEach(() => {
+      render(<PatreonIntegration user={mockUser} />)
     })
-    expect(
-      screen.getByText(
-        'Support us on Patreon to get a badge here on the platform and special insights and voting rights on decisions.',
-      ),
-    ).toBeInTheDocument()
+
+    it('renders correctly', () => {
+      expect(screen.getByText(HEADING)).toBeInTheDocument()
+    })
+
+    it('displays instructions on how to connect and connect button', () => {
+      expect(screen.getByText(CONNECT_BUTTON_TEXT)).toBeInTheDocument()
+      expect(
+        screen.getByText((t) =>
+          t.includes('Connect your Patreon account by clicking below'),
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it('links to one army patreon page', () => {
+      expect(
+        screen.getByRole(
+          (t, e) => e?.getAttribute('href') === ONE_ARMY_PATREON_URL,
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('with supporter', () => {
+    beforeEach(() => {
+      render(<PatreonIntegration user={mockPatreonSupporter} />)
+    })
+
+    it('displays the connected Patreon account information and buttons', () => {
+      expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument()
+      expect(screen.getByText(SUPPORTER_MESSAGE)).toBeInTheDocument()
+      expect(screen.getByText('Patreon Tier Title')).toBeInTheDocument()
+      expect(screen.getByText(UPDATE_BUTTON_TEXT)).toBeInTheDocument()
+      expect(screen.getByText(REMOVE_BUTTON_TEXT)).toBeInTheDocument()
+    })
+
+    it('calls removePatreonConnection when "Remove Connection" button is clicked', async () => {
+      await act(async () => {
+        fireEvent.click(screen.getByText(REMOVE_BUTTON_TEXT))
+      })
+      expect(mockRemovePatreonConnection).toHaveBeenCalledWith(
+        mockUser.userName,
+      )
+      expect(screen.getByText(CONNECT_BUTTON_TEXT)).toBeInTheDocument()
+    })
+  })
+
+  describe('not supporter', () => {
+    beforeEach(() => {
+      render(<PatreonIntegration user={mockPatreonNotSupporter} />)
+    })
+
+    it('displays the connected Patreon account information and buttons', () => {
+      expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument()
+      expect(screen.getByText(UPDATE_BUTTON_TEXT)).toBeInTheDocument()
+      expect(screen.getByText(REMOVE_BUTTON_TEXT)).toBeInTheDocument()
+    })
+
+    it('does not display supporter message or invalid tier', () => {
+      expect(screen.queryByText(SUPPORTER_MESSAGE)).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(WRONG_PATREON_TIER_TITLE),
+      ).not.toBeInTheDocument()
+    })
+
+    it('displays become a supporter message', () => {
+      expect(screen.getByText(BECOME_A_SUPPORTER_MESSAGE)).toBeInTheDocument()
+    })
   })
 })

--- a/src/pages/UserSettings/content/formSections/PatreonIntegration.test.tsx
+++ b/src/pages/UserSettings/content/formSections/PatreonIntegration.test.tsx
@@ -3,7 +3,6 @@ import '@testing-library/jest-dom'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import {
-  BECOME_A_SUPPORTER_MESSAGE,
   CONNECT_BUTTON_TEXT,
   HEADING,
   ONE_ARMY_PATREON_URL,
@@ -152,7 +151,13 @@ describe('PatreonIntegration', () => {
     })
 
     it('displays become a supporter message', () => {
-      expect(screen.getByText(BECOME_A_SUPPORTER_MESSAGE)).toBeInTheDocument()
+      expect(
+        screen.getByText((t) =>
+          t.includes(
+            'It looks like you are not an active supporter of this project.',
+          ),
+        ),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
+++ b/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
@@ -16,8 +16,6 @@ const BETA_DISCLAIMER =
 export const SUCCESS_MESSAGE = 'Successfully linked Patreon account!'
 export const SUPPORTER_MESSAGE =
   'Thanks for supporting us! :) Update your data if you changed your Patreon tiers or remove the connection below.'
-export const BECOME_A_SUPPORTER_MESSAGE =
-  'Thanks for connecting your account! It looks like you are not an active supporter of this project. If you become a supporter in the future, click the button below to update your data.'
 
 export const CONNECT_BUTTON_TEXT = 'Connect To Patreon'
 export const UPDATE_BUTTON_TEXT = 'Update Patreon Data'
@@ -120,7 +118,15 @@ export const PatreonIntegration = (props: { user: IUserPP }) => {
             </Flex>
           ) : (
             <Flex sx={{ flexDirection: 'column' }}>
-              <Text mt={4}>{BECOME_A_SUPPORTER_MESSAGE}</Text>
+              <Text mt={4}>
+                Thanks for connecting your account! It looks like you are not an
+                active supporter of this project. You can support us{' '}
+                <a href={ONE_ARMY_PATREON_URL} target="_blank" rel="noreferrer">
+                  here
+                </a>
+                . If you become a supporter in the future, click the button
+                below to update your data.
+              </Text>
             </Flex>
           )}
         </Box>

--- a/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
+++ b/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
@@ -8,24 +8,26 @@ import { FlexSectionContainer } from './elements'
 
 import type { IUserPP } from 'src/models'
 
-const HEADING = '❤️ Become a Supporter'
+export const HEADING = '❤️ Become a Supporter'
 const SUBHEADING =
   'Support us on Patreon to get a badge here on the platform and special insights and voting rights on decisions.'
 const BETA_DISCLAIMER =
   'This feature is still in beta and we will continue to roll out more features for supporters.'
-const SUCCESS_MESSAGE = 'Successfully linked Patreon account!'
-const SUPPORTER_MESSAGE =
+export const SUCCESS_MESSAGE = 'Successfully linked Patreon account!'
+export const SUPPORTER_MESSAGE =
   'Thanks for supporting us! :) Update your data if you changed your Patreon tiers or remove the connection below.'
+export const BECOME_A_SUPPORTER_MESSAGE =
+  'Thanks for connecting your account! It looks like you are not an active supporter of this project. If you become a supporter in the future, click the button below to update your data.'
 
-const CONNECT_BUTTON_TEXT = 'Connect To Patreon'
-const UPDATE_BUTTON_TEXT = 'Update Patreon Data'
-const REMOVE_BUTTON_TEXT = 'Remove Connection'
+export const CONNECT_BUTTON_TEXT = 'Connect To Patreon'
+export const UPDATE_BUTTON_TEXT = 'Update Patreon Data'
+export const REMOVE_BUTTON_TEXT = 'Remove Connection'
 
-export const PatreonIntegration = () => {
+export const ONE_ARMY_PATREON_URL = 'https://www.patreon.com/one_army'
+
+export const PatreonIntegration = (props: { user: IUserPP }) => {
   const { userStore } = useCommonStores().stores
-  const [user, setUser] = React.useState<IUserPP | undefined>(
-    userStore.user ?? undefined,
-  )
+  const [user, setUser] = React.useState<IUserPP>(props.user)
 
   const removePatreonConnection = () => {
     if (!user) {
@@ -82,7 +84,7 @@ export const PatreonIntegration = () => {
             />
             <Text>{SUCCESS_MESSAGE}</Text>
           </Flex>
-          {user.patreon.membership && (
+          {user.badges?.supporter && user.patreon.membership ? (
             <Flex sx={{ flexDirection: 'column' }}>
               <Text mt={4}>{SUPPORTER_MESSAGE}</Text>
               {user.patreon.membership.tiers.map(({ id, attributes }) => (
@@ -116,17 +118,17 @@ export const PatreonIntegration = () => {
                 </Flex>
               ))}
             </Flex>
+          ) : (
+            <Flex sx={{ flexDirection: 'column' }}>
+              <Text mt={4}>{BECOME_A_SUPPORTER_MESSAGE}</Text>
+            </Flex>
           )}
         </Box>
       ) : (
         <Text mt={4} mb={4} sx={{ display: 'block', whiteSpace: 'pre-line' }}>
           How it works: <br />
           1.{' '}
-          <a
-            href="https://www.patreon.com/one_army"
-            target="_blank"
-            rel="noreferrer"
-          >
+          <a href={ONE_ARMY_PATREON_URL} target="_blank" rel="noreferrer">
             Support us
           </a>{' '}
           on Patreon <br />


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
it seems like we should have a message for people who a) connect with patreon but b) are not an active supporter

added some thorough tests for this component

removed beta wrapper - ready to release! 

## Git Issues

Closes #

## Screenshots/Videos
@davehakkens let me know if you like the looks of this?
![Screenshot 2024-01-08 at 7 03 43 PM](https://github.com/ONEARMY/community-platform/assets/37253846/3b3d3e36-16ff-4bbc-aeb3-1a66bf136831)


_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
