### PR TITLE
fix: change user impact update to require an id

### DIFF
--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
@@ -48,7 +48,8 @@ export const ImpactYearSection = observer(({ year }: Props) => {
     setSubmitResults(null)
     try {
       const fields = transformImpactInputs(values)
-      await userStore.updateUserImpact(fields, year)
+      const userId = userStore.user?._id || ''
+      await userStore.updateUserImpact(fields, year, userId)
       setSubmitResults({ type: 'success', message: form.saveSuccess })
       setIsEditMode(false)
       setImpact(fields)

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -301,9 +301,13 @@ describe('userStore', () => {
     it('throws an error if user undefined', async () => {
       // Act
       expect(async () => {
-        await store.updateUserImpact('testUserId', {
-          impact: { total: 100, totalPreciousPlastic: 100 },
-        })
+        await store.updateUserImpact(
+          {
+            impact: { total: 100, totalPreciousPlastic: 100 },
+          },
+          '2024',
+          'testUserId',
+        )
       }).rejects.toThrow()
     })
 
@@ -316,6 +320,7 @@ describe('userStore', () => {
       await store.updateUserImpact(
         { impact: { total: 100, totalPreciousPlastic: 100 } },
         impactYear,
+        'testUserId',
       )
 
       // Assert

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -240,15 +240,19 @@ export class UserStore extends ModuleStore {
   public async updateUserImpact(
     fields: IImpactYearFieldList,
     year: IImpactYear,
+    userId: string,
   ) {
-    if (!this.user) {
-      throw new Error('User not found')
+    if (this.user?._id !== userId) {
+      throw new Error('User and user ID mismatch')
     }
 
     await this.db
       .collection(COLLECTION_NAME)
-      .doc(this.user._id)
-      .update({ [`impact.${year}`]: fields })
+      .doc(userId)
+      .update({
+        _id: userId,
+        [`impact.${year}`]: fields,
+      })
   }
 
   public async unsubscribeUser(unsubscribeToken: string) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In production _I think_ there's a caching issue going on where the impact thinks it's updating the data but the DB is silently not updating. 

Not entirely sure this does anything, feedback would be helpful - include how to test it.