### PR TITLE
feat: remove map streaming

### DIFF
--- a/src/pages/Maps/Maps.tsx
+++ b/src/pages/Maps/Maps.tsx
@@ -32,7 +32,7 @@ const MapsPage = observer(() => {
   })
 
   useEffect(() => {
-    retrieveMapPins()
+    mapsStore.retrieveMapPins(MAP_PROFILE_TYPE_HIDDEN_BY_DEFAULT)
     mapsStore.retrievePinFilters()
 
     const showPin = async () => {
@@ -45,7 +45,6 @@ const MapsPage = observer(() => {
     showPin()
 
     return () => {
-      mapsStore.removeSubscriptions()
       mapsStore.setActivePin(undefined)
     }
   }, [])
@@ -78,8 +77,6 @@ const MapsPage = observer(() => {
     }
   }
 
-  const retrieveMapPins = () =>
-    mapsStore.retrieveMapPins(MAP_PROFILE_TYPE_HIDDEN_BY_DEFAULT)
   const setCenter = (latlng: ILatLng) => {
     setState((state) => ({
       ...state,

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -12,7 +12,6 @@ import { getUserAvatar } from '../User/user.store'
 import { filterMapPinsByType } from './filter'
 import { MAP_GROUPINGS } from './maps.groupings'
 
-import type { Subscription } from 'rxjs'
 import type { IDBEndpoint } from 'src/models'
 import type {
   IBoundingBox,
@@ -30,7 +29,6 @@ type IFilterToRemove = IMapPinType | undefined
 
 const COLLECTION_NAME: IDBEndpoint = 'mappins'
 export class MapsStore extends ModuleStore {
-  mapPins$: Subscription
   @observable
   public activePinFilters: Array<IMapGrouping> = []
   @observable
@@ -94,21 +92,18 @@ export class MapsStore extends ModuleStore {
   @action
   public async retrieveMapPins(filterToRemove: IFilterToRemove = undefined) {
     // TODO: make the function accept a bounding box to reduce load from DB
-    /*
-       TODO: unaccepted pins should be filtered in DB, before reaching the client
-             It would need to modifiy:
-              - stream in stores/databaseV2/clients/firestore.tsx
-              - streamCollection in stores/databaseV2/clients/firestore.tsx
-             to support where clause.
-    */
-    this.mapPins$ = this.db
+
+    if (this.mapPins?.length > 0) {
+      // we already fetched pins
+      return
+    }
+
+    // TODO: the client-side filtering done at `processDBMapPins` should be here
+    const pins = await this.db
       .collection<IMapPin>(COLLECTION_NAME)
-      .stream((pins) => {
-        // TODO - make more efficient by tracking only new pins received and updating
-        if (pins.length !== this.mapPins.length) {
-          this.processDBMapPins(pins, filterToRemove)
-        }
-      })
+      .getWhere('_deleted', '!=', true)
+
+    this.processDBMapPins(pins, filterToRemove)
   }
 
   @action
@@ -210,12 +205,6 @@ export class MapsStore extends ModuleStore {
     }
     logger.debug('setting user pin', pin)
     await this.db.collection<IMapPin>(COLLECTION_NAME).doc(pin._id).set(pin)
-  }
-
-  public removeSubscriptions() {
-    if (this.mapPins$) {
-      this.mapPins$.unsubscribe()
-    }
   }
 
   // return subset of profile info used when displaying map pins

--- a/src/stores/databaseV2/types/index.d.ts
+++ b/src/stores/databaseV2/types/index.d.ts
@@ -54,7 +54,7 @@ export type DBQueryWhereOperator =
   | '=='
   | '!='
   | 'array-contains'
-export type DBQueryWhereValue = string | number
+export type DBQueryWhereValue = string | number | boolean
 
 /**
  * @remarks


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Removes streaming from map pins. Should reduce database reads.

BUT, even though is better, this is solution also doesn't scale with an increasing number of users and pins.
we should evaluate some kind of caching, maybe a cloud function?

## Git Issues

Closes #