### PR TITLE
Fix: un-revert "refactor user notification tests"

### DIFF
--- a/functions/src/aggregations/common.aggregations.ts
+++ b/functions/src/aggregations/common.aggregations.ts
@@ -8,7 +8,7 @@ import { IModerationStatus } from 'oa-shared'
 
 type IDocumentRef = FirebaseFirestore.DocumentReference
 type ICollectionRef = FirebaseFirestore.CollectionReference
-type IDBChange = Change<firestore.QueryDocumentSnapshot>
+export type IDBChange = Change<firestore.QueryDocumentSnapshot>
 
 export const VALUE_MODIFIERS = {
   delete: () => FieldValue.delete(),

--- a/functions/src/aggregations/userNotifications.aggregations.spec.ts
+++ b/functions/src/aggregations/userNotifications.aggregations.spec.ts
@@ -2,11 +2,8 @@ import { DB_ENDPOINTS, IUserDB } from '../models'
 import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
 import type { INotification } from '../../../src/models'
 import { EmailNotificationFrequency } from 'oa-shared'
-
-// use require to allow import of exports.default syntax for the function
-const {
-  default: UserNotificationsAggregationFunction,
-} = require('./userNotifications.aggregations')
+import { processNotifications } from './userNotifications.aggregations'
+import { FieldValue } from 'firebase-admin/firestore'
 
 const mockNotification: Partial<INotification> = { _id: 'notification_1' }
 
@@ -40,67 +37,45 @@ const userWithNeverEmailFrequency = userFactory('user_1', {
 })
 
 describe('User Notifications Aggregation', () => {
-  const db = FirebaseEmulatedTest.admin.firestore()
-
-  beforeAll(async () => {
-    await FirebaseEmulatedTest.clearFirestoreDB()
-    await FirebaseEmulatedTest.seedFirestoreDB('users', [userFactory('user_1')])
-    await FirebaseEmulatedTest.seedFirestoreDB('user_notifications')
-    const targetEndpoint = DB_ENDPOINTS['user_notifications']
-    db.collection(targetEndpoint).doc('emails_pending').set({})
-  })
-  afterAll(async () => {
-    await FirebaseEmulatedTest.clearFirestoreDB()
-  })
-
   it('Aggregates user notifications to collection', async () => {
-    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
-      userWithoutNotifications,
-      userWithNotifications,
-      'users',
-      'user_1',
-    )
-    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
-
-    // check if aggregated list of pending emails created in user_notifications endpoint
-    // with a subset of information
-    const targetEndpoint = DB_ENDPOINTS['user_notifications']
-    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
     const { _authID, notification_settings, notifications } =
       userWithNotifications
     const { emailFrequency } = notification_settings
-    expect(res.data()).toEqual({
+
+    const data = processNotifications(
+      FirebaseEmulatedTest.mockFirestoreChangeObject(
+        userWithoutNotifications,
+        userWithNotifications,
+        'users',
+        'user_1',
+      ),
+    )
+    expect(data).toEqual({
       user_1: { _authID, emailFrequency, notifications },
     })
   })
 
   it('Does not aggregate read, notified, or emailed user notifications to collection', async () => {
-    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
-      userWithNotifications,
-      userWithReadNotifications,
-      'users',
-      'user_1',
+    const data = processNotifications(
+      FirebaseEmulatedTest.mockFirestoreChangeObject(
+        userWithNotifications,
+        userWithReadNotifications,
+        'users',
+        'user_1',
+      ),
     )
-    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
-
-    // check if list is removed when all notifications are read, notified, or filtered
-    const targetEndpoint = DB_ENDPOINTS['user_notifications']
-    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
-    expect(res.data()).toEqual({})
+    expect(data).toEqual({ user_1: FieldValue.delete() })
   })
 
   it('Does not aggregate user notifications to collection for users with never frequency ', async () => {
-    const change = FirebaseEmulatedTest.mockFirestoreChangeObject(
-      userWithNotifications,
-      userWithNeverEmailFrequency,
-      'users',
-      'user_1',
+    const data = processNotifications(
+      FirebaseEmulatedTest.mockFirestoreChangeObject(
+        userWithNotifications,
+        userWithNeverEmailFrequency,
+        'users',
+        'user_1',
+      ),
     )
-    await FirebaseEmulatedTest.run(UserNotificationsAggregationFunction, change)
-
-    // check if user is not added to list when they have "never" email frequency setting
-    const targetEndpoint = DB_ENDPOINTS['user_notifications']
-    const res = await db.collection(targetEndpoint).doc('emails_pending').get()
-    expect(res.data()).toEqual({})
+    expect(data).toEqual({ user_1: FieldValue.delete() })
   })
 })


### PR DESCRIPTION
This reverts commit 851e368d0f0db538236c16de84401dbcad1bf6ba which was itself a revert of 9f7362782fc76df13885d2051bf86151c0146100.

Now confident it wasn't having any impact on DB calls.
