### PR TITLE
chore: deal with jest console warnings

### DIFF
--- a/src/logger/index.test.ts
+++ b/src/logger/index.test.ts
@@ -3,7 +3,7 @@ import { logger } from './index'
 describe('logger', () => {
   it('should support all log level methods', () => {
     ;['debug', 'info', 'warn', 'error', 'fatal'].forEach((level) => {
-      logger[level]('test')
+      expect(typeof logger[level]).toBe('function')
     })
   })
 })

--- a/src/pages/Question/QuestionDiscussion.tsx
+++ b/src/pages/Question/QuestionDiscussion.tsx
@@ -47,7 +47,7 @@ export const QuestionDiscussion = (props: IProps) => {
   }, [questionDocId])
 
   const handleEdit = async (_id: string, comment: string) => {
-    logger.info({ _id, comment }, 'question comment edited')
+    logger.debug({ _id, comment }, 'question comment edited')
     if (discussion) {
       store.editComment(discussion, _id, comment)
     }

--- a/src/pages/Research/Content/EditResearch/index.tsx
+++ b/src/pages/Research/Content/EditResearch/index.tsx
@@ -84,7 +84,7 @@ const EditResearch = observer(() => {
   }
 
   if (formValues.locked && formValues.locked.by !== loggedInUser?.userName) {
-    logger.info('Research is locked', formValues.locked)
+    logger.debug('Research is locked', formValues.locked)
     return (
       <BlockedRoute>
         The research description is currently being edited by another editor.

--- a/src/pages/UserSettings/UserSettings.test.tsx
+++ b/src/pages/UserSettings/UserSettings.test.tsx
@@ -66,7 +66,10 @@ describe('UserSettings', () => {
     mockUser = FactoryUser()
 
     // Act
-    const wrapper = await Wrapper(mockUser)
+    let wrapper
+    await act(async () => {
+      wrapper = await Wrapper(mockUser)
+    })
 
     // Assert
     expect(wrapper.getByText('Edit profile'))

--- a/src/stores/Message/message.store.tsx
+++ b/src/stores/Message/message.store.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext } from 'react'
 import { action, makeObservable } from 'mobx'
-import { logger } from 'src/logger'
 import { isUserBlockedFromMessaging } from 'src/utils/helpers'
 
 import { ModuleStore } from '../common/module.store'
@@ -22,16 +21,12 @@ export class MessageStore extends ModuleStore {
   public async upload(values: IMessageInput) {
     const messagesByEmailer = await this.messagesByEmailer(values.email)
     if (messagesByEmailer.length >= EMAIL_ADDRESS_SEND_LIMIT) {
-      logger.error('Too many messages sent', values)
-
       const error = new Error('Too many messages sent')
       return Promise.reject(error)
     }
 
     const isUserBlocked = isUserBlockedFromMessaging(this.activeUser)
     if (isUserBlocked) {
-      logger.error('User blocked from messaging', values)
-
       const error = new Error('Blocked from messaging')
       return Promise.reject(error)
     }
@@ -42,7 +37,6 @@ export class MessageStore extends ModuleStore {
         .doc()
         .set({ isSent: false, ...values })
     } catch (error) {
-      logger.error(error)
       return error
     }
   }

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -6,6 +6,7 @@ import { FactoryHowto } from 'src/test/factories/Howto'
 import { FactoryResearchItem } from 'src/test/factories/ResearchItem'
 import { FactoryUser } from 'src/test/factories/User'
 
+import { logger } from '../../logger'
 import { UserStore } from './user.store'
 
 import type { IUserPP } from 'src/models/userPreciousPlastic.models'
@@ -111,6 +112,10 @@ describe('userStore', () => {
     })
 
     it('returns a single user object when 2 exist', async () => {
+      // Suppress warning for this test since the original function logs a warning if two users are found.
+      // However, this is covered by an Expect in the test, removing the need for console logging during testing.
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(jest.fn())
+
       // Lookup1
       store.db.getWhere.mockReturnValueOnce([
         FactoryUser({
@@ -149,6 +154,8 @@ describe('userStore', () => {
         links: expect.any(Array),
         notifications: expect.any(Array),
       })
+
+      warnSpy.mockRestore()
     })
 
     it('falls back to auth property for lookup when no user found', async () => {

--- a/src/utils/cdnImageUrl.test.ts
+++ b/src/utils/cdnImageUrl.test.ts
@@ -1,3 +1,5 @@
+import { logger } from 'src/logger'
+
 const STORAGE_BUCKET = 'some-bucket'
 
 describe('cdnImageUrl', () => {
@@ -6,6 +8,15 @@ describe('cdnImageUrl', () => {
   })
 
   it('should ignore invalid URL', () => {
+    jest.doMock('src/logger', () => ({
+      logger: {
+        warn: jest.fn(),
+      },
+    }))
+
+    //  Supress warning for this test since we are purposely testing for an invalid URL with an Expect
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(jest.fn())
+
     // Mocking empty CDN_URL
     jest.doMock('src/config/config', () => ({
       getConfigurationOption: jest.fn(),
@@ -18,6 +29,7 @@ describe('cdnImageUrl', () => {
       'https://firebasestorage.googleapis.com/v0/b/some-bucket/image.jpg'
 
     expect(cdnImageUrl(originalUrl)).toBe(originalUrl)
+    warnSpy.mockRestore()
   })
 
   it('should return well formed URL if input is poorly formatted', () => {


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

I dealt with most of the Jest console warnings as well as the unnecessary logging appearing.

- For `logger` itself, I expected the test log entries of debug, info, warn, fatal instead of displaying them.

- For `Message.store.tsx` I removed the logger.error calls because the test looks for Errors thrown so no need to cloud the logging, if the tests will fail in that regard.

- For files that called logger.info, I switched to logger.debug instead to hide the calls in the tests, but keep them around for debugging. Let me know if you think this what the right choice for those items. 

- There were a few tests like in `user.store.test.tsx` where it was testing for if two users were returned form the same id and it would return a warning, but if it wouldn't cause a failure of the test. 

So for those type of scenarios, I decided to mock the warning to hide from the test suite, since its not failing on expect. Let me know if you want something different in that scenario.

Lastly, while trying to figure out the best approach, I noticed that in `functions/src/test/firebase/logger.ts` there was at one point a top level mock that spied on all firebase logger methods


## Git Issues

Closes #3303




