### PR TITLE
fix: hide thumbnail for single image

### DIFF
--- a/packages/components/src/ImageGallery/ImageGallery.stories.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.stories.tsx
@@ -54,6 +54,12 @@ export const NoThumbnails: StoryFn<typeof ImageGallery> = (
   return <ImageGallery images={testImages} {...props} hideThumbnails />
 }
 
+export const HideThumbnailForSingleImage: StoryFn<typeof ImageGallery> = (
+  props: Omit<ImageGalleryProps, 'images'>,
+) => {
+  return <ImageGallery images={[testImages[0]]} {...props} />
+}
+
 export const ShowNextPrevButtons: StoryFn<typeof ImageGallery> = (
   props: Omit<ImageGalleryProps, 'images'>,
 ) => {

--- a/packages/components/src/ImageGallery/ImageGallery.test.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.test.tsx
@@ -6,6 +6,7 @@ import { ImageGallery } from './ImageGallery'
 import {
   Default,
   DoNotShowNextPrevButtons,
+  HideThumbnailForSingleImage,
   NoThumbnails,
   ShowNextPrevButtons,
   testImages,
@@ -151,6 +152,18 @@ describe('ImageGallery', () => {
     image = await globalFindByRole(group, 'img', { hidden: false })
     expect(image).toBeInTheDocument()
     expect(image?.getAttribute('src')).toEqual(testImages[0].downloadUrl)
+  })
+
+  it('hides thumbnail for single image', async () => {
+    const { getAllByTestId } = render(
+      <HideThumbnailForSingleImage
+        {...(HideThumbnailForSingleImage.args as ImageGalleryProps)}
+      />,
+    )
+
+    expect(() => {
+      getAllByTestId('thumbnail')
+    }).toThrow()
   })
 
   it('supports no thumbnail option', async () => {

--- a/packages/components/src/ImageGallery/ImageGallery.tsx
+++ b/packages/components/src/ImageGallery/ImageGallery.tsx
@@ -126,7 +126,7 @@ export const ImageGallery = (props: ImageGalleryProps) => {
   const activeImageIndex = state.activeImageIndex
   const activeImage = images[activeImageIndex]
   const imageNumber = images.length
-  const showThumbnails = !props.hideThumbnails && images.length >= 1
+  const showThumbnails = !props.hideThumbnails && images.length > 1
   const showNextPrevButton = !!props.showNextPrevButton && images.length > 1
 
   return activeImage ? (


### PR DESCRIPTION
- **chore(ci): persist deps to cache**
- **fix: hide thumbnails for single image**

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Hide thumbnail navigation on ImageGallery if there is only one image present. See link for lots of thumbnails providing no value: https://community.projectkamp.com/research/can-we-setup-a-screw-system-for-a-community

## Screenshots/Videos

Before:

![Screenshot 2024-04-07 at 09 21 03](https://github.com/ONEARMY/community-platform/assets/472589/c72ee226-2bf7-4c97-bf2c-4f3e7df1ee34)

After:

![Screenshot 2024-04-07 at 09 20 49](https://github.com/ONEARMY/community-platform/assets/472589/0b6b4621-544f-4d86-b559-4173f281a024)
