### PR TITLE
fix: let messages send to users unless opted out

### DIFF
--- a/functions/src/emailNotifications/utils.test.ts
+++ b/functions/src/emailNotifications/utils.test.ts
@@ -76,6 +76,15 @@ describe('isReceiverContactable', () => {
     await expect(isReceiverContactable('uid')).resolves.toEqual(true)
   })
 
+  it("returns true when contactable value isn't specified", async () => {
+    jest.spyOn(utils, 'getUserAndEmail').mockResolvedValue({
+      toUser: {} as IUserDB,
+      toUserEmail: 'anything@email.com',
+    })
+
+    await expect(isReceiverContactable('uid')).resolves.toEqual(true)
+  })
+
   it("errors when user isn't contactable", async () => {
     jest.spyOn(utils, 'getUserAndEmail').mockResolvedValue({
       toUser: { isContactableByPublic: false } as IUserDB,

--- a/functions/src/emailNotifications/utils.ts
+++ b/functions/src/emailNotifications/utils.ts
@@ -65,7 +65,10 @@ export const isBelowMessageLimit = async (email) => {
 
 export const isReceiverContactable = async (userName) => {
   const { toUser } = await getUserAndEmail(userName)
-  if (!toUser.isContactableByPublic) {
+  if (
+    typeof toUser.isContactableByPublic === 'boolean' &&
+    !toUser.isContactableByPublic
+  ) {
     throw new Error(errors.PROFILE_NOT_CONTACTABLE)
   }
   return true


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

When I moved the feature from opt-in to opt-out, I missed this change needed.

