### PR TITLE
feat/load research comments from discussion

### DIFF
--- a/src/models/discussion.models.tsx
+++ b/src/models/discussion.models.tsx
@@ -11,7 +11,7 @@ export type IDiscussionComment = IComment & {
 export type IDiscussion = {
   _id: string
   sourceId: string
-  sourceType: 'question'
+  sourceType: 'question' | 'researchUpdate'
   comments: IDiscussionComment[]
 }
 

--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -86,6 +86,7 @@ export namespace IResearch {
   /** Research items synced from the database will contain additional metadata */
   // Use of Omit to override the 'updates' type to UpdateDB
   export type ItemDB = Omit<Item, 'updates'> & {
+    totalCommentCount: number
     updates: UpdateDB[]
   } & DBDoc
 

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -86,7 +86,6 @@ const factory = async (
     triggerNotification: jest.fn(),
   }
 
-  // TODO: Switch to generic jest mock
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   store.discussionStore = {

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -440,7 +440,6 @@ export class ResearchStore extends ModuleStore {
           ...toJS(researchItem),
         }
 
-        // await this._updateResearchItem(dbRef, newItem)
         await dbRef.update({
           mentions: users
             .map((userName) => ({
@@ -496,11 +495,8 @@ export class ResearchStore extends ModuleStore {
 
         if (discussion) {
           await this.discussionStore.deleteComment(discussion, commentId)
-          // TODO: Update root comment count
         }
-      }
 
-      if (commentId && item && user && update.comments) {
         const dbRef = this.db
           .collection<IResearch.Item>(COLLECTION_NAME)
           .doc(item._id)

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -100,6 +100,10 @@ export class ModuleStore {
     return this.rootStore!.stores.userNotificationsStore
   }
 
+  get discussionStore() {
+    return this.rootStore!.stores.discussionStore
+  }
+
   /****************************************************************************
    *            Database Management Methods
    * **************************************************************************/


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Branched off of #3281, which should be merged before this one. 

Switches to use Discussions entity for persisting Comments for Research Items. 

* [ ] Tests that verify error paths are handled
* [ ] Handle mentions in comments
	* [ ] Ideally this gets comment ID returned by discussionStore.addComment. At the moment this function returns the entire discussion object.
* [ ] Fast follow (follow up PR): Remove all `comments` property from Research Update
* [x] deleteComment: verify does not modify research update
* [x] Iterate root level comment count when adding comment. No test currently exists
* [x] Merges data from legacy and Discussion stores