### PR TITLE
fix: hide prev and next buttons when there is only one image in the p…

### DIFF
--- a/packages/components/src/ImageGallery/ImageGallery.stories.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.stories.tsx
@@ -66,3 +66,16 @@ export const ShowNextPrevButtons: StoryFn<typeof ImageGallery> = (
     />
   )
 }
+
+export const DoNotShowNextPrevButtons: StoryFn<typeof ImageGallery> = (
+  props: Omit<ImageGalleryProps, 'images'>,
+) => {
+  return (
+    <ImageGallery
+      images={[testImages[0]]}
+      {...props}
+      hideThumbnails
+      showNextPrevButton={true}
+    />
+  )
+}

--- a/packages/components/src/ImageGallery/ImageGallery.test.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.test.tsx
@@ -1,10 +1,14 @@
-import { findByRole as globalFindByRole, waitFor } from '@testing-library/react'
+import {
+  findByRole as globalFindByRole,
+  waitFor
+} from '@testing-library/react'
 import { vi } from 'vitest'
 
 import { render } from '../tests/utils'
 import { ImageGallery } from './ImageGallery'
 import {
   Default,
+  DoNotShowNextPrevButtons,
   NoThumbnails,
   ShowNextPrevButtons,
   testImages,
@@ -174,5 +178,21 @@ describe('ImageGallery', () => {
 
     expect(nextBtn).toBeInTheDocument()
     expect(previousBtn).toBeInTheDocument()
+  })
+
+  it('does not support show next/previous buttons because only one image', async () => {
+    const { queryByRole } = render(
+      <DoNotShowNextPrevButtons
+        {...(DoNotShowNextPrevButtons.args as ImageGalleryProps)}
+      />,
+    )
+
+    // const nextBtn = getByRole('button', { name: 'Next image' })
+    // const previousBtn = getByRole('button', { name: 'Previous image' })
+    const nextBtn = queryByRole('button', { name: 'Next image' })
+    const previousBtn = queryByRole('button', { name: 'Previous image' })
+
+    expect(nextBtn).not.toBeInTheDocument()
+    expect(previousBtn).not.toBeInTheDocument()
   })
 })

--- a/packages/components/src/ImageGallery/ImageGallery.test.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.test.tsx
@@ -1,7 +1,4 @@
-import {
-  findByRole as globalFindByRole,
-  waitFor
-} from '@testing-library/react'
+import { findByRole as globalFindByRole, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 
 import { render } from '../tests/utils'

--- a/packages/components/src/ImageGallery/ImageGallery.test.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.test.tsx
@@ -184,8 +184,6 @@ describe('ImageGallery', () => {
       />,
     )
 
-    // const nextBtn = getByRole('button', { name: 'Next image' })
-    // const previousBtn = getByRole('button', { name: 'Previous image' })
     const nextBtn = queryByRole('button', { name: 'Next image' })
     const previousBtn = queryByRole('button', { name: 'Previous image' })
 

--- a/packages/components/src/ImageGallery/ImageGallery.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.tsx
@@ -127,7 +127,7 @@ export const ImageGallery = (props: ImageGalleryProps) => {
   const activeImage = images[activeImageIndex]
   const imageNumber = images.length
   const showThumbnails = !props.hideThumbnails && images.length >= 1
-  const showNextPrevButton = !!props.showNextPrevButton
+  const showNextPrevButton = !!props.showNextPrevButton && images.length > 1
 
   return activeImage ? (
     <Flex sx={{ flexDirection: 'column' }}>

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -207,7 +207,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
           <ImageGallery
             images={formatImagesForGallery(coverImage)}
             hideThumbnails={true}
-            showNextPrevButton={true}
+            showNextPrevButton={coverImage?.length > 1 || false}
           />
         ) : (
           <AspectRatio ratio={24 / 3}>

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -207,7 +207,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
           <ImageGallery
             images={formatImagesForGallery(coverImage)}
             hideThumbnails={true}
-            showNextPrevButton={coverImage?.length > 1 || false}
+            showNextPrevButton={true}
           />
         ) : (
           <AspectRatio ratio={24 / 3}>


### PR DESCRIPTION
…rofile image gallery

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Conditionally hiding the prev, next buttons in the image gallery from the SpaceProfile 

## Git Issues

Closes #

#3242

## Screenshots/Videos


When only one image
![image](https://github.com/ONEARMY/community-platform/assets/7417010/6982d8a5-79f7-401b-b230-27fd19d97584)

When multiple images
![image](https://github.com/ONEARMY/community-platform/assets/7417010/7a661869-8b28-4e17-9bbc-fa04159ff07b)



---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
