### PR TITLE
fix(components): remove margin from first tab

### DIFF
--- a/packages/components/src/TabbedContent/TabbedContent.tsx
+++ b/packages/components/src/TabbedContent/TabbedContent.tsx
@@ -28,17 +28,29 @@ export const Tab = styled(MuiTab)`
   }
 
   &:first-of-type {
-    margin-left: 15px;
+    margin-left: 0;
+    position: relative;
   }
 
   &.Mui-selected {
     background-color: ${(p) => (p.theme as Theme)?.colors.background};
     text-decoration: none;
+
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      left: 0;
+      top: 100%;
+      height: ${(p) => (p.theme as Theme)?.space?.[3]}px;
+      width: ${(p) => (p.theme as Theme)?.space?.[3]}px;
+      background-color: ${(p) => (p.theme as Theme)?.colors.background};
+    }
   }
 `
 
 export const TabPanel = styled(MuiTabPanel)`
   background-color: ${(p) => (p.theme as Theme)?.colors.background};
-  border-radius: ${(p) => (p.theme as Theme)?.space?.[3]}px;
+  border-radius: ${(p) => (p.theme as Theme)?.space?.[2]}px;
   padding: ${(p) => (p.theme as Theme)?.space?.[3]}px;
 `


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

* Removes margin from left side of first tab item
* Reduces borderRadius to match enclosing Box

**Before:** 

![Screenshot 2024-01-31 at 21 56 38](https://github.com/ONEARMY/community-platform/assets/472589/9bfc611f-c866-4454-a1e1-12ae9f7d2789)

**After:**

![Screenshot 2024-01-31 at 21 54 45](https://github.com/ONEARMY/community-platform/assets/472589/7171f3d8-a5d4-4000-81e9-0119a31bafa1)
