### PR TITLE
fix: map pin caching

### DIFF
--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -99,10 +99,17 @@ export class MapsStore extends ModuleStore {
     }
 
     // TODO: the client-side filtering done at `processDBMapPins` should be here
-    this.db.collection<IMapPin>(COLLECTION_NAME).stream((update) => {
-      const pins = update.filter((v) => !v._deleted)
-      this.processDBMapPins(pins, filterToRemove)
-    })
+    let updateCount = 0
+    const subscription = this.db
+      .collection<IMapPin>(COLLECTION_NAME)
+      .stream((update) => {
+        updateCount++
+        this.processDBMapPins(update, filterToRemove)
+        // hack - unsubscribe after receiving max 2 updates (1 cache + 1 server)
+        if (updateCount >= 2) {
+          subscription.unsubscribe()
+        }
+      })
   }
 
   @action

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -99,11 +99,10 @@ export class MapsStore extends ModuleStore {
     }
 
     // TODO: the client-side filtering done at `processDBMapPins` should be here
-    const pins = await this.db
-      .collection<IMapPin>(COLLECTION_NAME)
-      .getWhere('_deleted', '!=', true)
-
-    this.processDBMapPins(pins, filterToRemove)
+    this.db.collection<IMapPin>(COLLECTION_NAME).stream((update) => {
+      const pins = update.filter((v) => !v._deleted)
+      this.processDBMapPins(pins, filterToRemove)
+    })
   }
 
   @action


### PR DESCRIPTION
PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
Revert changes in #3466 to allow caching of map pins (see comment in PR for details)

Unfortunately the `getWhere` query always executes against server, whereas the `stream` query includes ability to cache results and retrieve from cache

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
