### PR TITLE
feat: enable research creation on pp

### DIFF
--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -5,6 +5,7 @@ import { missing } from '../../../../src/pages/User/impact/labels'
 import { contact } from '../../../../src/pages/User/labels'
 import { MOCK_DATA } from '../data'
 import { UserMenuItem } from '../support/commands'
+import { setIsPreciousPlastic } from '../utils/TestUtils'
 
 const { admin, subscriber } = MOCK_DATA.users
 const eventReader = MOCK_DATA.users.event_reader
@@ -82,7 +83,7 @@ describe('[Profile]', () => {
     })
 
     it('[Can see impact data for workspaces]', () => {
-      localStorage.setItem('platformTheme', 'precious-plastic')
+      setIsPreciousPlastic()
 
       cy.login(subscriber.email, subscriber.password)
 

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -4,6 +4,7 @@ import {
   RESEARCH_MAX_LENGTH,
   RESEARCH_TITLE_MIN_LENGTH,
 } from '../../../../../src/pages/Research/constants'
+import { setIsPreciousPlastic } from '../../utils/TestUtils'
 
 const researcherEmail = 'research_creator@test.com'
 const researcherPassword = 'research_creator'

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -103,6 +103,73 @@ describe('[Research]', () => {
       cy.get('div').contains('role required to access this page')
     })
 
+    it('[Any PP user]', () => {
+      const title = 'PP plastic stuff'
+      const expectSlug = 'pp-plastic-stuff'
+      const description = 'Bespoke research topic'
+
+      const updateTitle = 'First wonderful update'
+      const updateDescription =
+        'Update. One. Ready to start with the observations.'
+      const updateVideoUrl = 'https://www.youtube.com/watch?v=U3mrj84p3cM'
+
+      setIsPreciousPlastic()
+      cy.logout()
+      cy.signUpNewUser()
+
+      cy.step('Can access create form')
+      cy.visit('/research')
+      cy.get('[data-cy=loader]').should('not.exist')
+      cy.get('[data-cy=create]').should('exist')
+
+      cy.step('Enter research article details')
+      cy.visit('/research/create')
+      cy.get('[data-cy=intro-title').clear().type(title).blur({ force: true })
+
+      cy.get('[data-cy=intro-description]')
+        .clear({ force: true })
+        .type(description)
+
+      cy.get('[data-cy=submit]').click()
+
+      cy.step('Publishes as expected')
+      cy.get('[data-cy=view-research]:enabled', { timeout: 20000 })
+        .click()
+        .url()
+        .should('include', `/research/${expectSlug}`)
+
+      cy.contains(title).should('exist')
+      cy.contains(description).should('exist')
+
+      cy.step('Can add update')
+      cy.get('[data-cy=addResearchUpdateButton]').click()
+      cy.get('[data-cy=intro-title]')
+        .clear()
+        .type(updateTitle)
+        .blur({ force: true })
+
+      cy.get('[data-cy=intro-description]')
+        .clear()
+        .type(updateDescription)
+        .blur({ force: true })
+
+      cy.get('[data-cy=videoUrl]')
+        .clear()
+        .type(updateVideoUrl)
+        .blur({ force: true })
+
+      cy.step('Update is published')
+      cy.get('[data-cy=submit]').click()
+
+      cy.step('Open the research update')
+      cy.get('[data-cy=view-research]:enabled', { timeout: 20000 })
+        .click()
+        .url()
+
+      cy.contains(updateTitle).should('exist')
+      cy.contains(updateDescription).should('exist')
+    })
+
     it('[Warning on leaving page]', () => {
       const stub = cy.stub()
       stub.returns(false)

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -3,7 +3,7 @@ import { ExternalLinkLabel } from 'oa-shared'
 import { form } from '../../../../src/pages/UserSettings/labels'
 import { SingaporeStubResponse } from '../fixtures/searchResults'
 import { UserMenuItem } from '../support/commands'
-import { DbCollectionName } from '../utils/TestUtils'
+import { DbCollectionName, setIsPreciousPlastic } from '../utils/TestUtils'
 
 import type { IUser } from '../../../../src/models/user.models'
 
@@ -23,7 +23,7 @@ type ILink = IUser['links'][0] & { index: number }
 
 describe('[Settings]', () => {
   beforeEach(() => {
-    localStorage.setItem('platformTheme', 'precious-plastic')
+    setIsPreciousPlastic()
     cy.visit('/sign-in')
   })
   const selectFocus = (focus: string) => {
@@ -366,7 +366,7 @@ describe('[Settings]', () => {
       cy.login('settings_member_new@test.com', 'test1234')
 
       cy.step('Go to User Settings for Precious Plastic')
-      localStorage.setItem('platformTheme', 'precious-plastic')
+      setIsPreciousPlastic()
       cy.clickMenuItem(UserMenuItem.Settings)
       selectFocus(expected.profileType)
       cy.get('[data-cy=pin-description]').should('not.exist')

--- a/packages/cypress/src/utils/TestUtils.ts
+++ b/packages/cypress/src/utils/TestUtils.ts
@@ -27,3 +27,7 @@ export const generateNewUserDetails = () => {
     password: 'test1234',
   }
 }
+
+export const setIsPreciousPlastic = () => {
+  return localStorage.setItem('platformTheme', 'precious-plastic')
+}

--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -292,7 +292,12 @@ const ResearchArticle = observer(() => {
       {isEditable && (
         <Flex my={4}>
           <Link to={`/research/${item.slug}/new-update`}>
-            <Button large ml={2} mb={[3, 3, 0]}>
+            <Button
+              large
+              ml={2}
+              mb={[3, 3, 0]}
+              data-cy="addResearchUpdateButton"
+            >
               Add update
             </Button>
           </Link>

--- a/src/pages/Research/Content/ResearchList.tsx
+++ b/src/pages/Research/Content/ResearchList.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react'
 import { Button, Loader } from 'oa-components'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import { isPreciousPlastic } from 'src/config/config'
 import { logger } from 'src/logger'
 import { Box, Flex, Heading } from 'theme-ui'
 
@@ -116,13 +117,21 @@ const ResearchList = observer(() => {
 
         <Flex sx={{ justifyContent: ['flex-end', 'flex-end', 'auto'] }}>
           <Box sx={{ width: '100%', display: 'block' }} mb={[3, 3, 0]}>
-            <AuthWrapper roleRequired={RESEARCH_EDITOR_ROLES}>
+            {isPreciousPlastic() ? (
               <Link to={userStore.activeUser ? '/research/create' : '/sign-up'}>
                 <Button variant={'primary'} data-cy="create">
                   {listing.create}
                 </Button>
               </Link>
-            </AuthWrapper>
+            ) : (
+              <AuthWrapper roleRequired={RESEARCH_EDITOR_ROLES}>
+                <Link to={'/research/create'}>
+                  <Button variant={'primary'} data-cy="create">
+                    {listing.create}
+                  </Button>
+                </Link>
+              </AuthWrapper>
+            )}
           </Box>
         </Flex>
       </Flex>

--- a/src/pages/Research/research.routes.tsx
+++ b/src/pages/Research/research.routes.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react'
 import { Route, Routes } from 'react-router-dom'
+import { isPreciousPlastic } from 'src/config/config'
 
 import { AuthRoute } from '../common/AuthRoute'
 import { RESEARCH_EDITOR_ROLES } from './constants'
@@ -35,13 +36,15 @@ const getRandomInt = (max) => {
   return Math.floor(Math.random() * max)
 }
 
+const roles = isPreciousPlastic() ? [] : RESEARCH_EDITOR_ROLES
+
 export const researchRouteElements = (
   <>
     <Route index element={<ResearchList />} />
     <Route
       path="create"
       element={
-        <AuthRoute roleRequired={RESEARCH_EDITOR_ROLES}>
+        <AuthRoute roleRequired={roles}>
           <CreateResearch />
         </AuthRoute>
       }
@@ -49,7 +52,7 @@ export const researchRouteElements = (
     <Route
       path=":slug/new-update"
       element={
-        <AuthRoute roleRequired={RESEARCH_EDITOR_ROLES}>
+        <AuthRoute roleRequired={roles}>
           <CreateUpdate />
         </AuthRoute>
       }
@@ -57,7 +60,7 @@ export const researchRouteElements = (
     <Route
       path=":slug/edit"
       element={
-        <AuthRoute roleRequired={RESEARCH_EDITOR_ROLES}>
+        <AuthRoute roleRequired={roles}>
           <ResearchItemEditor />
         </AuthRoute>
       }
@@ -65,7 +68,7 @@ export const researchRouteElements = (
     <Route
       path=":slug/edit-update/:update"
       element={
-        <AuthRoute roleRequired={RESEARCH_EDITOR_ROLES}>
+        <AuthRoute roleRequired={roles}>
           <UpdateItemEditor />
         </AuthRoute>
       }


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This allows any logged in user on Precious Plastic only to create their own research. The create research button is there for all with the standard link to login if they aren't already.

<img width="1294" alt="Screenshot 2024-05-10 at 17 42 57" src="https://github.com/ONEARMY/community-platform/assets/16688508/288e71f8-e6a7-4d57-be51-18cf8cdee5b4">


