### PR TITLE
fix: breadcrumb paths use category ids

### DIFF
--- a/src/pages/common/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/pages/common/Breadcrumbs/Breadcrumbs.tsx
@@ -22,7 +22,7 @@ const generateSteps = (
     if (item.researchCategory) {
       steps.push({
         text: item.researchCategory.label,
-        link: `/research?category=${item.researchCategory.label}`,
+        link: `/research?category=${item.researchCategory._id}`,
       })
     }
 
@@ -34,7 +34,7 @@ const generateSteps = (
     if (item.questionCategory) {
       steps.push({
         text: item.questionCategory.label,
-        link: `/questions?category=${item.questionCategory.label}`,
+        link: `/questions?category=${item.questionCategory._id}`,
       })
     }
 
@@ -46,7 +46,7 @@ const generateSteps = (
     if (item.category) {
       steps.push({
         text: item.category.label,
-        link: `/how-to?category=${item.category.label}`,
+        link: `/how-to?category=${item.category._id}`,
       })
     }
 


### PR DESCRIPTION
## Description

Fixes the issue with breadcrumbs going to category label rather than id. As it's a live thing and annoying for users, I'll do e2e tests in a follow-up PR.
