### PR TITLE
chore: lower number of e2e ci runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,7 +475,7 @@ workflows:
             - e2e-tests
           matrix:
             parameters:
-              CI_NODE: [1, 2, 3, 4]
+              CI_NODE: [1, 2]
               CI_BROWSER: ['chrome']
           filters:
             branches:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

I'm skeptical the four nodes does anything other than slow the CI process down. 

