### PR TITLE
feat: add missing impact display when no report

### DIFF
--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -37,7 +37,7 @@ export const ImpactItem = ({ fields, user, year }: Props) => {
         ) : (
           <ImpactMissing
             fields={fields}
-            user={user}
+            owner={user}
             visibleFields={visibleFields}
             year={year}
           />

--- a/src/pages/User/impact/ImpactMissing.test.tsx
+++ b/src/pages/User/impact/ImpactMissing.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'mobx-react'
+import { useCommonStores } from 'src/index'
+import { FactoryUser } from 'src/test/factories/User'
+
+import { ImpactMissing } from './ImpactMissing'
+import { invisible, missing, reportYearLabel } from './labels'
+
+jest.mock('src/index', () => {
+  return {
+    useCommonStores: () => ({
+      stores: {
+        userStore: {
+          activeUser: { userName: 'activeUser' },
+        },
+      },
+    }),
+  }
+})
+
+describe('ImpactMissing', () => {
+  describe('[public]', () => {
+    it('renders message that impact is missing', async () => {
+      render(
+        <Provider {...useCommonStores().stores}>
+          <ImpactMissing
+            fields={undefined}
+            owner={undefined}
+            year={2023}
+            visibleFields={undefined}
+          />
+        </Provider>,
+      )
+
+      await screen.findByText(missing.user.label)
+    })
+
+    it('renders right message and button for impact report year', async () => {
+      render(
+        <Provider {...useCommonStores().stores}>
+          <ImpactMissing
+            fields={undefined}
+            owner={undefined}
+            year={2022}
+            visibleFields={undefined}
+          />
+        </Provider>,
+      )
+
+      await screen.findByText(reportYearLabel)
+      await screen.findByText(`2022 ${missing.user.link}`)
+    })
+
+    it('renders message that all data is invisible', async () => {
+      const fields = [
+        {
+          id: 'volunteers',
+          value: 45,
+          isVisible: true,
+        },
+      ]
+
+      render(
+        <Provider {...useCommonStores().stores}>
+          <ImpactMissing
+            fields={fields}
+            owner={undefined}
+            year={2022}
+            visibleFields={[]}
+          />
+        </Provider>,
+      )
+      await screen.findByText(invisible.user.label)
+    })
+  })
+
+  describe('[page owner]', () => {
+    it('renders right message for impact owner', async () => {
+      const user = FactoryUser({ userName: 'activeUser' })
+
+      render(
+        <Provider {...useCommonStores().stores}>
+          <ImpactMissing
+            fields={undefined}
+            owner={user}
+            year={2023}
+            visibleFields={undefined}
+          />
+        </Provider>,
+      )
+
+      await screen.findByText(missing.owner.label)
+    })
+  })
+})

--- a/src/pages/User/impact/ImpactMissing.tsx
+++ b/src/pages/User/impact/ImpactMissing.tsx
@@ -5,13 +5,13 @@ import { useCommonStores } from 'src/index'
 import { Flex, Text } from 'theme-ui'
 
 import { IMPACT_REPORT_LINKS } from './constants'
-import { invisible, missing } from './labels'
+import { invisible, missing, reportYearLabel } from './labels'
 
 import type { IImpactYear, IImpactYearFieldList, IUserPP } from 'src/models'
 
 interface Props {
   fields: IImpactYearFieldList | undefined
-  user: IUserPP | undefined
+  owner: IUserPP | undefined
   visibleFields: IImpactYearFieldList | undefined
   year: IImpactYear
 }
@@ -29,31 +29,35 @@ const isAllInvisible = (fields, visibleFields) => {
   return false
 }
 
-const isPageOwnerCheck = (activeUser, user) => {
-  const usersPresent = activeUser && user
-  const usersTheSame = toJS(activeUser)?.userName === user?.userName
+const isPageOwnerCheck = (activeUser, owner) => {
+  const usersPresent = activeUser && owner
+  const usersTheSame = toJS(activeUser)?.userName === owner?.userName
 
   return usersPresent && usersTheSame ? true : false
 }
 
 export const ImpactMissing = observer((props: Props) => {
-  const { fields, user, visibleFields, year } = props
+  const { fields, owner, visibleFields, year } = props
   const { userStore } = useCommonStores().stores
 
   const labelSet = isAllInvisible(fields, visibleFields) ? invisible : missing
 
-  const isPageOwner = isPageOwnerCheck(userStore.activeUser, user)
+  const isPageOwner = isPageOwnerCheck(userStore.activeUser, owner)
+  const isReportYear = IMPACT_REPORT_LINKS[year] ? true : false
 
-  const userButton = `${year} ${labelSet.user.link}`
+  const button = `${year} ${labelSet.user.link}`
   const label = isPageOwner ? labelSet.owner.label : labelSet.user.label
 
   return (
     <Flex sx={{ flexFlow: 'column', gap: 2, mt: 2 }}>
       <Text>{label}</Text>
-      {!isPageOwner && (
-        <ExternalLink href={IMPACT_REPORT_LINKS[year]}>
-          <Button>{userButton}</Button>
-        </ExternalLink>
+      {!isPageOwner && isReportYear && (
+        <>
+          <Text>{reportYearLabel}</Text>
+          <ExternalLink href={IMPACT_REPORT_LINKS[year]}>
+            <Button>{button}</Button>
+          </ExternalLink>
+        </>
       )}
       {isPageOwner && (
         <a href="/settings">

--- a/src/pages/User/impact/constants.ts
+++ b/src/pages/User/impact/constants.ts
@@ -1,10 +1,7 @@
 import type { IImpactYear } from 'src/models'
 
 export const IMPACT_REPORT_LINKS = {
-  2023: 'https://www.preciousplastic.com/impact/2023',
-  2022: 'https://www.preciousplastic.com/impact',
-  2021: 'https://www.preciousplastic.com/impact',
-  2020: 'https://www.preciousplastic.com/impact',
+  2022: 'https://www.preciousplastic.com/impact/2023',
   2019: 'https://www.preciousplastic.com/impact',
 }
 

--- a/src/pages/User/impact/labels.ts
+++ b/src/pages/User/impact/labels.ts
@@ -14,8 +14,7 @@ export const invisible = {
 
 export const missing = {
   user: {
-    label:
-      "Looks like they haven't shared their Impact Data yet. Until they do you can have a pick of the global impact report! :)",
+    label: "Looks like they haven't shared their Impact Data yet.",
     link: 'Impact Report',
   },
   owner: {
@@ -23,3 +22,6 @@ export const missing = {
     link: 'Enter impact data',
   },
 }
+
+export const reportYearLabel =
+  'Until they do you can have a pick of the global impact report! :)'

--- a/src/pages/User/impact/labels.ts
+++ b/src/pages/User/impact/labels.ts
@@ -24,4 +24,4 @@ export const missing = {
 }
 
 export const reportYearLabel =
-  'Until they do you can have a pick of the global impact report! :)'
+  'In the meantime, check out the global report! :)'


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

PP don't have reports for each impact year, so this adds a simpler display for those years.


## Screenshots/Videos

<img width="1092" alt="Screenshot 2024-01-15 at 12 11 35" src="https://github.com/ONEARMY/community-platform/assets/16688508/9ec78508-93f9-4bdf-87f2-0f53ddf3d1c3">