### PR TITLE
refactor: server collection sync

### DIFF
--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -99,17 +99,12 @@ export class MapsStore extends ModuleStore {
     }
 
     // TODO: the client-side filtering done at `processDBMapPins` should be here
-    let updateCount = 0
-    const subscription = this.db
-      .collection<IMapPin>(COLLECTION_NAME)
-      .stream((update) => {
-        updateCount++
+    this.db.collection<IMapPin>(COLLECTION_NAME).syncLocally(
+      (update) => {
         this.processDBMapPins(update, filterToRemove)
-        // hack - unsubscribe after receiving max 2 updates (1 cache + 1 server)
-        if (updateCount >= 2) {
-          subscription.unsubscribe()
-        }
-      })
+      },
+      { keepAlive: false },
+    )
   }
 
   @action

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -108,7 +108,7 @@ export class ModuleStore {
   init() {
     if (!this.isInitialized) {
       if (this.basePath) {
-        this._subscribeToCollection(this.basePath)
+        this.syncAndEmitDocs(this.basePath)
         this.isInitialized = true
       }
     }
@@ -203,15 +203,18 @@ export class ModuleStore {
     })
     return Promise.all(promises)
   }
-  // efficiently checks the cache first and emits any subsequent updates
-  private _subscribeToCollection(endpoint: IDBEndpoint) {
+  /** Sync all server docs locally and stream output changes */
+  private syncAndEmitDocs(endpoint: IDBEndpoint) {
     this.allDocs$.next([])
     this.activeCollectionSubscription.unsubscribe()
     this.activeCollectionSubscription = this.db
       .collection(endpoint)
-      .stream((data) => {
-        this.allDocs$.next(data)
-      })
+      .syncLocally(
+        (data) => {
+          this.allDocs$.next(data)
+        },
+        { keepAlive: false },
+      )
   }
 }
 

--- a/src/stores/databaseV2/types/AbstractDatabaseClient.ts
+++ b/src/stores/databaseV2/types/AbstractDatabaseClient.ts
@@ -17,12 +17,16 @@ export interface AbstractDatabaseClient {
     queryOpts: DBQueryOptions,
   ): Promise<(T & DBDoc)[]>
 
-  streamCollection?<T>(
+  deleteDoc(endpoint: string, docId: string): Promise<void>
+}
+
+// Some clients support document streaming (e.g. firebase does, indexedDB does not)
+export interface AbstractDatabaseClientStreamable
+  extends AbstractDatabaseClient {
+  streamCollection<T>(
     endpoint: string,
     queryOpts?: DBQueryOptions,
   ): Observable<(T & DBDoc)[]>
 
-  streamDoc?<T>(endpoint: string): Observable<T & DBDoc>
-
-  deleteDoc(endpoint: string, docId: string): Promise<void>
+  streamDoc<T>(endpoint: string): Observable<T & DBDoc>
 }

--- a/src/stores/databaseV2/types/index.d.ts
+++ b/src/stores/databaseV2/types/index.d.ts
@@ -4,7 +4,10 @@
  * API items.  On a detail page for a single item, the summary will be
  * shown followed by the remarks section (if any).
  */
-export type { AbstractDatabaseClient } from './DBClient'
+export type {
+  AbstractDatabaseClient,
+  AbstractDatabaseClientStreamable,
+} from './DBClient'
 
 /**
  * The `DBClients` consists of separate databases for use online and offline.
@@ -18,7 +21,7 @@ export type { AbstractDatabaseClient } from './DBClient'
  */
 export interface DBClients {
   cacheDB: AbstractDatabaseClient
-  serverDB: AbstractDatabaseClient
+  serverDB: AbstractDatabaseClientStreamable
   serverCacheDB: AbstractDatabaseClient
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description
To follow on from discussions raised in #3472:

- Rename the db collection `stream` method to `syncLocally` and update comments to better reflect how the action uses local caching to minimise server requests
- Update default `syncLocally` behavior to stop streaming from server after first response, and provide a `keepAlive` option that can be used to override if required
- Update debug logging to better track start/end and total docs from sync methods
- Tidy map pin sync method to remove previous workaround in favour of new general method
- Tidy abstractDB interfaces to provide separate entries for DBs that support streaming vs not

**Breaking (?)**
- There might be some user functionality that depends on live update streaming which is no longer supported (e.g. updated view counters or total comments), although it's hard to tell if this is the case or whether individual docs are polled for updates (hopefully will be picked up in tests). Likely too any functionality that depends on this mechanism will probably need to be refactored anyway to try and make more efficient

## Git Issues

Closes #

## Screenshots/Videos
**Example debug logs track sync operations**
![image](https://github.com/ONEARMY/community-platform/assets/10515065/51ec14c3-0a5c-4e83-a545-3e79c8acc9de)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
