### PR TITLE
fix: questions discussion actions updating display

### DIFF
--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -162,13 +162,13 @@ export const CommentItem = (props: CommentItemProps) => {
 
         <Modal width={600} isOpen={showEditModal}>
           <EditComment
-            isReply={isReply}
             comment={text}
             handleSubmit={(commentText) => {
               handleEdit && handleEdit(_id, commentText)
               setShowEditModal(false)
             }}
             handleCancel={() => setShowEditModal(false)}
+            isReply={isReply}
           />
         </Modal>
 

--- a/packages/components/src/EditComment/EditComment.tsx
+++ b/packages/components/src/EditComment/EditComment.tsx
@@ -37,7 +37,12 @@ export const EditComment = (props: IProps) => {
           >
             Edit {isReply ? 'Reply' : 'Comment'}
           </Label>
-          <Field name="comment" id="comment" component={FieldTextarea} />
+          <Field
+            component={FieldTextarea}
+            data-cy="edit-comment"
+            id="comment"
+            name="comment"
+          />
           <Flex mt={4} ml="auto">
             <Button
               small
@@ -48,6 +53,7 @@ export const EditComment = (props: IProps) => {
               Cancel
             </Button>
             <Button
+              data-cy="edit-comment-submit"
               type={'submit'}
               aria-label="Save changes"
               small

--- a/packages/cypress/src/integration/questions/read.spec.ts
+++ b/packages/cypress/src/integration/questions/read.spec.ts
@@ -28,6 +28,7 @@ describe('[Questions]', () => {
         (discussion) => discussion.sourceId === question._id,
       )
       const newReply = 'Thanks Dave and Ben. What does everyone else think?'
+      const updatedNewReply = 'Anyone else?'
 
       cy.step('Can visit question')
       cy.visit(`/questions/${question.slug}`)
@@ -50,10 +51,25 @@ describe('[Questions]', () => {
       cy.get('[data-cy=vote-useful]').click()
       cy.contains(`${question.votedUsefulBy.length + 1} useful`)
 
+      cy.step('Logged in users can add replies')
       cy.get('[data-cy=show-replies]:first').click()
       cy.get('[data-cy=comments-form]:first').type(newReply)
       cy.get('[data-cy=comment-submit]:first').click()
       cy.contains(`${questionDiscussion.comments.length + 1} comments`)
+      cy.contains(newReply)
+
+      cy.step('Logged in users can edit their replies')
+      cy.get('[data-cy="CommentItem: edit button"]:first').click()
+      cy.get('[data-cy=edit-comment]').clear().type(updatedNewReply)
+      cy.get('[data-cy=edit-comment-submit]').click()
+
+      cy.contains(updatedNewReply)
+      cy.contains(newReply).should('not.exist')
+
+      cy.step('Logged in users can delete their replies')
+      cy.get('[data-cy="CommentItem: delete button"]:first').click()
+      cy.get('[data-cy="Confirm.modal: Confirm"]:first').click()
+      cy.contains(updatedNewReply).should('not.exist')
     })
   })
 })

--- a/src/pages/Question/QuestionDiscussion.tsx
+++ b/src/pages/Question/QuestionDiscussion.tsx
@@ -47,10 +47,11 @@ export const QuestionDiscussion = (props: IProps) => {
   }, [questionDocId])
 
   const handleEdit = async (_id: string, comment: string) => {
+    if (!discussion) return
+
+    const updatedDiscussion = await store.editComment(discussion, _id, comment)
     logger.info({ _id, comment }, 'question comment edited')
-    if (discussion) {
-      store.editComment(discussion, _id, comment)
-    }
+    updatedDiscussion && transformComments(updatedDiscussion)
   }
 
   const handleEditRequest = async () => {
@@ -58,38 +59,36 @@ export const QuestionDiscussion = (props: IProps) => {
   }
 
   const handleDelete = async (_id: string) => {
-    logger.debug({ _id }, 'question comment deleted')
     if (discussion) {
-      await store.deleteComment(discussion, _id)
+      const updatedDiscussion = await store.deleteComment(discussion, _id)
+      logger.info({ _id }, 'question comment deleted')
+      updatedDiscussion && transformComments(updatedDiscussion)
     }
   }
 
   const onSubmit = async (comment: string) => {
-    if (!comment) {
+    if (!comment || !discussion) {
       return
     }
 
-    if (discussion) {
-      const updatedDiscussion = await store.addComment(discussion, comment)
-      if (updatedDiscussion) {
-        transformComments(updatedDiscussion)
-        setComment('')
-      }
+    const updatedDiscussion = await store.addComment(discussion, comment)
+    if (updatedDiscussion) {
+      transformComments(updatedDiscussion)
+      setComment('')
     }
   }
 
   const handleSubmitReply = async (commentId: string, reply) => {
+    if (!discussion) return
+
+    const updatedDiscussion = await store.addComment(
+      discussion,
+      reply,
+      commentId,
+    )
     logger.info({ commentId, reply }, 'reply submitted')
-    if (discussion) {
-      const updatedDiscussion = await store.addComment(
-        discussion,
-        reply,
-        commentId,
-      )
-      if (updatedDiscussion) {
-        transformComments(updatedDiscussion)
-      }
-    }
+
+    updatedDiscussion && transformComments(updatedDiscussion)
   }
 
   return (


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

While discussion items for questions could be updated or deleted, the display of the page didn't update automatically. This fixes that.

## Git Issues

Closes #3385

## Screenshots/Videos

https://github.com/ONEARMY/community-platform/assets/16688508/f1dbe160-a0dc-4092-a911-6729787b7f31
