### PR TITLE
Hide most-relevant sorting option when there is no text query

### DIFF
--- a/src/pages/Howto/Content/HowtoList/HowtoFilterHeader.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoFilterHeader.tsx
@@ -8,11 +8,12 @@ import { Flex, Input } from 'theme-ui'
 import { CategoriesSelectV2 } from '../../../common/Category/CategoriesSelectV2'
 import { howtoService, HowtosSearchParams } from '../../howto.service'
 import { listing } from '../../labels'
-import { HowtosSortOptions } from './HowtoSortOptions'
+import { HowtoSortOptions } from './HowtoSortOptions'
 
 import type { SelectValue } from '../../../common/Category/CategoriesSelectV2'
+import type { HowtoSortOption } from './HowtoSortOptions'
 
-const sortOptions = Array.from(HowtosSortOptions, ([value, label]) => ({
+const sortOptions = Array.from(HowtoSortOptions, ([value, label]) => ({
   label: label,
   value: value,
 }))
@@ -24,7 +25,7 @@ export const HowtoFilterHeader = () => {
   const categoryParam = searchParams.get(HowtosSearchParams.category)
   const category = categories?.find((x) => x.value === categoryParam) ?? null
   const q = searchParams.get(HowtosSearchParams.q)
-  const sort = searchParams.get(HowtosSearchParams.sort)
+  const sort = searchParams.get(HowtosSearchParams.sort) as HowtoSortOption
 
   const _inputStyle = {
     width: ['100%', '100%', '200px'],
@@ -100,9 +101,14 @@ export const HowtoFilterHeader = () => {
       <Flex sx={_inputStyle}>
         <FieldContainer>
           <Select
-            options={sortOptions}
+            options={sortOptions.filter(
+              (x) => !(x.value === 'MostRelevant' && !q), // Do not show MostRelevant unless there is a search query
+            )}
             placeholder={listing.sort}
-            value={{ label: sort, value: sort }}
+            value={{
+              label: HowtoSortOptions.get(sort) ?? '',
+              value: sort,
+            }}
             onChange={(sortBy) =>
               updateFilter(HowtosSearchParams.sort, sortBy.value)
             }

--- a/src/pages/Howto/Content/HowtoList/HowtoList.tsx
+++ b/src/pages/Howto/Content/HowtoList/HowtoList.tsx
@@ -14,7 +14,7 @@ import { HowtoFilterHeader } from './HowtoFilterHeader'
 
 import type { DocumentData, QueryDocumentSnapshot } from 'firebase/firestore'
 import type { IHowto } from 'src/models'
-import type { HowtoSortOptions } from './HowtoSortOptions'
+import type { HowtoSortOption } from './HowtoSortOptions'
 
 export const HowtoList = observer(() => {
   const { themeStore, userStore } = useCommonStores().stores
@@ -29,7 +29,7 @@ export const HowtoList = observer(() => {
   const [searchParams, setSearchParams] = useSearchParams()
   const q = searchParams.get(HowtosSearchParams.q) || ''
   const category = searchParams.get(HowtosSearchParams.category) || ''
-  const sort = searchParams.get(HowtosSearchParams.sort) as HowtoSortOptions
+  const sort = searchParams.get(HowtosSearchParams.sort) as HowtoSortOption
 
   useEffect(() => {
     if (!sort) {

--- a/src/pages/Howto/Content/HowtoList/HowtoSortOptions.ts
+++ b/src/pages/Howto/Content/HowtoList/HowtoSortOptions.ts
@@ -1,4 +1,4 @@
-export type HowtoSortOptions =
+export type HowtoSortOption =
   | 'MostRelevant'
   | 'Newest'
   | 'MostUseful'
@@ -6,10 +6,10 @@ export type HowtoSortOptions =
   | 'MostDownloads'
   | 'MostComments'
 
-export const HowtosSortOptions = new Map<HowtoSortOptions, string>()
-HowtosSortOptions.set('MostRelevant', 'Most Relevant')
-HowtosSortOptions.set('Newest', 'Newest')
-HowtosSortOptions.set('MostComments', 'Most Comments')
-HowtosSortOptions.set('LatestUpdated', 'Latest Updated')
-HowtosSortOptions.set('MostUseful', 'Most Useful')
-HowtosSortOptions.set('MostDownloads', 'Most Downloads')
+export const HowtoSortOptions = new Map<HowtoSortOption, string>()
+HowtoSortOptions.set('MostRelevant', 'Most Relevant')
+HowtoSortOptions.set('Newest', 'Newest')
+HowtoSortOptions.set('MostComments', 'Most Comments')
+HowtoSortOptions.set('LatestUpdated', 'Latest Updated')
+HowtoSortOptions.set('MostUseful', 'Most Useful')
+HowtoSortOptions.set('MostDownloads', 'Most Downloads')

--- a/src/pages/Howto/howto.service.ts
+++ b/src/pages/Howto/howto.service.ts
@@ -23,7 +23,7 @@ import type {
 } from 'firebase/firestore'
 import type { IHowto, IUser, IUserPPDB } from '../../models'
 import type { ICategory } from '../../models/categories.model'
-import type { HowtoSortOptions } from './Content/HowtoList/HowtoSortOptions'
+import type { HowtoSortOption } from './Content/HowtoList/HowtoSortOptions'
 
 export enum HowtosSearchParams {
   category = 'category',
@@ -34,7 +34,7 @@ export enum HowtosSearchParams {
 const search = async (
   words: string[],
   category: string,
-  sort: HowtoSortOptions,
+  sort: HowtoSortOption,
   currentUser?: IUserPPDB,
   snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
   take: number = 10,
@@ -79,7 +79,7 @@ const moderationFilters = (currentUser?: IUser) => {
 const createQueries = (
   words: string[],
   category: string,
-  sort: HowtoSortOptions,
+  sort: HowtoSortOption,
   currentUser?: IUser,
   snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
   take: number = 10,
@@ -130,7 +130,7 @@ const getHowtoCategories = async () => {
   )
 }
 
-const getSort = (sort: HowtoSortOptions) => {
+const getSort = (sort: HowtoSortOption) => {
   switch (sort) {
     case 'MostComments':
       return orderBy('totalComments', 'desc')

--- a/src/pages/Question/QuestionFilterHeader.tsx
+++ b/src/pages/Question/QuestionFilterHeader.tsx
@@ -3,7 +3,10 @@ import { useSearchParams } from 'react-router-dom'
 import debounce from 'debounce'
 import { Select } from 'oa-components'
 import { FieldContainer } from 'src/common/Form/FieldContainer'
-import { questionService } from 'src/pages/Question/question.service'
+import {
+  QuestionSearchParams,
+  questionService,
+} from 'src/pages/Question/question.service'
 import { Flex, Input } from 'theme-ui'
 
 import { CategoriesSelectV2 } from '../common/Category/CategoriesSelectV2'
@@ -11,17 +14,21 @@ import { listing } from './labels'
 import { QuestionSortOptions } from './QuestionSortOptions'
 
 import type { SelectValue } from '../common/Category/CategoriesSelectV2'
+import type { QuestionSortOption } from './QuestionSortOptions'
 
-type QuestionSearchParams = 'category' | 'q' | 'sort'
+const sortOptions = Array.from(QuestionSortOptions, ([value, label]) => ({
+  label: label,
+  value: value,
+}))
 
 export const QuestionFilterHeader = () => {
   const [categories, setCategories] = useState<SelectValue[]>([])
 
   const [searchParams, setSearchParams] = useSearchParams()
-  const categoryParam = searchParams.get('category')
+  const categoryParam = searchParams.get(QuestionSearchParams.category)
   const category = categories?.find((x) => x.value === categoryParam) ?? null
-  const q = searchParams.get('q')
-  const sort = searchParams.get('sort')
+  const q = searchParams.get(QuestionSearchParams.q)
+  const sort = searchParams.get(QuestionSearchParams.sort) as QuestionSortOption
 
   const _inputStyle = {
     width: ['100%', '100%', '200px'],
@@ -60,12 +67,12 @@ export const QuestionFilterHeader = () => {
       const params = new URLSearchParams(searchParams.toString())
       params.set('q', value)
 
-      if (value.length > 0 && sort !== QuestionSortOptions.MostRelevant) {
-        params.set('sort', QuestionSortOptions.MostRelevant)
+      if (value.length > 0 && sort !== 'MostRelevant') {
+        params.set('sort', 'MostRelevant')
       }
 
       if (value.length === 0 || !value) {
-        params.set('sort', QuestionSortOptions.Newest)
+        params.set('sort', 'Newest')
       }
 
       setSearchParams(params)
@@ -86,7 +93,7 @@ export const QuestionFilterHeader = () => {
         <CategoriesSelectV2
           value={category}
           onChange={(updatedCategory) =>
-            updateFilter('category', updatedCategory)
+            updateFilter(QuestionSearchParams.category, updatedCategory)
           }
           placeholder={listing.filterCategory}
           isForm={false}
@@ -96,13 +103,14 @@ export const QuestionFilterHeader = () => {
       <Flex sx={_inputStyle}>
         <FieldContainer>
           <Select
-            options={Object.values(QuestionSortOptions).map((x) => ({
-              label: x.toString(),
-              value: x.toString(),
-            }))}
+            options={sortOptions.filter(
+              (x) => !(x.value === 'MostRelevant' && !q), // Do not show MostRelevant unless there is a search query
+            )}
             placeholder={listing.sort}
-            value={{ label: sort, value: sort }}
-            onChange={(sortBy) => updateFilter('sort', sortBy.label)}
+            value={{ label: QuestionSortOptions.get(sort) ?? '', value: sort }}
+            onChange={(sortBy) =>
+              updateFilter(QuestionSearchParams.sort, sortBy.value)
+            }
           />
         </FieldContainer>
       </Flex>

--- a/src/pages/Question/QuestionSortOptions.ts
+++ b/src/pages/Question/QuestionSortOptions.ts
@@ -1,8 +1,15 @@
-export enum QuestionSortOptions {
-  MostRelevant = 'MostRelevant',
-  Newest = 'Newest',
-  LatestUpdated = 'LatestUpdated',
-  LatestComments = 'LatestComments',
-  Comments = 'MostComments',
-  LeastComments = 'LeastComments',
-}
+export type QuestionSortOption =
+  | 'MostRelevant'
+  | 'Newest'
+  | 'LatestUpdated'
+  | 'LatestComments'
+  | 'Comments'
+  | 'LeastComments'
+
+export const QuestionSortOptions = new Map<QuestionSortOption, string>()
+QuestionSortOptions.set('MostRelevant', 'Most Relevant')
+QuestionSortOptions.set('Newest', 'Newest')
+QuestionSortOptions.set('LatestUpdated', 'Latest Updated')
+QuestionSortOptions.set('LatestComments', 'Latest Comments')
+QuestionSortOptions.set('Comments', 'Comments')
+QuestionSortOptions.set('LeastComments', 'Least Comments')

--- a/src/pages/Question/question.service.test.ts
+++ b/src/pages/Question/question.service.test.ts
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom'
 
 import { exportedForTesting } from './question.service'
-import { QuestionSortOptions } from './QuestionSortOptions'
 
 const mockWhere = jest.fn()
 const mockOrderBy = jest.fn()
@@ -39,11 +38,7 @@ describe('question.search', () => {
     const words = ['test', 'text']
 
     // act
-    exportedForTesting.createQueries(
-      words,
-      '',
-      QuestionSortOptions.MostRelevant,
-    )
+    exportedForTesting.createQueries(words, '', 'MostRelevant')
 
     // assert
     expect(mockWhere).toHaveBeenCalledWith(
@@ -58,11 +53,7 @@ describe('question.search', () => {
     const category = 'cat1'
 
     // act
-    exportedForTesting.createQueries(
-      [],
-      category,
-      QuestionSortOptions.MostRelevant,
-    )
+    exportedForTesting.createQueries([], category, 'MostRelevant')
 
     // assert
     expect(mockWhere).toHaveBeenCalledWith(
@@ -74,11 +65,7 @@ describe('question.search', () => {
 
   it('should not call orderBy if sorting by most relevant', async () => {
     // act
-    exportedForTesting.createQueries(
-      ['test'],
-      '',
-      QuestionSortOptions.MostRelevant,
-    )
+    exportedForTesting.createQueries(['test'], '', 'MostRelevant')
 
     // assert
     expect(mockOrderBy).toHaveBeenCalledTimes(0)
@@ -86,7 +73,7 @@ describe('question.search', () => {
 
   it('should call orderBy when sorting is not MostRelevant', async () => {
     // act
-    exportedForTesting.createQueries(['test'], '', QuestionSortOptions.Newest)
+    exportedForTesting.createQueries(['test'], '', 'Newest')
 
     // assert
     expect(mockOrderBy).toHaveBeenLastCalledWith('_created', 'desc')
@@ -97,13 +84,7 @@ describe('question.search', () => {
     const take = 12
 
     // act
-    exportedForTesting.createQueries(
-      ['test'],
-      '',
-      QuestionSortOptions.Newest,
-      undefined,
-      take,
-    )
+    exportedForTesting.createQueries(['test'], '', 'Newest', undefined, take)
 
     // assert
     expect(mockLimit).toHaveBeenLastCalledWith(take)

--- a/src/pages/Question/question.service.ts
+++ b/src/pages/Question/question.service.ts
@@ -12,7 +12,6 @@ import {
 
 import { DB_ENDPOINTS } from '../../models'
 import { firestore } from '../../utils/firebase'
-import { QuestionSortOptions } from './QuestionSortOptions'
 
 import type {
   DocumentData,
@@ -22,11 +21,18 @@ import type {
 } from 'firebase/firestore'
 import type { IQuestion } from '../../models'
 import type { ICategory } from '../../models/categories.model'
+import type { QuestionSortOption } from './QuestionSortOptions'
+
+export enum QuestionSearchParams {
+  category = 'category',
+  q = 'q',
+  sort = 'sort',
+}
 
 const search = async (
   words: string[],
   category: string,
-  sort: QuestionSortOptions,
+  sort: QuestionSortOption,
   snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
   take: number = 10,
 ) => {
@@ -54,7 +60,7 @@ const search = async (
 const createQueries = (
   words: string[],
   category: string,
-  sort: QuestionSortOptions,
+  sort: QuestionSortOption,
   snapshot?: QueryDocumentSnapshot<DocumentData, DocumentData>,
   take: number = 10,
 ) => {
@@ -102,17 +108,17 @@ const getQuestionCategories = async () => {
   )
 }
 
-const getSort = (sort: QuestionSortOptions) => {
+const getSort = (sort: QuestionSortOption) => {
   switch (sort) {
-    case QuestionSortOptions.Comments:
+    case 'Comments':
       return orderBy('commentCount', 'desc')
-    case QuestionSortOptions.LeastComments:
+    case 'LeastComments':
       return orderBy('commentCount', 'asc')
-    case QuestionSortOptions.Newest:
+    case 'Newest':
       return orderBy('_created', 'desc')
-    case QuestionSortOptions.LatestComments:
+    case 'LatestComments':
       return orderBy('latestCommentDate', 'desc')
-    case QuestionSortOptions.LatestUpdated:
+    case 'LatestUpdated':
       return orderBy('_modified', 'desc')
   }
 }

--- a/src/pages/Research/Content/ResearchFilterHeader.tsx
+++ b/src/pages/Research/Content/ResearchFilterHeader.tsx
@@ -22,13 +22,10 @@ const researchStatusOptions = [
   })),
 ]
 
-const researchSortOptions = Array.from(
-  ResearchSortOptions,
-  ([value, label]) => ({
-    label: label,
-    value: value,
-  }),
-)
+const sortOptions = Array.from(ResearchSortOptions, ([value, label]) => ({
+  label: label,
+  value: value,
+}))
 
 export const ResearchFilterHeader = () => {
   const [categories, setCategories] = useState<SelectValue[]>([])
@@ -117,9 +114,11 @@ export const ResearchFilterHeader = () => {
       <Flex sx={_inputStyle}>
         <FieldContainer>
           <Select
-            options={researchSortOptions}
+            options={sortOptions.filter(
+              (x) => !(x.value === 'MostRelevant' && !q), // Do not show MostRelevant unless there is a search query
+            )}
             placeholder={listing.sort}
-            value={{ label: sort, value: sort }}
+            value={{ label: ResearchSortOptions.get(sort) ?? '', value: sort }}
             onChange={(sortBy) =>
               updateFilter(ResearchSearchParams.sort, sortBy.value)
             }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Hides MostRelevant option when there is no search text.
Fixes sorting option displayed value (now always displays the label instead of the value - "Most Relevant" instead of "MostRelevant")
Improved typescript usage and aligned patterns of Howto/Research/Questions search

## Git Issues

Closes #