### PR TITLE
fix: revert "refactor user notification tests"

### DIFF
--- a/functions/src/aggregations/common.aggregations.ts
+++ b/functions/src/aggregations/common.aggregations.ts
@@ -8,7 +8,7 @@ import { IModerationStatus } from 'oa-shared'
 
 type IDocumentRef = FirebaseFirestore.DocumentReference
 type ICollectionRef = FirebaseFirestore.CollectionReference
-export type IDBChange = Change<firestore.QueryDocumentSnapshot>
+type IDBChange = Change<firestore.QueryDocumentSnapshot>
 
 export const VALUE_MODIFIERS = {
   delete: () => FieldValue.delete(),

--- a/functions/src/aggregations/userNotifications.aggregations.spec.ts
+++ b/functions/src/aggregations/userNotifications.aggregations.spec.ts
@@ -2,8 +2,11 @@ import { DB_ENDPOINTS, IUserDB } from '../models'
 import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
 import type { INotification } from '../../../src/models'
 import { EmailNotificationFrequency } from 'oa-shared'
-import { processNotifications } from './userNotifications.aggregations'
-import { FieldValue } from 'firebase-admin/firestore'
+
+// use require to allow import of exports.default syntax for the function
+const {
+  default: UserNotificationsAggregationFunction,
+} = require('./userNotifications.aggregations')
 
 const mockNotification: Partial<INotification> = { _id: 'notification_1' }
 
@@ -37,45 +40,67 @@ const userWithNeverEmailFrequency = userFactory('user_1', {
 })
 
 describe('User Notifications Aggregation', () => {
+  const db = FirebaseEmulatedTest.admin.firestore()
+
+  beforeAll(async () => {
+    await FirebaseEmulatedTest.clearFirestoreDB()
+    await FirebaseEmulatedTest.seedFirestoreDB('users', [userFactory('user_1')])
+    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications')
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    db.collection(targetEndpoint).doc('emails_pending').set({})
+  })
+  afterAll(async () => {
+    await FirebaseEmulatedTest.clearFirestoreDB()
+  })
+
   it('Aggregates user notifications to collection', async () => {
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      userWithoutNotifications,
+      userWithNotifications,
+      'users',
+      'user_1',
+    )
+    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
+
+    // check if aggregated list of pending emails created in user_notifications endpoint
+    // with a subset of information
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
     const { _authID, notification_settings, notifications } =
       userWithNotifications
     const { emailFrequency } = notification_settings
-
-    const data = processNotifications(
-      FirebaseEmulatedTest.mockFirestoreChangeObject(
-        userWithoutNotifications,
-        userWithNotifications,
-        'users',
-        'user_1',
-      ),
-    )
-    expect(data).toEqual({
+    expect(res.data()).toEqual({
       user_1: { _authID, emailFrequency, notifications },
     })
   })
 
   it('Does not aggregate read, notified, or emailed user notifications to collection', async () => {
-    const data = processNotifications(
-      FirebaseEmulatedTest.mockFirestoreChangeObject(
-        userWithNotifications,
-        userWithReadNotifications,
-        'users',
-        'user_1',
-      ),
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      userWithNotifications,
+      userWithReadNotifications,
+      'users',
+      'user_1',
     )
-    expect(data).toEqual({ user_1: FieldValue.delete() })
+    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
+
+    // check if list is removed when all notifications are read, notified, or filtered
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
+    expect(res.data()).toEqual({})
   })
 
   it('Does not aggregate user notifications to collection for users with never frequency ', async () => {
-    const data = processNotifications(
-      FirebaseEmulatedTest.mockFirestoreChangeObject(
-        userWithNotifications,
-        userWithNeverEmailFrequency,
-        'users',
-        'user_1',
-      ),
+    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
+      userWithNotifications,
+      userWithNeverEmailFrequency,
+      'users',
+      'user_1',
     )
-    expect(data).toEqual({ user_1: FieldValue.delete() })
+    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
+
+    // check if user is not added to list when they have "never" email frequency setting
+    const targetEndpoint = DB_ENDPOINTS['user_notifications']
+    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
+    expect(res.data()).toEqual({})
   })
 })

--- a/functions/src/aggregations/userNotifications.aggregations.ts
+++ b/functions/src/aggregations/userNotifications.aggregations.ts
@@ -1,48 +1,11 @@
 import * as functions from 'firebase-functions'
-import { DB_ENDPOINTS, INotification, IUserDB } from '../models'
+import { DB_ENDPOINTS, IUserDB } from '../models'
 import { handleDBAggregations, VALUE_MODIFIERS } from './common.aggregations'
-import type { IAggregation, IDBChange } from './common.aggregations'
+import type { IAggregation } from './common.aggregations'
 import { EmailNotificationFrequency } from 'oa-shared'
 
 interface INotificationAggregation extends IAggregation {
   sourceFields: (keyof IUserDB)[]
-}
-
-const getPendingNotifications = (notifications: INotification[]) => {
-  return notifications.filter((n) => !n.notified && !n.read && !n.email)
-}
-
-const shouldSendNotifications = (
-  emailFrequency: EmailNotificationFrequency,
-  pendingNotifications: INotification[],
-) => {
-  return (
-    emailFrequency &&
-    emailFrequency !== EmailNotificationFrequency.NEVER &&
-    pendingNotifications.length > 0
-  )
-}
-
-export const processNotifications = (dbChange: IDBChange) => {
-  const user = dbChange.after.data() as IUserDB
-  const emailFrequency = user.notification_settings?.emailFrequency || null
-  const pending = getPendingNotifications(user.notifications || [])
-
-  // remove user from list if they do not have emails enabled or no pending notifications
-  if (!shouldSendNotifications(emailFrequency, pending)) {
-    return {
-      [user._id]: VALUE_MODIFIERS.delete(),
-    }
-  }
-
-  // return list of pending notifications alongside metadata
-  return {
-    [user._id]: {
-      _authID: user._authID,
-      emailFrequency,
-      notifications: pending,
-    },
-  }
 }
 
 const UserNotificationAggregation: INotificationAggregation =
@@ -53,7 +16,28 @@ const UserNotificationAggregation: INotificationAggregation =
     changeType: 'updated',
     targetCollection: 'user_notifications',
     targetDocId: 'emails_pending',
-    process: ({ dbChange }) => processNotifications(dbChange),
+    process: ({ dbChange }) => {
+      const user: IUserDB = dbChange.after.data() as any
+      const { _id, _authID, notification_settings, notifications } = user
+      const emailFrequency = notification_settings?.emailFrequency || null
+      const pending = (notifications || []).filter(
+        (n) => !n.notified && !n.read && !n.email,
+      )
+      // remove user from list if they do not have emails enabled or no pending notifications
+      if (
+        !emailFrequency ||
+        emailFrequency === EmailNotificationFrequency.NEVER ||
+        pending.length === 0
+      ) {
+        return {
+          [_id]: VALUE_MODIFIERS.delete(),
+        }
+      }
+      // return list of pending notifications alongside metadata
+      return {
+        [_id]: { _authID, emailFrequency, notifications: pending },
+      }
+    },
   }
 
 /** Watch changes to all user docs and apply aggregations */


### PR DESCRIPTION
This reverts commit 9f7362782fc76df13885d2051bf86151c0146100.

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Over March 10-11th there was a sharp rise (100% on Precious Plastic and 200% on Project Kamp) of daily firestore reads and writes. While there are a few possible changes from this period, this one is easy to revert and impacts both platforms so worth experimenting with.
