### PR TITLE
fix: allowed message check with right id type

### DIFF
--- a/functions/src/emailNotifications/utils.ts
+++ b/functions/src/emailNotifications/utils.ts
@@ -79,8 +79,17 @@ export const isSameEmail = (userDoc, email) => {
 }
 
 export const isUserAllowedToMessage = async (uid) => {
-  const { toUser } = await getUserAndEmail(uid)
-  if (toUser.isBlockedFromMessaging) {
+  const { docs } = await db
+    .collection(DB_ENDPOINTS.users)
+    .where('_authID', '==', uid)
+    .limit(1)
+    .get()
+
+  if (!docs[0]) {
+    throw new Error(`Cannot get user ${uid}`)
+  }
+
+  if (docs[0].data().isBlockedFromMessaging) {
     throw new Error(errors.USER_BLOCKED)
   }
   return true


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

`isUserAllowedToMessage` was wrongly using the firebase doc uid (which turns out to be the `_authID`) to search for users.

IF ALL OK WITH WHOEVER REVIEWS, PLEASE MERGE AND RELEASE STRAIGHT AWAY.