### PR TITLE
Feat: Function to update discussions when user details change

### DIFF
--- a/functions/src/models.ts
+++ b/functions/src/models.ts
@@ -1,40 +1,27 @@
-import * as functions from 'firebase-functions'
-
+import type * as functions from 'firebase-functions'
 // Import and Re-export models from the main platform if required by functions
-
 // NOTE - as of yarn 3.3 we need to import relatively instead of from a workspace import.
 // This is because the functions code sits at same level of main platform package.json, creating cyclic symlinks
 // functions -> node_modules -> community-plaform -> functions -> node_modules ....
-
 // Importing from outside the src code is still fine because we make single builds with webpack
 // which can resolve at build time, but would not work if deploying direct to firebase functions.
 // Alternative fix would be to put the platform code one level further nested e.g. <root>/platform/src
-import type {
+export type {
   DBDoc,
   IDBEndpoint,
+  IDiscussion,
   IHowtoDB,
   IMapPin,
   IMessageDB,
   IModerable,
+  INotification,
   IPendingEmails,
   IResearchDB,
   IUserDB,
-  INotification,
 } from '../../src/models'
-export {
-  DBDoc,
-  IDBEndpoint,
-  IHowtoDB,
-  IUserDB,
-  IMapPin,
-  IMessageDB,
-  IModerable,
-  IResearchDB,
-  IPendingEmails,
-  INotification,
-}
 
 import { dbEndpointSubcollections, generateDBEndpoints } from 'oa-shared'
+
 export const DB_ENDPOINTS = generateDBEndpoints()
 export const DB_ENDPOINT_SUBCOLLECTIONS = dbEndpointSubcollections
 

--- a/functions/src/userUpdates/hasKeyDetailsChanged.test.ts
+++ b/functions/src/userUpdates/hasKeyDetailsChanged.test.ts
@@ -1,0 +1,40 @@
+import { hasKeyDetailsChanged } from './hasKeyDetailsChanged'
+
+import type { IUserDB } from '../../../src/models'
+
+describe('hasKeyDetailsChanged', () => {
+  it('returns true when details have changed', () => {
+    const prevUser = {
+      displayName: 'old name',
+      location: { countryCode: 'USA' },
+    } as IUserDB
+    const user = {
+      displayName: 'new name',
+      location: { countryCode: 'USA' },
+      badges: { verified: true },
+    } as IUserDB
+
+    expect(hasKeyDetailsChanged(prevUser, user)).toEqual(true)
+  })
+
+  it('returns false when details are the same', () => {
+    const prevUser = {
+      displayName: 'same name',
+      location: { countryCode: 'USA' },
+      badges: {
+        verified: true,
+        supporter: false,
+      },
+    } as IUserDB
+    const user = {
+      displayName: 'same name',
+      location: { countryCode: 'USA' },
+      badges: {
+        verified: true,
+        supporter: false,
+      },
+    } as IUserDB
+
+    expect(hasKeyDetailsChanged(prevUser, user)).toEqual(false)
+  })
+})

--- a/functions/src/userUpdates/hasKeyDetailsChanged.ts
+++ b/functions/src/userUpdates/hasKeyDetailsChanged.ts
@@ -1,0 +1,11 @@
+import type { IUserDB } from '../models'
+
+export const hasKeyDetailsChanged = (prevUser: IUserDB, user: IUserDB) => {
+  const detailsChanged = [
+    prevUser.displayName !== user.displayName,
+    prevUser.location?.countryCode !== user.location?.countryCode,
+    prevUser.badges?.verified !== user.badges?.verified,
+    prevUser.badges?.supporter !== user.badges?.supporter,
+  ]
+  return !!detailsChanged.find((detail) => detail === true)
+}

--- a/functions/src/userUpdates/index.test.ts
+++ b/functions/src/userUpdates/index.test.ts
@@ -1,9 +1,11 @@
 const admin = require('firebase-admin')
 
 const test = require('firebase-functions-test')()
+
+import { v4 as uuid } from 'uuid'
+
 import { DB_ENDPOINTS } from '../models'
 import { handleUserUpdates } from './index'
-import { v4 as uuid } from 'uuid'
 
 describe('userUpdates', () => {
   let db
@@ -22,7 +24,7 @@ describe('userUpdates', () => {
     )
   }
 
-  describe('processHowToUpdates', () => {
+  describe('updateDocuments', () => {
     it('updates howto when user country has changed', async () => {
       // Arrange
       const userId = uuid()

--- a/functions/src/userUpdates/index.ts
+++ b/functions/src/userUpdates/index.ts
@@ -1,14 +1,11 @@
 import * as functions from 'firebase-functions'
+
 import { db } from '../Firebase/firestoreDB'
-import {
-  DB_ENDPOINTS,
-  IDBDocChange,
-  IHowtoDB,
-  IResearchDB,
-  IUserDB,
-} from '../models'
+import { DB_ENDPOINTS } from '../models'
 import { backupUser } from './backupUser'
-import { del } from 'request'
+import { updateDiscussionComments } from './updateDiscussionComments'
+
+import type { IDBDocChange, IHowtoDB, IResearchDB, IUserDB } from '../models'
 
 /*********************************************************************
  * Side-effects to be carried out on various user updates, namely:
@@ -22,22 +19,28 @@ export const handleUserUpdates = functions
   .firestore.document(`${DB_ENDPOINTS.users}/{id}`)
   .onUpdate(async (change, context) => {
     await backupUser(change)
-    await processHowToUpdates(change)
+    await updateDocuments(change)
   })
 
-async function processHowToUpdates(change: IDBDocChange) {
-  const info = (change.after.exists ? change.after.data() : {}) as IUserDB
-  const prevInfo = (change.before.exists ? change.before.data() : {}) as IUserDB
-  // optional chaining (.?.) incase does not exists
+const isUserCountryDifferent = (prevInfo, info) => {
   const prevCountryCode = prevInfo.location?.countryCode
   const newCountryCode = info.location?.countryCode
   const prevCountry = prevInfo.country
   const newCountry = info.country
+
+  return prevCountryCode !== newCountryCode || prevCountry !== newCountry
+}
+
+async function updateDocuments(change: IDBDocChange) {
+  const info = (change.after.exists ? change.after.data() : {}) as IUserDB
+  const prevInfo = (change.before.exists ? change.before.data() : {}) as IUserDB
+
+  const newCountryCode = info.location?.countryCode
+  const newCountry = info.country
   const prevDeleted = prevInfo._deleted || false
   const deleted = info._deleted || false
 
-  const didChangeCountry =
-    prevCountryCode !== newCountryCode || prevCountry !== newCountry
+  const didChangeCountry = isUserCountryDifferent(prevInfo, info)
   if (didChangeCountry) {
     // Update country flag in user's created howTos
     const country = newCountryCode ? newCountryCode : newCountry.toLowerCase()
@@ -56,6 +59,8 @@ async function processHowToUpdates(change: IDBDocChange) {
       originalUserName: prevInfo.userName,
     })
   }
+
+  await updateDiscussionComments(prevInfo, info)
 
   const didDelete = prevDeleted !== deleted && deleted
   if (didDelete) {

--- a/functions/src/userUpdates/updateDiscussionComments.test.ts
+++ b/functions/src/userUpdates/updateDiscussionComments.test.ts
@@ -1,0 +1,82 @@
+import { updateDiscussionComments } from './updateDiscussionComments'
+
+import type { IUserDB } from '../models'
+
+const prevUser = {
+  _id: 'hjg235z',
+  location: { countryCode: 'UK' },
+  badges: {
+    verified: true,
+  },
+} as IUserDB
+
+const userComment = {
+  _id: 'commentId',
+  _creatorId: prevUser._id,
+  creatorName: prevUser.displayName,
+  creatorCountry: prevUser.location.countryCode,
+  isUserVerified: prevUser.badges.verified,
+  comment: 'Great Post',
+}
+
+const discussion = {
+  _id: 'DissIDD',
+  contributorIds: [prevUser._id, 'afdg9731'],
+  comments: [userComment],
+}
+
+const updateMock = jest.fn()
+const snapshot = (discussion) => ({
+  docs: [
+    {
+      data: () => discussion,
+      ref: {
+        update: (data) => updateMock(data),
+      },
+    },
+  ],
+})
+
+const getMock = jest.fn()
+jest.mock('../Firebase/firestoreDB', () => ({
+  db: {
+    collection: () => ({
+      where: () => ({
+        get: () => getMock(),
+      }),
+    }),
+  },
+}))
+
+describe('updateDiscussionComments', () => {
+  it('returns stright away if no user details have changed', () => {
+    const user = { ...prevUser } as IUserDB
+
+    updateDiscussionComments(prevUser, user)
+
+    expect(getMock).not.toHaveBeenCalled()
+  })
+
+  it('updates the discussion comments with the new user details', async () => {
+    const user = {
+      ...prevUser,
+      location: { countryCode: 'New' },
+      badges: {
+        verified: false,
+        supporter: true,
+      },
+    } as IUserDB
+    getMock.mockResolvedValue(snapshot(discussion))
+
+    await updateDiscussionComments(prevUser, user)
+    const expectedUpdatedComment = expect.objectContaining({
+      creatorCountry: user.location.countryCode,
+      isUserVerified: user.badges.verified,
+      isUserSupporter: user.badges.supporter,
+    })
+
+    expect(updateMock).toHaveBeenCalledWith({
+      comments: [expectedUpdatedComment],
+    })
+  })
+})

--- a/functions/src/userUpdates/updateDiscussionComments.ts
+++ b/functions/src/userUpdates/updateDiscussionComments.ts
@@ -1,0 +1,44 @@
+import { DB_ENDPOINTS } from 'oa-shared'
+
+import { db } from '../Firebase/firestoreDB'
+import { hasKeyDetailsChanged } from './hasKeyDetailsChanged'
+
+import type { IDiscussion, IUserDB } from '../models'
+
+export const updateDiscussionComments = async (
+  prevUser: IUserDB,
+  user: IUserDB,
+) => {
+  if (!hasKeyDetailsChanged(prevUser, user)) return
+
+  let updatedCommentCount = 0
+
+  const { _id, badges, location } = user
+  const userDetails = {
+    creatorCountry: location?.countryCode || '',
+    isUserVerified: !!badges?.verified,
+    isUserSupporter: !!badges?.supporter,
+  }
+
+  const snapshot = await db
+    .collection(DB_ENDPOINTS.discussions)
+    .where('contributorIds', 'array-contains', _id)
+    .get()
+
+  for (const doc of snapshot.docs) {
+    const discussion = doc.data() as IDiscussion
+
+    const comments = discussion.comments.map((comment) => {
+      if (comment._creatorId !== _id) return comment
+
+      updatedCommentCount++
+      return {
+        ...comment,
+        ...userDetails,
+      }
+    })
+
+    await doc.ref.update({ comments })
+  }
+  console.log(`Updated ${updatedCommentCount} discussion comments`)
+}

--- a/shared/mocks/data/discussions.ts
+++ b/shared/mocks/data/discussions.ts
@@ -53,6 +53,10 @@ export const discussions = {
         text: '<3',
       },
     ],
+    contributorIds: [
+      'Q1sgtnNTPBSYCKEXCOWaOMcPqZD3',
+      'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+    ],
     sourceId: '3s7Fyn6Jf8ryANJM6Jf6',
     sourceType: 'question',
   },

--- a/src/models/discussion.models.tsx
+++ b/src/models/discussion.models.tsx
@@ -15,6 +15,7 @@ export type IDiscussion = {
   sourceId: string
   sourceType: 'question' | 'researchUpdate'
   comments: IDiscussionComment[]
+  contributorIds: string[]
 }
 
 export type IDiscussionSourceModelOptions = IQuestion.Item

--- a/src/stores/Discussions/discussion.store.test.ts
+++ b/src/stores/Discussions/discussion.store.test.ts
@@ -154,6 +154,9 @@ describe('discussion.store', () => {
 
       // Assert
       expect(setFn).toHaveBeenCalledTimes(1)
+      expect(newDiscussion.contributorIds).toEqual(
+        expect.arrayContaining([newDiscussion.comments[1]._creatorId]),
+      )
       expect(newDiscussion.comments).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ text: 'New reply' }),
@@ -296,6 +299,9 @@ describe('discussion.store', () => {
 
       // Asert
       expect(setFn).toHaveBeenCalledTimes(1)
+      expect(discussionItem.contributorIds).not.toEqual(
+        expect.arrayContaining([comment._creatorId]),
+      )
       expect(setFn.mock.calls[0][0].comments).toHaveLength(0)
     })
 

--- a/src/stores/Discussions/discussions.store.tsx
+++ b/src/stores/Discussions/discussions.store.tsx
@@ -186,7 +186,7 @@ export class DiscussionStore extends ModuleStore {
             currentDiscussion.comments,
             commentId,
           )
-          
+
           currentDiscussion.contributorIds = this._removeContributorId(
             discussion,
             targetComment?._creatorId,

--- a/src/test/factories/Discussion.ts
+++ b/src/test/factories/Discussion.ts
@@ -9,6 +9,7 @@ export const FactoryDiscussion = (
 ): IDiscussion => ({
   _id: faker.string.uuid(),
   comments: [],
+  contributorIds: [],
   sourceId: faker.string.uuid(),
   sourceType: 'question',
   ...discussionOverloads,


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Right now, if a user changes various details, that change won't be reflected on already created discussion comments.


## Before

https://github.com/ONEARMY/community-platform/assets/16688508/6842f130-5279-4925-88ae-743c219f3cd8


## After

https://github.com/ONEARMY/community-platform/assets/16688508/dc6922b5-2d48-469e-bdba-ef4f00d3331e



