### PR TITLE
fix: replace AspectImage with Image and Boxes

### DIFF
--- a/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
+++ b/src/pages/Howto/Content/Howto/HowtoDescription/HowtoDescription.tsx
@@ -29,17 +29,7 @@ import {
   addIDToSessionStorageArray,
   retrieveSessionStorageArray,
 } from 'src/utils/sessionStorage'
-import {
-  Alert,
-  AspectImage,
-  Box,
-  Card,
-  Divider,
-  Flex,
-  Heading,
-  Image,
-  Text,
-} from 'theme-ui'
+import { Alert, Box, Card, Divider, Flex, Heading, Image, Text } from 'theme-ui'
 
 import { ContentAuthorTimestamp } from '../../../../common/ContentAuthorTimestamp/ContentAuthorTimestamp'
 import {
@@ -349,22 +339,45 @@ const HowtoDescription = ({ howto, loggedInUser, ...props }: IProps) => {
             position: 'relative',
           }}
         >
-          {howto.cover_image && (
-            <AspectImage
-              loading="lazy"
-              ratio={12 / 9}
+          <Box
+            sx={{
+              overflow: 'hidden',
+            }}
+          >
+            <Box
               sx={{
-                objectFit: 'cover',
                 width: '100%',
-                height: '100%',
+                height: '0',
+                pb: '75%',
               }}
-              src={cdnImageUrl(howto.cover_image.downloadUrl, {
-                width: 780,
-              })}
-              crossOrigin=""
-              alt="how-to cover"
-            />
-          )}
+            ></Box>
+            <Box
+              sx={{
+                position: 'absolute',
+                top: '0',
+                bottom: '0',
+                left: '0',
+                right: '0',
+              }}
+            >
+              {howto.cover_image && (
+                // 3407 - AspectImage creates divs that can mess up page layout,
+                // so using Image here instead and recreating the div layout
+                // that was created by AspectImage
+                <Image
+                  loading="lazy"
+                  src={cdnImageUrl(howto.cover_image.downloadUrl)}
+                  sx={{
+                    objectFit: 'cover',
+                    height: '100%',
+                    width: '100%',
+                  }}
+                  crossOrigin=""
+                  alt="how-to cover"
+                />
+              )}
+            </Box>
+          </Box>
           {howto.moderation !== IModerationStatus.ACCEPTED && (
             <ModerationStatus
               status={howto.moderation}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

- some images shown in the **HowTo** section were not the full height of the div, leaving a white space ('bar') at the bottom of the div
- it looks like the problem was that the `AspectImage` component auto-generates 3 divs and an img tag; one of the divs had a style of `position: relative` which was causing the image to not fill the enclosing outer div.
- the solution was to use an `Image` component instead of `AspectImage`, and to build the 3 divs manually in the code with required styling to recreate an `AspectImage` but without the trouble-causing style.

## Git Issues

Closes #3407 

## Screenshots/Videos

- image not fully filling the div
**before**
![page_with_problem_before](https://github.com/ONEARMY/community-platform/assets/1590042/709468bb-e0c5-4976-8710-1ac83508b532)
**after**
![page_with_problem_after](https://github.com/ONEARMY/community-platform/assets/1590042/672f5150-4a62-4c93-9729-37520e63a95a)
**image**
![problem](https://github.com/ONEARMY/community-platform/assets/1590042/12dff256-f168-4e67-a2cd-9e285cc4dfde)

- image that is 'very portrait'
**before**
![page_with_very_portrait_before](https://github.com/ONEARMY/community-platform/assets/1590042/29d55391-0a3c-451c-84a2-ebbd7f6efcba)
**after**
![page_with_very_portrait_after](https://github.com/ONEARMY/community-platform/assets/1590042/0aa9854b-d657-4b3a-b26e-2ae4971a4e2f)
**image**
![very_portrait](https://github.com/ONEARMY/community-platform/assets/1590042/0dd2d960-379d-4015-92fa-d378a43eebcf)

- image that is 'very landscape'
**before**
![page_with_very_landscape_before](https://github.com/ONEARMY/community-platform/assets/1590042/81eb1125-f11e-4b75-a3c5-efcb50b75092)
**after**
![page_with_very_landscape_after](https://github.com/ONEARMY/community-platform/assets/1590042/44cd5e00-527a-4b68-bccc-9cc30f3783c5)
**image**
![very_landscape](https://github.com/ONEARMY/community-platform/assets/1590042/afc5ad80-b485-4d74-9fed-94afc9d4b56e)

- image that is very large
**before**
![page_with_very_big_before](https://github.com/ONEARMY/community-platform/assets/1590042/57482287-38b7-4248-bd76-e130c1ff3b72)
**after**
![page_with_very_big_after](https://github.com/ONEARMY/community-platform/assets/1590042/c2612e1c-5813-4bb8-a51a-19abfc4ba822)
**image**
![very_big](https://github.com/ONEARMY/community-platform/assets/1590042/8245013b-1390-425e-8703-54906622f9c4)


## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
