### PR TITLE
fix: remove duplicate comments

### DIFF
--- a/packages/components/src/DiscussionContainer/transformToStructuredComments.ts
+++ b/packages/components/src/DiscussionContainer/transformToStructuredComments.ts
@@ -14,6 +14,11 @@ export const transformToTree = (comments: CommentWithRepliesParent[]) => {
 
     if (comment.parentCommentId) {
       const parentComment = commentsById[comment.parentCommentId]
+
+      if (!parentComment) {
+        continue
+      }
+
       if (!parentComment.replies) {
         parentComment.replies = []
       }

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -217,6 +217,13 @@ export class ResearchStore extends ModuleStore {
       enrichedResearchUpdated.comments = discussion
         ? (update.comments || []).concat(discussion.comments)
         : []
+
+      // Remove duplicate comments based on _id proprety
+      enrichedResearchUpdated.comments = [
+        ...new Map(
+          enrichedResearchUpdated.comments.map((item) => [item._id, item]),
+        ).values(),
+      ]
       return enrichedResearchUpdated
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "declaration": true,
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "downlevelIteration": true
   },
   "include": ["src/**/*", "types"],
   "exclude": [


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In certain circumstances, Discussion comments may already exist on a Research data object if it has been loaded from the a local data cache. This will result in duplicate comments appearing. This is a side affect of our hard to reason with state management. We should to refactor to perform a clean fetch. 

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
