### PR TITLE
fix: impact fields sorted in correct order

### DIFF
--- a/src/pages/User/impact/ImpactItem.test.tsx
+++ b/src/pages/User/impact/ImpactItem.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'mobx-react'
+import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import { FactoryUser } from 'src/test/factories/User'
+
+import { ImpactItem } from './ImpactItem'
+
+jest.mock('src/common/hooks/useCommonStores', () => {
+  return {
+    useCommonStores: () => ({
+      stores: {
+        userStore: {
+          activeUser: { userName: 'activeUser' },
+        },
+      },
+    }),
+  }
+})
+
+describe('ImpactItem', () => {
+  it('renders an impact item with visible fields for a specific year, with impact fields in order: plastic, revenue, employees, volunteers, machines ', async () => {
+    const user = FactoryUser({ userName: 'activeUser' })
+    const fields = [
+      {
+        id: 'machines',
+        value: 15,
+        isVisible: true,
+      },
+      {
+        id: 'revenue',
+        value: 54000,
+        isVisible: true,
+      },
+      { id: 'plastic', value: 30000, isVisible: true },
+    ]
+    render(
+      <Provider {...useCommonStores().stores}>
+        <ImpactItem fields={fields} user={user} year={2022} />
+      </Provider>,
+    )
+    const plasticItem = await screen.findByText('30,000 Kg of plastic recycled')
+    const revenueItem = await screen.findByText('$ 54,000 revenue')
+
+    expect(plasticItem.compareDocumentPosition(revenueItem)).toBe(4)
+  })
+})

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -1,3 +1,4 @@
+import { sortImpactYearDisplayFields } from 'src/pages/UserSettings/content/formSections/Impact/utils'
 import { Box, Heading } from 'theme-ui'
 
 import { ImpactField } from './ImpactField'
@@ -24,7 +25,8 @@ export const ImpactItem = ({ fields, user, year }: Props) => {
     padding: 2,
   }
 
-  const visibleFields = fields?.filter((field) => field.isVisible)
+  const sortedFields = sortImpactYearDisplayFields(fields)
+  const visibleFields = sortedFields?.filter((field) => field.isVisible)
 
   return (
     <Box sx={outterBox} cy-data="ImpactItem">

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
@@ -8,7 +8,11 @@ import { Box, Heading } from 'theme-ui'
 
 import { ImpactYearField } from './ImpactYear.field'
 import { ImpactYearDisplayField } from './ImpactYearDisplay.field'
-import { transformImpactData, transformImpactInputs } from './utils'
+import {
+  sortImpactYearDisplayFields,
+  transformImpactData,
+  transformImpactInputs,
+} from './utils'
 
 import type { IImpactYear, IImpactYearFieldList } from 'src/models'
 import type { SubmitResults } from 'src/pages/User/contact/UserContactError'
@@ -31,6 +35,7 @@ export const ImpactYearSection = observer(({ year }: Props) => {
         setImpact(impact[year])
       }
     }
+
     fetchImpact()
   }, [])
 
@@ -48,10 +53,11 @@ export const ImpactYearSection = observer(({ year }: Props) => {
     setSubmitResults(null)
     try {
       const fields = transformImpactInputs(values)
+      const sortedFields = sortImpactYearDisplayFields(fields)
       await userStore.updateUserImpact(fields, year)
       setSubmitResults({ type: 'success', message: form.saveSuccess })
       setIsEditMode(false)
-      setImpact(fields)
+      setImpact(sortedFields)
     } catch (error) {
       setSubmitResults({ type: 'error', message: error.message })
     }
@@ -77,7 +83,9 @@ export const ImpactYearSection = observer(({ year }: Props) => {
             />
           ) : (
             <ImpactYearDisplayField
-              fields={transformImpactInputs(values)}
+              fields={sortImpactYearDisplayFields(
+                transformImpactInputs(values),
+              )}
               formId={formId}
               setIsEditMode={setIsEditMode}
             />

--- a/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.test.ts
@@ -1,4 +1,8 @@
-import { transformImpactData, transformImpactInputs } from './utils'
+import {
+  sortImpactYearDisplayFields,
+  transformImpactData,
+  transformImpactInputs,
+} from './utils'
 
 describe('transformImpactData', () => {
   it('returns data structured as field inputs', () => {
@@ -49,5 +53,30 @@ describe('transformImpactInputs', () => {
       },
     ]
     expect(transformImpactInputs(inputFields)).toEqual(expected)
+  })
+})
+
+describe('sortImpactYearDisplayFields', () => {
+  it('sorts impact data in the same order as impact questions', () => {
+    const fields = [
+      {
+        id: 'machines',
+        value: 15,
+        isVisible: true,
+      },
+      {
+        id: 'revenue',
+        value: 2000,
+        isVisible: true,
+      },
+      { id: 'plastic', value: 30000, isVisible: true },
+    ]
+
+    const expected = [
+      { id: 'plastic', value: 30000, isVisible: true },
+      { id: 'revenue', value: 2000, isVisible: true },
+      { id: 'machines', value: 15, isVisible: true },
+    ]
+    expect(sortImpactYearDisplayFields(fields)).toEqual(expected)
   })
 })

--- a/src/pages/UserSettings/content/formSections/Impact/utils.ts
+++ b/src/pages/UserSettings/content/formSections/Impact/utils.ts
@@ -50,3 +50,18 @@ export const transformImpactInputs = (
 
   return fields
 }
+
+export const sortImpactYearDisplayFields = (
+  fields: IImpactYearFieldList | undefined,
+): IImpactYearFieldList => {
+  const sortedFields = [] as IImpactYearFieldList
+  if (!fields) {
+    return sortedFields
+  }
+
+  impactQuestions.forEach((question) => {
+    const answer = fields.find((element) => element.id === question.id)
+    answer !== undefined ? sortedFields.push(answer) : null
+  })
+  return sortedFields
+}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Enforces correct order on impact fields (Plastic, Revenue, Employees, Volunteers, Machines).

## Git Issues

Closes #3251
