### PR TITLE
fix(research): use the getter from the research store to get the more correct count of all the comments for a research article

### DIFF
--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -18,7 +18,6 @@ import { NotFoundPage } from 'src/pages/NotFound/NotFound'
 import { useResearchStore } from 'src/stores/Research/research.store'
 import {
   getPublicUpdates,
-  getResearchTotalCommentCount,
   isAllowedToDeleteContent,
   isAllowedToEditContent,
 } from 'src/utils/helpers'
@@ -228,7 +227,7 @@ const ResearchArticle = observer(() => {
         onFollowClick={() => onFollowClick(item.slug)}
         contributors={contributors}
         subscribersCount={researchStore.subscribersCount}
-        commentsCount={getResearchTotalCommentCount(item)}
+        commentsCount={researchStore.commentsCount}
         updatesCount={
           item.updates?.filter(
             (u) => u.status !== ResearchUpdateStatus.DRAFT && !u._deleted,

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,5 +1,4 @@
-import { IModerationStatus, ResearchUpdateStatus, UserRole } from 'oa-shared'
-import { FactoryResearchItemUpdate } from 'src/test/factories/ResearchItem'
+import { IModerationStatus, UserRole } from 'oa-shared'
 import { FactoryUser } from 'src/test/factories/User'
 
 import {
@@ -8,7 +7,6 @@ import {
   filterModerableItems,
   formatLowerNoSpecial,
   getProjectEmail,
-  getResearchTotalCommentCount,
   hasAdminRights,
   isAllowedToEditContent,
   isAllowedToPin,
@@ -20,8 +18,7 @@ import {
   stripSpecialCharacters,
 } from './helpers'
 
-import type { IModerable, IResearch } from 'src/models'
-import type { IItem } from 'src/stores/common/FilterSorterDecorator/FilterSorterDecorator'
+import type { IModerable } from 'src/models'
 
 describe('src/utils/helpers', () => {
   it('stripSpecialCharacters should remove special characters and replace spaces with dashes', () => {
@@ -268,93 +265,6 @@ describe('src/utils/helpers', () => {
 
     it('should return false when given false', () => {
       expect(isContactable(false)).toBe(false)
-    })
-  })
-
-  describe('getResearchTotalCommentCount Function', () => {
-    it('should return 0 when item has no updates', () => {
-      const item = { item: {} } as any
-      expect(getResearchTotalCommentCount(item)).toBe(0)
-    })
-
-    it('should return 0 when updates have no comments', () => {
-      const item = {
-        updates: Array.from({ length: 3 }).fill(
-          FactoryResearchItemUpdate({
-            status: ResearchUpdateStatus.PUBLISHED,
-            _deleted: false,
-            comments: [],
-          }),
-        ),
-      } as IResearch.ItemDB | IItem
-      expect(getResearchTotalCommentCount(item)).toBe(0)
-    })
-
-    it('should use totalCommentCount if present', () => {
-      const item = {
-        totalCommentCount: 5,
-        updates: Array.from({ length: 3 }).fill(
-          FactoryResearchItemUpdate({
-            status: ResearchUpdateStatus.PUBLISHED,
-            _deleted: false,
-            comments: Array.from({ length: 3 }),
-          }),
-        ),
-      } as IResearch.ItemDB | IItem
-      expect(getResearchTotalCommentCount(item)).toBe(5)
-    })
-
-    it('should use totalCommentCount when 0', () => {
-      const item = {
-        totalCommentCount: 0,
-        updates: Array.from({ length: 3 }).fill(
-          FactoryResearchItemUpdate({
-            status: ResearchUpdateStatus.PUBLISHED,
-            _deleted: false,
-            comments: Array.from({ length: 3 }),
-          }),
-        ),
-      } as IResearch.ItemDB | IItem
-      expect(getResearchTotalCommentCount(item)).toBe(0)
-    })
-
-    it('should return the correct amount of comments', () => {
-      const item = {
-        updates: Array.from({ length: 3 }).fill(
-          FactoryResearchItemUpdate({
-            status: ResearchUpdateStatus.PUBLISHED,
-            _deleted: false,
-            comments: Array.from({ length: 3 }),
-          }),
-        ),
-      } as IResearch.ItemDB | IItem
-      expect(getResearchTotalCommentCount(item)).toBe(9)
-    })
-
-    it('should ignore deleted and draft updates', () => {
-      const item = {
-        updates: Array.from({ length: 2 })
-          .fill(
-            FactoryResearchItemUpdate({
-              status: ResearchUpdateStatus.PUBLISHED,
-              _deleted: false,
-              comments: Array.from({ length: 2 }),
-            }),
-          )
-          .concat([
-            FactoryResearchItemUpdate({
-              status: ResearchUpdateStatus.PUBLISHED,
-              _deleted: true,
-              comments: Array.from({ length: 3 }),
-            }),
-            FactoryResearchItemUpdate({
-              status: ResearchUpdateStatus.DRAFT,
-              _deleted: false,
-              comments: Array.from({ length: 6 }),
-            }),
-          ]),
-      } as IResearch.ItemDB | IItem
-      expect(getResearchTotalCommentCount(item)).toBe(4)
     })
   })
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -207,30 +207,6 @@ export const isContactable = (preference: boolean | undefined) => {
     : DEFAULT_PUBLIC_CONTACT_PREFERENCE
 }
 
-export const getResearchTotalCommentCount = (
-  item: IResearch.ItemDB,
-): number => {
-  if (Object.hasOwnProperty.call(item, 'totalCommentCount')) {
-    return item.totalCommentCount || 0
-  }
-
-  if (item.updates) {
-    const commentOnUpdates = item.updates.reduce((totalComments, update) => {
-      const updateCommentsLength =
-        !update._deleted &&
-        update.status !== ResearchUpdateStatus.DRAFT &&
-        update.comments
-          ? update.comments.length
-          : 0
-      return totalComments + updateCommentsLength
-    }, 0)
-
-    return commentOnUpdates ? commentOnUpdates : 0
-  } else {
-    return 0
-  }
-}
-
 export const getPublicUpdates = (item: IResearch.Item) => {
   if (item.updates) {
     return item.updates.filter(


### PR DESCRIPTION

PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_

It remplaces the usage of the denormalized field to an accurate count of all comments for a research article.
The denormalized field is kept for sorting in list
It removes seemly useless update when editing a comment
It deletes dead code and especially an helper function that was redundant with the store getter.
It moves and updates old helper functions unit tests to the research store unit tests file.

## Git Issues

Closes #3510


---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
