### PR TITLE
chore: add force command for indexes deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ commands:
       - run:
           # Use version of firebase-tools already installed in functions workspace to deploy
           name: Deploy to Firebase
-          command: npx firebase-tools@12.7.0 deploy --debug -P << parameters.alias >> --non-interactive
+          command: npx firebase-tools@12.7.0 deploy --debug -P << parameters.alias >> --non-interactive --force
           environment:
             GOOGLE_APPLICATION_CREDENTIALS: service_account.json
 


### PR DESCRIPTION
As we're now defining the database indexes programmatically, we need the already deployed indexes to not complain with every fresh deployment.