### PR TITLE
fix: user settings so that impact isn't overwritten

### DIFF
--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -113,6 +113,12 @@ export const SettingsPage = observer((props: IProps) => {
         })),
         openingHours: openingHours!.length > 0 ? openingHours : [{} as any],
       }
+
+      // remove as updated by sub-form
+      if (formValues.impact) {
+        delete formValues.impact
+      }
+
       setState({
         formValues,
         notification: { message: '', icon: '', show: false },

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -311,6 +311,8 @@ describe('userStore', () => {
 
   describe('updateUserImpact', () => {
     it('throws an error if user undefined', async () => {
+      store.activeUser = null
+
       // Act
       expect(async () => {
         await store.updateUserImpact('testUserId', {
@@ -320,7 +322,7 @@ describe('userStore', () => {
     })
 
     it('updates the user impact in the database', async () => {
-      store.user = FactoryUser({
+      store.activeUser = FactoryUser({
         _id: 'testUserId',
       })
       const impactYear = faker.datatype.number({ min: 2019, max: 2023 })

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -243,14 +243,18 @@ export class UserStore extends ModuleStore {
     fields: IImpactYearFieldList,
     year: IImpactYear,
   ) {
-    if (!this.user) {
+    const user = this.activeUser
+
+    if (!user) {
       throw new Error('User not found')
     }
 
     await this.db
       .collection(COLLECTION_NAME)
-      .doc(this.user._id)
+      .doc(user._id)
       .update({ [`impact.${year}`]: fields })
+
+    await this.refreshActiveUserDetails()
   }
 
   public async unsubscribeUser(unsubscribeToken: string) {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

There have been issues around the impact data not appearing to persist after a user saves it. The biggest reason for this is when a user updates the impact data and then saves their profile, the impact data was being overwritten by the old impact data state being stored. 