### PR TITLE
feat(notifications): add generic comment notification

### DIFF
--- a/functions/src/emailNotifications/__snapshots__/createNotificationEmails.spec.ts.snap
+++ b/functions/src/emailNotifications/__snapshots__/createNotificationEmails.spec.ts.snap
@@ -245,7 +245,6 @@ exports[`create email test Creates email from pending notifications weekly 1`] =
                   >Test research</a
                 >
               </p>
-
               <p>
                 <a href="https://community.preciousplastic.com/u/user_3"
                   >User 3</a

--- a/functions/src/emailNotifications/__snapshots__/createNotificationEmails.spec.ts.snap
+++ b/functions/src/emailNotifications/__snapshots__/createNotificationEmails.spec.ts.snap
@@ -81,21 +81,23 @@ exports[`create email test Creates email from pending notifications monthly 1`] 
               </div>
 
               <p>
-                New comment on your
-                <a href="https://community.preciousplastic.com/test">how-to</a>
-                by
+                New comment by
                 <a href="https://community.preciousplastic.com/u/user_1"
                   >User 1</a
                 >
+                on
+                <a href="https://community.preciousplastic.com/test"
+                  >Test how-to</a
+                >
               </p>
               <p>
-                New comment on your
-                <a href="https://community.preciousplastic.com/test"
-                  >research</a
-                >
-                by
+                New comment by
                 <a href="https://community.preciousplastic.com/u/user_3"
                   >User 3</a
+                >
+                on
+                <a href="https://community.preciousplastic.com/test"
+                  >Test research</a
                 >
               </p>
               <p>
@@ -234,15 +236,16 @@ exports[`create email test Creates email from pending notifications weekly 1`] =
               </p>
 
               <p>
-                New comment on your
-                <a href="https://community.preciousplastic.com/test"
-                  >research</a
-                >
-                by
+                New comment by
                 <a href="https://community.preciousplastic.com/u/user_2"
                   >User 2</a
                 >
+                on
+                <a href="https://community.preciousplastic.com/test"
+                  >Test research</a
+                >
               </p>
+
               <p>
                 <a href="https://community.preciousplastic.com/u/user_3"
                   >User 3</a

--- a/functions/src/emailNotifications/createNotificationEmails.spec.ts
+++ b/functions/src/emailNotifications/createNotificationEmails.spec.ts
@@ -1,7 +1,10 @@
-import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
-import { DB_ENDPOINTS, IUserDB, INotification } from '../models'
-import { createNotificationEmails } from './createNotificationEmails'
 import { EmailNotificationFrequency } from 'oa-shared'
+
+import { DB_ENDPOINTS } from '../models'
+import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
+import { createNotificationEmails } from './createNotificationEmails'
+
+import type { INotification, IUserDB } from '../models'
 
 jest.mock('../Firebase/auth', () => ({
   firebaseAuth: {
@@ -35,7 +38,7 @@ const notificationFactory = (
     userId: '',
   },
   relevantUrl: '',
-  type: 'new_comment',
+  type: 'new_comment_discussion',
   read: false,
   notified: false,
   ...notification,
@@ -69,7 +72,8 @@ describe('create email test', () => {
           userId: 'user_2',
         },
         relevantUrl: '/test',
-        type: 'new_comment_research',
+        title: 'Test research',
+        type: 'new_comment_discussion',
       }),
       notificationFactory('user_1', 'notification_3', {
         triggeredBy: {
@@ -96,7 +100,8 @@ describe('create email test', () => {
           userId: 'user_1',
         },
         relevantUrl: '/test',
-        type: 'new_comment',
+        title: 'Test how-to',
+        type: 'new_comment_discussion',
       }),
       notificationFactory('user_2', 'notification_2', {
         triggeredBy: {
@@ -104,7 +109,8 @@ describe('create email test', () => {
           userId: 'user_3',
         },
         relevantUrl: '/test',
-        type: 'new_comment_research',
+        title: 'Test research',
+        type: 'new_comment_discussion',
       }),
       notificationFactory('user_2', 'notification_3', {
         triggeredBy: {
@@ -131,7 +137,8 @@ describe('create email test', () => {
           userId: 'user_1',
         },
         relevantUrl: '/test',
-        type: 'new_comment',
+        title: 'Test how-to',
+        type: 'new_comment_discussion',
       }),
     ]
 

--- a/functions/src/emailNotifications/utils.ts
+++ b/functions/src/emailNotifications/utils.ts
@@ -207,7 +207,9 @@ const getCommentListItem = (notification: INotification) => `
   New comment by ${getUserLink(
     notification.triggeredBy.displayName,
     notification.triggeredBy.userId,
-  )} on <a href='${SITE_URL}${notification.relevantUrl}'>${notification.title}</a>
+  )} on <a href='${SITE_URL}${notification.relevantUrl}'>${
+  notification.title
+}</a>
 </p>`
 
 const getMentionListItem = (notification: INotification) => `

--- a/functions/src/emailNotifications/utils.ts
+++ b/functions/src/emailNotifications/utils.ts
@@ -203,13 +203,10 @@ const getResourceLink = (
 
 const getCommentListItem = (notification: INotification) => `
 <p>
-    New comment on your ${getResourceLink(
-      notification.type,
-      notification.relevantUrl,
-    )} by ${getUserLink(
-  notification.triggeredBy.displayName,
-  notification.triggeredBy.userId,
-)}
+  New comment by ${getUserLink(
+    notification.triggeredBy.displayName,
+    notification.triggeredBy.userId,
+  )} on <a href='${SITE_URL}${notification.relevantUrl}'>${notification.title}</a>
 </p>`
 
 const getMentionListItem = (notification: INotification) => `
@@ -266,7 +263,9 @@ const getModerationRejectedListItem = (notification: INotification) => `
 </p>`
 
 const isCommentNotification = (notification: INotification) =>
-  ['new_comment_research', 'new_comment'].includes(notification.type)
+  ['new_comment_research', 'new_comment', 'new_comment_discussion'].includes(
+    notification.type,
+  )
 
 const isMentionNotification = (notification: INotification) =>
   ['research_mention', 'howto_mention'].includes(notification.type)

--- a/functions/src/emailNotifications/utils.ts
+++ b/functions/src/emailNotifications/utils.ts
@@ -1,17 +1,18 @@
 import { CONFIG } from '../config/config'
-import {
-  PP_PROJECT_IMAGE,
-  PK_PROJECT_IMAGE,
-  PP_PROJECT_NAME,
-  PK_PROJECT_NAME,
-  PP_SIGNOFF,
-  PK_SIGNOFF,
-} from './constants'
 import { firebaseAuth } from '../Firebase/auth'
 import { db } from '../Firebase/firestoreDB'
-import { DB_ENDPOINTS, IMessageDB, INotification, IUserDB } from '../models'
+import { DB_ENDPOINTS } from '../models'
+import {
+  PK_PROJECT_IMAGE,
+  PK_PROJECT_NAME,
+  PK_SIGNOFF,
+  PP_PROJECT_IMAGE,
+  PP_PROJECT_NAME,
+  PP_SIGNOFF,
+} from './constants'
 
 import type { NotificationType } from 'oa-shared'
+import type { IMessageDB, INotification, IUserDB } from '../models'
 
 export const errors = {
   MESSAGE_LIMIT:

--- a/functions/src/emulator/seed/content-generate.ts
+++ b/functions/src/emulator/seed/content-generate.ts
@@ -65,7 +65,7 @@ async function setMockNotifications(user: IMockAuthUser) {
   const update: Partial<IUserDB> = {
     notifications: [
       {
-        type: 'new_comment',
+        type: 'new_comment_discussion',
         notified: false,
         read: false,
         _created: new Date().toISOString(),
@@ -74,6 +74,7 @@ async function setMockNotifications(user: IMockAuthUser) {
           displayName: 'Demo User',
           userId: 'demo_user',
         },
+        relevantUrl: '/testing-demo',
         title: 'Demo Title',
       },
     ],
@@ -87,6 +88,7 @@ async function setMockNotifications(user: IMockAuthUser) {
         howto_needs_updates: true,
         map_pin_approved: true,
         map_pin_needs_updates: true,
+        new_comment_discussion: true,
         new_comment_research: true,
         research_useful: true,
         research_mention: true,

--- a/packages/components/src/NotificationItem/NotificationItem.stories.tsx
+++ b/packages/components/src/NotificationItem/NotificationItem.stories.tsx
@@ -17,6 +17,7 @@ export const Default: StoryFn<typeof NotificationItem> = () => (
 
 export const Comment: StoryFn<typeof NotificationItem> = () => (
   <NotificationItem type="new_comment">
+    (Legacy)
     {faker.lorem.sentence()}
   </NotificationItem>
 )
@@ -29,6 +30,7 @@ export const CommentDiscussion: StoryFn<typeof NotificationItem> = () => (
 
 export const CommentResearch: StoryFn<typeof NotificationItem> = () => (
   <NotificationItem type="new_comment_research">
+    (Legacy)
     {faker.lorem.sentence()}
   </NotificationItem>
 )

--- a/packages/components/src/NotificationItem/NotificationItem.stories.tsx
+++ b/packages/components/src/NotificationItem/NotificationItem.stories.tsx
@@ -21,6 +21,12 @@ export const Comment: StoryFn<typeof NotificationItem> = () => (
   </NotificationItem>
 )
 
+export const CommentDiscussion: StoryFn<typeof NotificationItem> = () => (
+  <NotificationItem type="new_comment_discussion">
+    {faker.lorem.sentence()}
+  </NotificationItem>
+)
+
 export const CommentResearch: StoryFn<typeof NotificationItem> = () => (
   <NotificationItem type="new_comment_research">
     {faker.lorem.sentence()}

--- a/packages/components/src/NotificationList/NotificationList.stories.tsx
+++ b/packages/components/src/NotificationList/NotificationList.stories.tsx
@@ -24,7 +24,7 @@ const notifications = [
     type: 'new_comment',
     children: (
       <>
-        {faker.lorem.words(4)}{' '}
+        (Legacy) {faker.lorem.words(4)}{' '}
         <InternalLink to="/">{faker.lorem.words(2)}</InternalLink>
       </>
     ),
@@ -51,7 +51,7 @@ const notifications = [
     type: 'new_comment_research',
     children: (
       <>
-        {faker.lorem.words(4)}{' '}
+        (Legacy) {faker.lorem.words(4)}{' '}
         <InternalLink to="/">{faker.lorem.words(2)}</InternalLink>
       </>
     ),

--- a/packages/components/src/NotificationList/NotificationList.stories.tsx
+++ b/packages/components/src/NotificationList/NotificationList.stories.tsx
@@ -39,6 +39,15 @@ const notifications = [
     ),
   },
   {
+    type: 'new_comment_discussion',
+    children: (
+      <>
+        (Legacy) {faker.lorem.words(4)}{' '}
+        <InternalLink to="/">{faker.lorem.words(2)}</InternalLink>
+      </>
+    ),
+  },
+  {
     type: 'new_comment_research',
     children: (
       <>

--- a/packages/cypress/src/integration/notifications.spec.ts
+++ b/packages/cypress/src/integration/notifications.spec.ts
@@ -122,7 +122,9 @@ describe('[Notifications]', () => {
           (n) => n['type'] === 'new_comment_discussion',
         )
 
-        expect(filtedNotifications[1]['type']).to.equal('new_comment_discussion')
+        expect(filtedNotifications[1]['type']).to.equal(
+          'new_comment_discussion',
+        )
         expect(filtedNotifications[1]['relevantUrl']).to.equal(
           '/research/qwerty#update_0',
         )

--- a/packages/cypress/src/integration/notifications.spec.ts
+++ b/packages/cypress/src/integration/notifications.spec.ts
@@ -90,10 +90,10 @@ describe('[Notifications]', () => {
         expect(notifications.length).to.be.greaterThan(0)
 
         const notification = notifications.find(
-          (n) => n['type'] === 'new_comment',
+          (n) => n['type'] === 'new_comment_discussion',
         )
 
-        expect(notification['type']).to.equal('new_comment')
+        expect(notification['type']).to.equal('new_comment_discussion')
         expect(notification['relevantUrl']).to.equal('/how-to/testing-testing')
         expect(notification['read']).to.equal(false)
         expect(notification['triggeredBy']['displayName']).to.equal(
@@ -118,16 +118,16 @@ describe('[Notifications]', () => {
         const [user] = docs
         const notifications = user['notifications']
         expect(notifications.length).to.greaterThan(0)
-        const notification = notifications.find(
-          (n) => n['type'] === 'new_comment_research',
+        const filtedNotifications = notifications.filter(
+          (n) => n['type'] === 'new_comment_discussion',
         )
 
-        expect(notification['type']).to.equal('new_comment_research')
-        expect(notification['relevantUrl']).to.equal(
+        expect(filtedNotifications[1]['type']).to.equal('new_comment_discussion')
+        expect(filtedNotifications[1]['relevantUrl']).to.equal(
           '/research/qwerty#update_0',
         )
-        expect(notification['read']).to.equal(false)
-        expect(notification['triggeredBy']['displayName']).to.equal(
+        expect(filtedNotifications[1]['read']).to.equal(false)
+        expect(filtedNotifications[1]['triggeredBy']['displayName']).to.equal(
           'howto_reader',
         )
       },

--- a/shared/models/notifications.ts
+++ b/shared/models/notifications.ts
@@ -6,15 +6,15 @@ export enum EmailNotificationFrequency {
 }
 
 export const NotificationTypes = [
-  'new_comment',
+  'new_comment', // legacy format, should use new_comment_discussion
   'howto_useful',
   'howto_mention',
   'howto_approved',
   'howto_needs_updates',
   'map_pin_approved',
   'map_pin_needs_updates',
-  'new_comment_research',
   'new_comment_discussion',
+  'new_comment_research', // legacy format, should use new_comment_discussion
   'research_useful',
   'research_mention',
   'research_update',

--- a/shared/models/notifications.ts
+++ b/shared/models/notifications.ts
@@ -14,6 +14,7 @@ export const NotificationTypes = [
   'map_pin_approved',
   'map_pin_needs_updates',
   'new_comment_research',
+  'new_comment_discussion',
   'research_useful',
   'research_mention',
   'research_update',

--- a/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
+++ b/src/pages/Howto/Content/Howto/HowToComments/HowToComments.tsx
@@ -23,17 +23,7 @@ export const HowToComments = ({ comments }: IProps) => {
 
   const onSubmit = async (comment: string) => {
     try {
-      const howto = stores.howtoStore.activeHowto
       await stores.howtoStore.addComment(comment)
-      if (howto) {
-        await stores.userNotificationsStore.triggerNotification(
-          'new_comment',
-          howto._createdBy,
-          '/how-to/' + howto.slug,
-          howto.title,
-        )
-      }
-
       setComment('')
 
       const action = 'Submitted'

--- a/src/pages/common/Header/getFormattedNotifications.tsx
+++ b/src/pages/common/Header/getFormattedNotifications.tsx
@@ -15,6 +15,7 @@ export const getFormattedNotificationMessage = (
   const relevantUrl = notification.relevantUrl || ''
   const relevantTitle = notification.title || ''
   switch (notification.type) {
+    // legacy format, should use new_comment_discussion
     case 'new_comment':
       return (
         <Box>
@@ -130,6 +131,7 @@ export const getFormattedNotificationMessage = (
           needs some updates before we can approve it
         </Box>
       )
+    // legacy format, should use new_comment_discussion
     case 'new_comment_research':
       return (
         <Box>

--- a/src/pages/common/Header/getFormattedNotifications.tsx
+++ b/src/pages/common/Header/getFormattedNotifications.tsx
@@ -141,9 +141,15 @@ export const getFormattedNotificationMessage = (
           <InternalLink to={relevantUrl}>{relevantTitle}</InternalLink>
         </Box>
       )
+    case 'new_comment_discussion':
+      return (
+        <Box>
+          New comment from <strong> {triggeredBy.displayName} </strong>
+          on <InternalLink to={relevantUrl}> {relevantTitle}</InternalLink>
+        </Box>
+      )
     default:
       return <></>
-      break
   }
 }
 

--- a/src/stores/Howto/howto.store.test.ts
+++ b/src/stores/Howto/howto.store.test.ts
@@ -351,6 +351,15 @@ describe('howto.store', () => {
             },
           ]),
         )
+        expect(
+          store.userNotificationsStore.triggerNotification,
+        ).toHaveBeenCalledTimes(2)
+        expect(store.userNotificationsStore.triggerNotification).toBeCalledWith(
+          'new_comment_discussion',
+          newHowto._createdBy,
+          '/how-to/' + newHowto.slug,
+          newHowto.title,
+        )
       })
 
       it('preserves @mentions in description', async () => {

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -323,6 +323,7 @@ export class HowtoStore extends ModuleStore {
           comments: [...toJS(howto.comments || []), newComment],
         })
 
+        await this.addCommentNotification(howto)
         await this.setActiveHowtoBySlug(updated?.slug || '')
       }
     } catch (err) {
@@ -603,6 +604,15 @@ export class HowtoStore extends ModuleStore {
       logger.error('error', error)
       throw new Error(error.message)
     }
+  }
+
+  private async addCommentNotification(howto: IHowto) {
+    await this.userNotificationsStore.triggerNotification(
+      'new_comment_discussion',
+      howto._createdBy,
+      '/how-to/' + howto.slug,
+      howto.title,
+    )
   }
 
   private async findMentionsInComments(rawComments: IComment[] | undefined) {

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -154,13 +154,13 @@ describe('research.store', () => {
           store.userNotificationsStore.triggerNotification,
         ).toHaveBeenCalledTimes(2)
         expect(store.userNotificationsStore.triggerNotification).toBeCalledWith(
-          'new_comment_research',
+          'new_comment_discussion',
           researchItem._createdBy,
           `/research/${researchItem.slug}#update_0`,
           researchItem.title,
         )
         expect(store.userNotificationsStore.triggerNotification).toBeCalledWith(
-          'new_comment_research',
+          'new_comment_discussion',
           'a-contributor',
           `/research/${researchItem.slug}#update_0`,
           researchItem.title,

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -448,7 +448,7 @@ export class ResearchStore extends ModuleStore {
 
         // Notify author and contributors
         await this.userNotificationsStore.triggerNotification(
-          'new_comment_research',
+          'new_comment_discussion',
           newItem._createdBy,
           '/research/' + newItem.slug + '#update_' + existingUpdateIndex,
           newItem.title,
@@ -456,7 +456,7 @@ export class ResearchStore extends ModuleStore {
 
         newItem.collaborators.map((username) => {
           this.userNotificationsStore.triggerNotification(
-            'new_comment_research',
+            'new_comment_discussion',
             username,
             '/research/' + newItem.slug + '#update_' + existingUpdateIndex,
             newItem.title,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In preparation for #3259 which will require a new comment notification to be added, this adds a new generic comment notification type and moves research/how tos over to it.

## Screenshots/Videos

<img width="272" alt="Screenshot 2024-02-28 at 14 01 51" src="https://github.com/ONEARMY/community-platform/assets/16688508/f57e9b7c-f00d-47aa-8cc5-dfc3bb923d03">
(The top one is a how-to, the second and third is research)