### PR TITLE
Refactor/research search

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,354 @@
 {
   "indexes": [
     {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "latestCommentDate",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "latestCommentDate",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "latestCommentDate",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "commentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "latestCommentDate",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "questions_rev20230926",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "questionCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "research_rev20201020",
       "queryScope": "COLLECTION",
       "fields": [
@@ -11,6 +359,24 @@
         {
           "fieldPath": "votedUsefulBy",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
         }
       ]
     },
@@ -25,6 +391,370 @@
         {
           "fieldPath": "votedUsefulBy",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUsefulVotes",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "keywords",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "totalUsefulVotes",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
         }
       ]
     },
@@ -39,6 +769,298 @@
         {
           "fieldPath": "votedUsefulBy",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchCategory._id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUsefulVotes",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_created",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "_modified",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalCommentCount",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "researchStatus",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "totalUsefulVotes",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "totalUpdates",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "research_rev20201020",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "totalUsefulVotes",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "_deleted",
+          "order": "DESCENDING"
         }
       ]
     },
@@ -99,46 +1121,6 @@
         {
           "fieldPath": "votedUsefulBy",
           "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "questions_rev20230926",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "_created",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "_modified",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "commentCount",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "commentCount",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "latestCommentDate",
-          "order": "DESCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "questions_rev20230926",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "questionCategory._id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "_created",
-          "order": "DESCENDING"
         }
       ]
     }

--- a/packages/components/src/UserStatistics/UserStatistics.test.tsx
+++ b/packages/components/src/UserStatistics/UserStatistics.test.tsx
@@ -41,7 +41,7 @@ describe('UserStatistics', () => {
     )
     const researchLink = getByTestId('research-link')
 
-    expect(researchLink.getAttribute('href')).toBe('/research?author=Test User')
+    expect(researchLink.getAttribute('href')).toBe('/research?q=Test User')
   })
 
   it('renders supporter icon when isSupporter is true', () => {

--- a/packages/components/src/UserStatistics/UserStatistics.tsx
+++ b/packages/components/src/UserStatistics/UserStatistics.tsx
@@ -96,7 +96,7 @@ export const UserStatistics = (props: UserStatisticsProps) => {
 
         {props.researchCount ? (
           <InternalLink
-            to={'/research?author=' + props.userName}
+            to={'/research?q=' + props.userName}
             sx={{ color: 'black' }}
             data-testid="research-link"
           >

--- a/packages/cypress/src/integration/research/read.spec.ts
+++ b/packages/cypress/src/integration/research/read.spec.ts
@@ -1,49 +1,9 @@
 describe('[Research]', () => {
-  const SKIP_TIMEOUT = { timeout: 300 }
-  const totalResearchCount = 2
   const researchArticleUrl = '/research/qwerty'
   const authoredResearchArticleUrl = '/research/a-test-research'
 
   beforeEach(() => {
     cy.visit('/research')
-  })
-
-  describe('[List research articles]', () => {
-    describe('[By Everyone]', () => {
-      it('[Shows a list of articles]', () => {
-        cy.step('All research articles are shown')
-
-        cy.get('[data-cy="ResearchListItem"]')
-          .its('length')
-          .should('be.eq', totalResearchCount)
-      })
-
-      it('[See all info]', () => {
-        cy.step('Research cards has basic info')
-        cy.get(
-          `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
-        ).within(() => {
-          cy.contains('qwerty').should('be.exist')
-          cy.contains('event_reader').should('be.exist')
-          cy.get('[data-cy="ItemUpdateText"]').contains('12').should('be.exist')
-          cy.get('[data-cy="ItemResearchStatus"]')
-            .contains('In progress')
-            .should('be.exist')
-        })
-
-        cy.step(
-          `Open Research details when click on a Research ${researchArticleUrl}`,
-        )
-        cy.get(
-          `[data-cy="ResearchListItem"] a[href="${researchArticleUrl}"]`,
-          SKIP_TIMEOUT,
-        ).click()
-        cy.url().should('include', researchArticleUrl)
-        cy.get('[data-cy=file-download-counter]')
-          .contains('2,555 downloads')
-          .should('be.exist')
-      })
-    })
   })
 
   describe('[Read a research article]', () => {

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -132,7 +132,7 @@ describe('[Research]', () => {
           expect(stub.callCount).to.equal(0)
           stub.resetHistory()
         })
-      cy.url().should('match', /\/research$/)
+      cy.url().should('match', /\/research?/)
     })
   })
 

--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -45,17 +45,18 @@ export namespace IResearch {
     updates: Update[]
     mentions?: UserMention[]
     _createdBy: string
-    _deleted: boolean
     collaborators: string[]
     subscribers?: UserIdList
     locked?: ResearchDocumentLock
     totalUpdates?: number
     totalUsefulVotes?: number
+    totalCommentCount?: number
     keywords?: string[]
-  } & Omit<FormInput, 'collaborators'>
+  } & Omit<FormInput, 'collaborators'> &
+    DBDoc
 
   /** A research item update */
-  export interface Update {
+  export type Update = {
     title: string
     description: string
     images: Array<IUploadedFileMeta | IConvertedFileMeta | File | null>
@@ -68,7 +69,8 @@ export namespace IResearch {
     status: ResearchUpdateStatus
     researchStatus?: ResearchStatus
     locked?: ResearchDocumentLock
-  }
+    _id: string
+  } & DBDoc
 
   export interface FormInput extends IModerable, ISharedFeatures {
     title: string

--- a/src/pages/Question/constants.ts
+++ b/src/pages/Question/constants.ts
@@ -2,4 +2,4 @@ export const QUESTION_MIN_TITLE_LENGTH = 10
 export const QUESTION_MAX_TITLE_LENGTH = 60
 export const QUESTION_MAX_DESCRIPTION_LENGTH = 1000
 export const QUESTION_MAX_IMAGES = 4
-export const ITEMS_PER_PAGE = 25
+export const ITEMS_PER_PAGE = 20

--- a/src/pages/Research/Content/ResearchComments.tsx
+++ b/src/pages/Research/Content/ResearchComments.tsx
@@ -12,7 +12,7 @@ import type { IResearch, UserComment } from 'src/models'
 
 interface IProps {
   comments: UserComment[]
-  update: IResearch.UpdateDB
+  update: IResearch.Update
   updateIndex: number
   showComments?: boolean
 }

--- a/src/pages/Research/Content/ResearchFilterHeader.tsx
+++ b/src/pages/Research/Content/ResearchFilterHeader.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import debounce from 'debounce'
+import { Select } from 'oa-components'
+import { ResearchStatus } from 'oa-shared'
+import { FieldContainer } from 'src/common/Form/FieldContainer'
+import { Flex, Input } from 'theme-ui'
+
+import { CategoriesSelectV2 } from '../../common/Category/CategoriesSelectV2'
+import { listing } from '../labels'
+import { ResearchSearchParams, researchService } from '../research.service'
+import { ResearchSortOptions } from '../ResearchSortOptions'
+
+import type { SelectValue } from '../../common/Category/CategoriesSelectV2'
+import type { ResearchSortOption } from '../ResearchSortOptions'
+
+const researchStatusOptions = [
+  { label: 'All', value: '' },
+  ...Object.values(ResearchStatus).map((x) => ({
+    label: x.toString(),
+    value: x.toString(),
+  })),
+]
+
+const researchSortOptions = Array.from(
+  ResearchSortOptions,
+  ([value, label]) => ({
+    label: label,
+    value: value,
+  }),
+)
+
+export const ResearchFilterHeader = () => {
+  const [categories, setCategories] = useState<SelectValue[]>([])
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const categoryParam = searchParams.get(ResearchSearchParams.category)
+  const category = categories?.find((x) => x.value === categoryParam) ?? null
+  const q = searchParams.get(ResearchSearchParams.q)
+  const sort = searchParams.get(ResearchSearchParams.sort) as ResearchSortOption
+  const status =
+    (searchParams.get(ResearchSearchParams.status) as ResearchStatus) || ''
+
+  // TODO: create a library component for this
+  const _inputStyle = {
+    width: ['100%', '100%', '200px'],
+    mr: [0, 0, 2],
+    mb: [3, 3, 0],
+  }
+
+  useEffect(() => {
+    const initCategories = async () => {
+      const categories = (await researchService.getResearchCategories()) || []
+      setCategories(
+        categories.map((x) => {
+          return { value: x._id, label: x.label }
+        }),
+      )
+    }
+
+    initCategories()
+  }, [])
+
+  const updateFilter = useCallback(
+    (key: ResearchSearchParams, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+      setSearchParams(params)
+    },
+    [searchParams],
+  )
+
+  const onSearchInputChange = useCallback(
+    debounce((value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set(ResearchSearchParams.q, value)
+
+      if (value.length > 0 && sort !== 'MostRelevant') {
+        params.set(ResearchSearchParams.sort, 'MostRelevant')
+      }
+
+      if (value.length === 0 || !value) {
+        params.set(ResearchSearchParams.sort, 'Newest')
+      }
+
+      setSearchParams(params)
+    }, 1000),
+    [searchParams],
+  )
+
+  return (
+    <Flex
+      sx={{
+        flexWrap: 'nowrap',
+        justifyContent: 'space-between',
+        flexDirection: ['column', 'column', 'row'],
+        mb: 3,
+      }}
+    >
+      {/* Categories */}
+      <Flex sx={_inputStyle}>
+        <CategoriesSelectV2
+          value={category}
+          onChange={(updatedCategory) =>
+            updateFilter(ResearchSearchParams.category, updatedCategory)
+          }
+          placeholder={listing.filterCategory}
+          isForm={false}
+          categories={categories}
+        />
+      </Flex>
+      {/* Sort */}
+      <Flex sx={_inputStyle}>
+        <FieldContainer>
+          <Select
+            options={researchSortOptions}
+            placeholder={listing.sort}
+            value={{ label: sort, value: sort }}
+            onChange={(sortBy) =>
+              updateFilter(ResearchSearchParams.sort, sortBy.value)
+            }
+          />
+        </FieldContainer>
+      </Flex>
+      {/* Status filter */}
+      <Flex sx={_inputStyle}>
+        <FieldContainer>
+          <Select
+            options={researchStatusOptions}
+            placeholder={listing.status}
+            value={status ? { label: status, value: status } : undefined}
+            onChange={(status) =>
+              updateFilter(ResearchSearchParams.status, status.value)
+            }
+          />
+        </FieldContainer>
+      </Flex>
+      {/* Text search */}
+      <Flex sx={_inputStyle}>
+        <Input
+          variant="inputOutline"
+          data-cy="research-search-box"
+          defaultValue={q || ''}
+          placeholder={listing.search}
+          onChange={(e) => onSearchInputChange(e.target.value)}
+        />
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -15,30 +15,22 @@ import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { isUserVerifiedWithStore } from 'src/common/isUserVerified'
 import { cdnImageUrl } from 'src/utils/cdnImageUrl'
 import { formatDate } from 'src/utils/date'
-import {
-  getPublicUpdates,
-  getResearchTotalCommentCount,
-  researchStatusColour,
-} from 'src/utils/helpers'
+import { getPublicUpdates, researchStatusColour } from 'src/utils/helpers'
 import { Box, Card, Flex, Grid, Heading, Image, Text } from 'theme-ui'
 
 import defaultResearchThumbnail from '../../../assets/images/default-research-thumbnail.jpg'
 
-import type { ITag } from 'src/models'
 import type { IResearch } from 'src/models/research.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 
 interface IProps {
-  item: IResearch.ItemDB & {
-    votedUsefulCount: number
-  } & { tagList?: ITag[] }
+  item: IResearch.Item
 }
 
 const ResearchListItem = ({ item }: IProps) => {
   const { aggregationsStore } = useCommonStores().stores
   const collaborators = item['collaborators'] || []
-  const usefulDisplayCount =
-    item.votedUsefulCount > 0 ? item.votedUsefulCount : 0
+  const usefulDisplayCount = item.totalUsefulVotes ?? 0
 
   const _commonStatisticStyle = {
     display: 'flex',
@@ -201,7 +193,7 @@ const ResearchListItem = ({ item }: IProps) => {
                     <Icon glyph="star-active" ml={1} />
                   </Text>
                   <Text color="black" ml={3} sx={_commonStatisticStyle}>
-                    {getResearchTotalCommentCount(item)}
+                    {item.totalCommentCount}
                     <Icon glyph="comment" ml={1} />
                   </Text>
                   <Text
@@ -231,7 +223,7 @@ const ResearchListItem = ({ item }: IProps) => {
                 text="How useful is it"
               />
               <IconCountWithTooltip
-                count={getResearchTotalCommentCount(item)}
+                count={item.totalCommentCount || 0}
                 icon="comment"
                 text="Total comments"
               />
@@ -261,7 +253,7 @@ const ResearchListItem = ({ item }: IProps) => {
   )
 }
 
-const getItemThumbnail = (researchItem: IResearch.ItemDB): string => {
+const getItemThumbnail = (researchItem: IResearch.Item): string => {
   if (researchItem.updates?.length) {
     const latestImage = getPublicUpdates(researchItem)
       ?.map((u) => (u.images?.[0] as IUploadedFileMeta)?.downloadUrl)
@@ -273,10 +265,8 @@ const getItemThumbnail = (researchItem: IResearch.ItemDB): string => {
   }
 }
 
-const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
-  const contentModifiedDate = formatDate(
-    new Date(item._contentModifiedTimestamp || item._modified),
-  )
+const getItemDate = (item: IResearch.Item, variant: string): string => {
+  const contentModifiedDate = formatDate(new Date(item._modified))
   const creationDate = formatDate(new Date(item._created))
 
   if (contentModifiedDate !== creationDate) {
@@ -288,7 +278,7 @@ const getItemDate = (item: IResearch.ItemDB, variant: string): string => {
   }
 }
 
-const getUpdateCount = (item: IResearch.ItemDB) => {
+const getUpdateCount = (item: IResearch.Item) => {
   return item.updates?.length
     ? item.updates.filter(
         (update) =>

--- a/src/pages/Research/Content/ResearchUpdate.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.tsx
@@ -23,7 +23,7 @@ import type { IComment } from 'src/models'
 import type { IResearch } from 'src/models/research.models'
 
 interface IProps {
-  update: IResearch.UpdateDB
+  update: IResearch.Update
   updateIndex: number
   isEditable: boolean
   slug: string

--- a/src/pages/Research/ResearchSortOptions.ts
+++ b/src/pages/Research/ResearchSortOptions.ts
@@ -1,0 +1,15 @@
+export type ResearchSortOption =
+  | 'MostRelevant'
+  | 'Newest'
+  | 'MostComments'
+  | 'LatestUpdated'
+  | 'MostUseful'
+  | 'MostUpdates'
+
+export const ResearchSortOptions = new Map<ResearchSortOption, string>()
+ResearchSortOptions.set('MostRelevant', 'Most Relevant')
+ResearchSortOptions.set('Newest', 'Newest')
+ResearchSortOptions.set('MostComments', 'Most Comments')
+ResearchSortOptions.set('LatestUpdated', 'Latest Updated')
+ResearchSortOptions.set('MostUseful', 'Most Useful')
+ResearchSortOptions.set('MostUpdates', 'Most Updates')

--- a/src/pages/Research/constants.ts
+++ b/src/pages/Research/constants.ts
@@ -8,3 +8,4 @@ export const RESEARCH_EDITOR_ROLES: UserRole[] = [
   UserRole.RESEARCH_EDITOR,
   UserRole.RESEARCH_CREATOR,
 ]
+export const ITEMS_PER_PAGE = 20

--- a/src/pages/Research/labels.ts
+++ b/src/pages/Research/labels.ts
@@ -87,3 +87,15 @@ export const update: ILabels = {
     placeholder: 'https://youtube.com/watch?v=',
   },
 }
+
+export const listing = {
+  create: 'Add Research',
+  noItems: 'No research to show',
+  heading: 'Help out with Research & Development',
+  filterCategory: 'Filter by category',
+  author: 'Filter by author',
+  status: 'Filter by status',
+  search: 'Search for a question',
+  sort: 'Sort by',
+  loadMore: 'Load More',
+}

--- a/src/pages/Research/research.routes.test.tsx
+++ b/src/pages/Research/research.routes.test.tsx
@@ -8,6 +8,7 @@ import {
   RouterProvider,
 } from 'react-router-dom'
 import { ThemeProvider } from '@emotion/react'
+import { faker } from '@faker-js/faker'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { Provider } from 'mobx-react'
 import { UserRole } from 'oa-shared'
@@ -20,11 +21,14 @@ import { FactoryUser } from 'src/test/factories/User'
 import { testingThemeStyles } from 'src/test/utils/themeUtils'
 
 import { researchRouteElements } from './research.routes'
+import { researchService } from './research.service'
 
 import type { ResearchStore } from 'src/stores/Research/research.store'
 
 const Theme = testingThemeStyles
 const mockActiveUser = FactoryUser()
+
+jest.mock('src/pages/Research/research.service')
 
 // Similar to issues in Academy.test.tsx - stub methods called in user store constructor
 // TODO - replace with mock store or avoid direct call
@@ -101,6 +105,28 @@ describe('research.routes', () => {
   describe('/research/', () => {
     it('renders the research listing', async () => {
       let wrapper
+
+      const researchTitle = faker.lorem.words(3)
+      const researchSlug = faker.lorem.slug()
+
+      researchService.search = jest.fn(() => {
+        return new Promise((resolve) => {
+          resolve({
+            items: [
+              {
+                ...FactoryResearchItem({
+                  title: researchTitle,
+                  slug: researchSlug,
+                }),
+                _id: '123',
+              },
+            ],
+            total: 1,
+            lastVisible: undefined,
+          })
+        })
+      })
+
       await act(async () => {
         wrapper = renderFn('/research').wrapper
       })

--- a/src/pages/Research/research.service.test.ts
+++ b/src/pages/Research/research.service.test.ts
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom'
+
+import { ResearchStatus } from 'oa-shared'
+
+import { exportedForTesting } from './research.service'
+
+const mockWhere = jest.fn()
+const mockOrderBy = jest.fn()
+const mockLimit = jest.fn()
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  query: jest.fn(),
+  and: jest.fn(),
+  where: (path, op, value) => mockWhere(path, op, value),
+  limit: (limit) => mockLimit(limit),
+  orderBy: (field, direction) => mockOrderBy(field, direction),
+}))
+
+jest.mock('../../stores/databaseV2/endpoints', () => ({
+  DB_ENDPOINTS: {
+    research: 'research',
+    researchCategories: 'researchCategories',
+  },
+}))
+
+jest.mock('../../config/config', () => ({
+  getConfigurationOption: jest.fn(),
+  FIREBASE_CONFIG: {
+    apiKey: 'AIyChVN',
+    databaseURL: 'https://test.firebaseio.com',
+    projectId: 'test',
+    storageBucket: 'test.appspot.com',
+  },
+  localStorage: jest.fn(),
+}))
+
+describe('research.search', () => {
+  it('searches for text', async () => {
+    // prepare
+    const words = ['test', 'text']
+
+    // act
+    exportedForTesting.createQueries(words, '', 'MostRelevant', null)
+
+    // assert
+    expect(mockWhere).toHaveBeenCalledWith(
+      'keywords',
+      'array-contains-any',
+      words,
+    )
+  })
+
+  it('filters by category', async () => {
+    // prepare
+    const category = 'cat1'
+
+    // act
+    exportedForTesting.createQueries([], category, 'MostRelevant', null)
+
+    // assert
+    expect(mockWhere).toHaveBeenCalledWith(
+      'researchCategory._id',
+      '==',
+      category,
+    )
+  })
+
+  it('should not call orderBy if sorting by most relevant', async () => {
+    // act
+    exportedForTesting.createQueries(['test'], '', 'MostRelevant', null)
+
+    // assert
+    expect(mockOrderBy).toHaveBeenCalledTimes(0)
+  })
+
+  it('should call orderBy when sorting is not MostRelevant', async () => {
+    // act
+    exportedForTesting.createQueries(['test'], '', 'Newest', null)
+
+    // assert
+    expect(mockOrderBy).toHaveBeenLastCalledWith('_created', 'desc')
+  })
+
+  it('should call orderBy when sorting is not MostRelevant', async () => {
+    // act
+    exportedForTesting.createQueries(
+      ['test'],
+      '',
+      'Newest',
+      ResearchStatus.COMPLETED,
+    )
+
+    // assert
+    expect(mockWhere).toHaveBeenCalledWith(
+      'researchStatus',
+      '==',
+      ResearchStatus.COMPLETED,
+    )
+  })
+
+  it('should limit results', async () => {
+    // prepare
+    const take = 12
+
+    // act
+    exportedForTesting.createQueries(
+      ['test'],
+      '',
+      'Newest',
+      null,
+      undefined,
+      take,
+    )
+
+    // assert
+    expect(mockLimit).toHaveBeenLastCalledWith(take)
+  })
+})

--- a/src/pages/Research/research.service.ts
+++ b/src/pages/Research/research.service.ts
@@ -1,0 +1,144 @@
+import {
+  and,
+  collection,
+  getCountFromServer,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  where,
+} from 'firebase/firestore'
+
+import { DB_ENDPOINTS } from '../../models'
+import { firestore } from '../../utils/firebase'
+
+import type {
+  DocumentData,
+  QueryDocumentSnapshot,
+  QueryFilterConstraint,
+  QueryNonFilterConstraint,
+} from 'firebase/firestore'
+import type { ResearchStatus } from 'oa-shared'
+import type { IResearch } from '../../models'
+import type { ICategory } from '../../models/categories.model'
+import type { ResearchSortOption } from './ResearchSortOptions'
+
+export enum ResearchSearchParams {
+  category = 'category',
+  q = 'q',
+  sort = 'sort',
+  status = 'status',
+}
+
+export type ResearchSearchParam = keyof typeof ResearchSearchParams
+
+const search = async (
+  words: string[],
+  category: string,
+  sort: ResearchSortOption,
+  status: ResearchStatus | null,
+  snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
+  take: number = 10,
+) => {
+  const { itemsQuery, countQuery } = createQueries(
+    words,
+    category,
+    sort,
+    status,
+    snapshot,
+    take,
+  )
+
+  const documentSnapshots = await getDocs(itemsQuery)
+  const lastVisible = documentSnapshots.docs
+    ? documentSnapshots.docs[documentSnapshots.docs.length - 1]
+    : undefined
+
+  const items = documentSnapshots.docs
+    ? documentSnapshots.docs.map((x) => x.data() as IResearch.Item)
+    : []
+  const total = (await getCountFromServer(countQuery)).data().count
+
+  return { items, total, lastVisible }
+}
+
+const createQueries = (
+  words: string[],
+  category: string,
+  sort: ResearchSortOption,
+  status: ResearchStatus | null,
+  snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
+  take: number = 10,
+) => {
+  const collectionRef = collection(firestore, DB_ENDPOINTS.research)
+  let filters: QueryFilterConstraint[] = [and(where('_deleted', '!=', true))]
+  let constraints: QueryNonFilterConstraint[] = []
+
+  if (words?.length > 0) {
+    filters = [...filters, and(where('keywords', 'array-contains-any', words))]
+  }
+
+  if (category) {
+    filters = [...filters, where('researchCategory._id', '==', category)]
+  }
+
+  if (status) {
+    filters = [...filters, where('researchStatus', '==', status)]
+  }
+
+  if (sort) {
+    const sortConstraint = getSort(sort)
+
+    if (sortConstraint) {
+      constraints = [...constraints, sortConstraint]
+    }
+  }
+
+  const countQuery = query(collectionRef, and(...filters), ...constraints)
+
+  if (snapshot) {
+    constraints = [...constraints, startAfter(snapshot)]
+  }
+
+  const itemsQuery = query(
+    collectionRef,
+    and(...filters),
+    ...constraints,
+    limit(take),
+  )
+
+  return { countQuery, itemsQuery }
+}
+
+const getResearchCategories = async () => {
+  const collectionRef = collection(firestore, DB_ENDPOINTS.researchCategories)
+
+  return (await getDocs(query(collectionRef))).docs.map(
+    (x) => x.data() as ICategory,
+  )
+}
+
+const getSort = (sort: ResearchSortOption) => {
+  switch (sort) {
+    case 'MostComments':
+      return orderBy('totalCommentCount', 'desc')
+    case 'MostUpdates':
+      return orderBy('totalUpdates', 'desc')
+    case 'MostUseful':
+      return orderBy('totalUsefulVotes', 'desc')
+    case 'Newest':
+      return orderBy('_created', 'desc')
+    case 'LatestUpdated':
+      return orderBy('_modified', 'desc')
+  }
+}
+
+export const researchService = {
+  search,
+  getResearchCategories,
+}
+
+export const exportedForTesting = {
+  createQueries,
+}

--- a/src/stores/Research/research.store.test.ts
+++ b/src/stores/Research/research.store.test.ts
@@ -9,7 +9,6 @@ import {
 } from 'src/test/factories/ResearchItem'
 import { FactoryUser } from 'src/test/factories/User'
 
-import { RootStore } from '../RootStore'
 import { ResearchStore } from './research.store'
 
 import type { IDiscussion } from 'src/models'
@@ -39,7 +38,7 @@ const factory = async (
     updates: [FactoryResearchItemUpdate(), FactoryResearchItemUpdate()],
     ...researchItemOverloads,
   })
-  const store = new ResearchStore(RootStore)
+  const store = new ResearchStore()
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -217,7 +217,7 @@ export const getResearchTotalCommentCount = (
   item: IResearch.ItemDB | IItem,
 ): number => {
   if (Object.hasOwnProperty.call(item, 'totalCommentCount')) {
-    return item.totalCommentCount
+    return item.totalCommentCount || 0
   }
 
   if (item.updates) {
@@ -237,7 +237,7 @@ export const getResearchTotalCommentCount = (
   }
 }
 
-export const getPublicUpdates = (item: IResearch.ItemDB) => {
+export const getPublicUpdates = (item: IResearch.Item) => {
   if (item.updates) {
     return item.updates.filter(
       (update) =>


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Changes: 

- Refactors research search to query firestore.
- Reduced displayed items from 25 to 20.
- The author filter was removed as it required creating a new collection to keep track of research authors (discussed with Dave).
- The author username is now added to searchable keywords so we still allow filtering by author (updated user statistics link).
- Removed sorting by Most Comments as currently they are not correctly calculated (requires a different approach from HowTos and Questions because comments are added to researchUpdates).
- Removed totalCommentCount from list items (same reason as above).

This PR requires a migration before merging.

## Git Issues

Closes #3405