### PR TITLE
chore: update faker-js

### DIFF
--- a/functions/src/emailNotifications/development/entry-server.mjs
+++ b/functions/src/emailNotifications/development/entry-server.mjs
@@ -14,7 +14,7 @@ export function render(url) {
   if (availableTemplates.includes(template)) {
     const html = getEmailHtml(template, {
       user: {
-        displayName: faker.name.fullName(),
+        displayName: faker.person.fullName(),
       },
       site: {
         name: PP_PROJECT_NAME,

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@commitlint/cz-commitlint": "^16.2.3",
     "@craco/craco": "^7.0.0",
     "@craco/types": "^7.0.0",
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^8.4.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -339,7 +339,7 @@ describe('userStore', () => {
       store.activeUser = FactoryUser({
         _id: 'testUserId',
       })
-      const impactYear = faker.datatype.number({ min: 2019, max: 2023 })
+      const impactYear = faker.number.int({ min: 2019, max: 2023 })
       // Act
       await store.updateUserImpact(
         { impact: { total: 100, totalPreciousPlastic: 100 } },

--- a/src/test/factories/Comment.ts
+++ b/src/test/factories/Comment.ts
@@ -5,7 +5,7 @@ import type { IComment } from 'src/models'
 export const FactoryComment = (
   commentOverloads: Partial<IComment> = {},
 ): IComment => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _created: faker.date.past().toString(),
   _edited: faker.date.past().toString(),
   _creatorId: faker.internet.userName(),

--- a/src/test/factories/Discussion.ts
+++ b/src/test/factories/Discussion.ts
@@ -7,9 +7,9 @@ import type { IDiscussion, IDiscussionComment } from 'src/models'
 export const FactoryDiscussion = (
   discussionOverloads: Partial<IDiscussion> = {},
 ): IDiscussion => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   comments: [],
-  sourceId: faker.datatype.uuid(),
+  sourceId: faker.string.uuid(),
   sourceType: 'question',
   ...discussionOverloads,
 })

--- a/src/test/factories/Howto.ts
+++ b/src/test/factories/Howto.ts
@@ -26,13 +26,13 @@ export const FactoryHowto = (
   description: faker.lorem.paragraph(),
   category: {
     label: 'howto',
-    _id: faker.datatype.uuid(),
+    _id: faker.string.uuid(),
     _modified: faker.date.past().toString(),
     _created: faker.date.past().toString(),
     _deleted: faker.datatype.boolean(),
     _contentModifiedTimestamp: faker.date.past().toString(),
   },
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
@@ -50,8 +50,8 @@ export const FactoryHowto = (
     updated: '',
     size: 0,
   },
-  total_views: faker.datatype.number(),
-  total_downloads: faker.datatype.number(),
+  total_views: faker.number.int(),
+  total_downloads: faker.number.int(),
   votedUsefulBy: [],
   ...howtoOverloads,
 })
@@ -78,7 +78,7 @@ export const FactoryHowtoStep = (
 export const FactoryHowtoDraft = (
   howtoOverloads: Partial<IHowtoDB> = {},
 ): IHowtoDB => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _contentModifiedTimestamp: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _createdBy: faker.internet.userName(),

--- a/src/test/factories/MapPin.ts
+++ b/src/test/factories/MapPin.ts
@@ -7,7 +7,7 @@ import type { IMapPin } from 'src/models'
 export const FactoryMapPin = (
   userOverloads: Partial<IMapPin> = {},
 ): IMapPin => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _deleted: faker.datatype.boolean(),
   type: faker.helpers.arrayElement(Object.values(ProfileType)),
   subType: faker.helpers.arrayElement([
@@ -25,8 +25,8 @@ export const FactoryMapPin = (
     IModerationStatus.ACCEPTED,
   ]),
   location: {
-    lng: parseFloat(faker.address.longitude()),
-    lat: parseFloat(faker.address.latitude()),
+    lng: faker.location.longitude(),
+    lat: faker.location.latitude(),
   },
   ...userOverloads,
 })

--- a/src/test/factories/Notification.ts
+++ b/src/test/factories/Notification.ts
@@ -11,7 +11,7 @@ export const FactoryNotification = (
   notified: faker.datatype.boolean(),
   read: faker.datatype.boolean(),
   triggeredBy: {
-    displayName: faker.name.fullName(),
+    displayName: faker.person.fullName(),
     userId: faker.internet.userName(),
   },
   type: faker.helpers.arrayElement(NotificationTypes),

--- a/src/test/factories/Question.ts
+++ b/src/test/factories/Question.ts
@@ -5,7 +5,7 @@ import type { IQuestion } from 'src/models'
 export const FactoryQuestionItem = (
   questionOverloads: Partial<IQuestion.Item> = {},
 ): IQuestion.Item => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
   _contentModifiedTimestamp: faker.date.past().toString(),

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -16,7 +16,7 @@ export const FactoryResearchItemUpdate = (
   files: [],
   fileLink: faker.internet.url(),
   downloadCount: 0,
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
@@ -28,7 +28,7 @@ export const FactoryResearchItemUpdate = (
 export const FactoryResearchItem = (
   researchItemOverloads: Partial<IResearchDB & ResearchCalculatedFields> = {},
 ): IResearchDB & ResearchCalculatedFields => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _createdBy: faker.internet.userName(),
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
@@ -47,17 +47,18 @@ export const FactoryResearchItem = (
   ]),
   mentions: [],
   previousSlugs: [],
-  total_views: faker.datatype.number(),
+  total_views: faker.number.int(),
   collaborators: [],
   subscribers: [],
   userHasSubscribed: faker.datatype.boolean(),
+  totalCommentCount: 0,
   ...researchItemOverloads,
 })
 
 export const FactoryResearchItemFormInput = (
   researchItemOverloads: Partial<IResearch.FormInput> = {},
 ): IResearch.FormInput => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _createdBy: faker.internet.userName(),
   description: faker.lorem.paragraphs(),
   title: faker.lorem.words(),

--- a/src/test/factories/User.ts
+++ b/src/test/factories/User.ts
@@ -7,15 +7,15 @@ import type { IUserPPDB } from 'src/models'
 export const FactoryUser = (
   userOverloads: Partial<IUserPPDB> = {},
 ): IUserPPDB => ({
-  _id: faker.datatype.uuid(),
+  _id: faker.string.uuid(),
   _created: faker.date.past().toString(),
   _modified: faker.date.past().toString(),
   _deleted: faker.datatype.boolean(),
   _contentModifiedTimestamp: faker.date.past().toString(),
-  _authID: faker.datatype.uuid(),
+  _authID: faker.string.uuid(),
   profileType: faker.helpers.arrayElement(Object.values(ProfileType)),
   userName: faker.internet.userName(),
-  displayName: faker.name.fullName(),
+  displayName: faker.person.fullName(),
   verified: faker.datatype.boolean(),
   links: [],
   moderation: faker.helpers.arrayElement([
@@ -24,7 +24,7 @@ export const FactoryUser = (
     IModerationStatus.REJECTED,
     IModerationStatus.ACCEPTED,
   ]),
-  country: faker.address.countryCode(),
+  country: faker.location.countryCode(),
   notifications: [],
   coverImages: [] as any[],
   ...userOverloads,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5336,6 +5336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@faker-js/faker@npm:8.4.1"
+  checksum: d802d531f8929562715adc279cfec763c9a4bc596ec67b0ce43fd0ae61b285d2b0eec6f1f4aa852452a63721a842fe7e81926dce7bd92acca94b01e2a1f55f5a
+  languageName: node
+  linkType: hard
+
 "@fal-works/esbuild-plugin-global-externals@npm:^2.1.2":
   version: 2.1.2
   resolution: "@fal-works/esbuild-plugin-global-externals@npm:2.1.2"
@@ -27591,7 +27598,7 @@ __metadata:
     "@craco/types": ^7.0.0
     "@emotion/react": ^11.10.6
     "@emotion/styled": ^11.8.1
-    "@faker-js/faker": ^7.6.0
+    "@faker-js/faker": ^8.4.1
     "@semantic-release/changelog": ^6.0.1
     "@semantic-release/git": ^10.0.1
     "@sentry/react": ^6.15.0


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description
Update Faker JS from 7.6.0 to 8.4.1, 7.6.0 was clouding up the unit test logs with warnings about methods being depreciated.
This PR updates FakerJS to the latest version, and changes all the deprecated methods to use the new ones. Removing the slew of warnings when running tests.

Here's a comparison between yarn test:unit outputs

[after_faker_upgrade_yarn_unit.txt](https://github.com/ONEARMY/community-platform/files/14808966/after_faker_upgrade_yarn_unit.txt)
[before_faker_upgrade_yarn_unit.txt](https://github.com/ONEARMY/community-platform/files/14808967/before_faker_upgrade_yarn_unit.txt)



