### PR TITLE
feat(seo): update headings for user settings form

### DIFF
--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -245,7 +245,7 @@ export const SettingsPage = observer((props: IProps) => {
                       }}
                     >
                       <Flex px={3} py={2}>
-                        <Heading>{heading}</Heading>
+                        <Heading as="h1">{heading}</Heading>
                       </Flex>
                     </Card>
                     <Box

--- a/src/pages/UserSettings/content/PostingGuidelines.tsx
+++ b/src/pages/UserSettings/content/PostingGuidelines.tsx
@@ -9,7 +9,9 @@ export const ProfileGuidelines = () => {
   return (
     <Card>
       <Flex sx={{ flexDirection: 'column' }} p={4}>
-        <Heading mb={2}>Profile tips</Heading>
+        <Heading as="h2" mb={2}>
+          Profile tips
+        </Heading>
         <Text variant="auxiliary" mb={1}>
           1. Have a look at our{' '}
           <ExternalLink href={theme.profileGuidelinesURL}>

--- a/src/pages/UserSettings/content/formSections/AccountSettings.section.tsx
+++ b/src/pages/UserSettings/content/formSections/AccountSettings.section.tsx
@@ -20,7 +20,7 @@ export const AccountSettingsSection = observer(() => {
           gap: 2,
         }}
       >
-        <Heading>{headings.accountSettings}</Heading>
+        <Heading as="h2">{headings.accountSettings}</Heading>
         <ChangeEmailForm />
         <ChangePasswordForm />
         <Text variant="body">

--- a/src/pages/UserSettings/content/formSections/ChangeEmail.form.tsx
+++ b/src/pages/UserSettings/content/formSections/ChangeEmail.form.tsx
@@ -69,7 +69,9 @@ export const ChangeEmailForm = () => {
                 data-cy="changeEmailForm"
                 sx={{ flexDirection: 'column', gap: 2 }}
               >
-                <Heading variant="small">{headings.changeEmail}</Heading>
+                <Heading as="h3" variant="small">
+                  {headings.changeEmail}
+                </Heading>
 
                 <Text sx={{ fontSize: 1 }}>
                   {fields.email.title}: <strong>{currentEmail}</strong>

--- a/src/pages/UserSettings/content/formSections/ChangePassword.form.tsx
+++ b/src/pages/UserSettings/content/formSections/ChangePassword.form.tsx
@@ -64,7 +64,9 @@ export const ChangePasswordForm = () => {
                 data-cy="changePasswordForm"
                 sx={{ flexDirection: 'column', gap: 1 }}
               >
-                <Heading variant="small">{headings.changePassword}</Heading>
+                <Heading as="h3" variant="small">
+                  {headings.changePassword}
+                </Heading>
 
                 <FormFieldWrapper
                   text={fields.oldPassword.title}

--- a/src/pages/UserSettings/content/formSections/Collection.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Collection.section.tsx
@@ -30,7 +30,9 @@ export const CollectionSection = (props: IProps) => {
   return (
     <FlexSectionContainer>
       <Flex sx={{ justifyContent: 'space-between' }}>
-        <Heading variant="small">{headings.collection}</Heading>
+        <Heading as="h2" variant="small">
+          {headings.collection}
+        </Heading>
       </Flex>
       <Box>
         <Flex sx={{ wrap: 'nowrap', alignItems: 'center', width: '100%' }}>

--- a/src/pages/UserSettings/content/formSections/EmailNotifications.section.tsx
+++ b/src/pages/UserSettings/content/formSections/EmailNotifications.section.tsx
@@ -38,7 +38,9 @@ export const EmailNotificationsSection = observer((props: IProps) => {
   )
   return (
     <FlexSectionContainer>
-      <Heading variant="small">{title}</Heading>
+      <Heading as="h2" variant="small">
+        {title}
+      </Heading>
       <Text mt={4} mb={4} sx={{ display: 'block' }}>
         {`${description}:`}
       </Text>

--- a/src/pages/UserSettings/content/formSections/Expertise.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Expertise.section.tsx
@@ -41,7 +41,9 @@ export const ExpertiseSection = (props: IProps) => {
   return (
     <FlexSectionContainer>
       <Flex sx={{ justifyContent: 'space-between' }}>
-        <Heading variant="small">{headings.expertise}</Heading>
+        <Heading as="h2" variant="small">
+          {headings.expertise}
+        </Heading>
       </Flex>
       <Box>
         <Text mt={4} mb={4}>

--- a/src/pages/UserSettings/content/formSections/Focus.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Focus.section.tsx
@@ -27,7 +27,9 @@ const ProfileTypes = () => {
       render={(props) => (
         <FlexSectionContainer>
           <Flex sx={{ justifyContent: 'space-between' }}>
-            <Heading variant="small">{headings.focus}</Heading>
+            <Heading as="h2" variant="small">
+              {headings.focus}
+            </Heading>
           </Flex>
           <Box>
             <Paragraph my={4}>{title}</Paragraph>

--- a/src/pages/UserSettings/content/formSections/Impact/Impact.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/Impact.section.tsx
@@ -33,7 +33,9 @@ export const ImpactSection = () => {
 
   return (
     <FlexSectionContainer>
-      <Heading dangerouslySetInnerHTML={{ __html: title }} variant="small" />
+      <Heading as="h2" variant="small">
+        {title}
+      </Heading>
       <Text mt={4} mb={4}>
         {description}
       </Text>

--- a/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Impact/ImpactYear.section.tsx
@@ -83,6 +83,7 @@ export const ImpactYearSection = observer(({ year }: Props) => {
   return (
     <Box sx={sx}>
       <Heading
+        as="h3"
         variant="small"
         ref={impactDivRef}
         id={`/settings#impact_${year}`}

--- a/src/pages/UserSettings/content/formSections/MemberMapPin.section.tsx
+++ b/src/pages/UserSettings/content/formSections/MemberMapPin.section.tsx
@@ -41,7 +41,7 @@ export const MemberMapPinSection = observer(
     return (
       <FlexSectionContainer>
         <Flex sx={{ justifyContent: 'space-between' }}>
-          <Heading variant="small" id="your-map-pin">
+          <Heading as="h2" variant="small" id="your-map-pin">
             {headings.map.title}
           </Heading>
         </Flex>

--- a/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
+++ b/src/pages/UserSettings/content/formSections/PatreonIntegration.tsx
@@ -61,7 +61,9 @@ export const PatreonIntegration = (props: { user: IUserPP }) => {
 
   return (
     <FlexSectionContainer>
-      <Heading variant="small">{HEADING}</Heading>
+      <Heading as="h2" variant="small">
+        {HEADING}
+      </Heading>
       <Text mt={4}>{SUBHEADING}</Text>
       <Text mt={4}>{BETA_DISCLAIMER}</Text>
       {user.patreon ? (

--- a/src/pages/UserSettings/content/formSections/PublicContact.section.tsx
+++ b/src/pages/UserSettings/content/formSections/PublicContact.section.tsx
@@ -21,7 +21,9 @@ export const PublicContactSection = observer(
 
     return (
       <FlexSectionContainer>
-        <Heading variant="small">{title}</Heading>
+        <Heading as="h2" variant="small">
+          {title}
+        </Heading>
         <Text mt={4} mb={4}>
           {description}
         </Text>

--- a/src/pages/UserSettings/content/formSections/UserInfos.section.tsx
+++ b/src/pages/UserSettings/content/formSections/UserInfos.section.tsx
@@ -116,7 +116,9 @@ export const UserInfosSection = (props: IProps) => {
   return (
     <FlexSectionContainer>
       <Flex sx={{ justifyContent: 'space-between' }}>
-        <Heading variant="small">{headings.infos}</Heading>
+        <Heading as="h2" variant="small">
+          {headings.infos}
+        </Heading>
       </Flex>
       <Box>
         <Flex sx={{ flexWrap: 'wrap' }}>

--- a/src/pages/UserSettings/content/formSections/Workspace.section.tsx
+++ b/src/pages/UserSettings/content/formSections/Workspace.section.tsx
@@ -58,7 +58,9 @@ export const WorkspaceSection = () => {
       render={({ input, meta }) => (
         <FlexSectionContainer>
           <Flex sx={{ justifyContent: 'space-between' }}>
-            <Heading variant="small">{title}</Heading>
+            <Heading as="h2" variant="small">
+              {title}
+            </Heading>
           </Flex>
           <Box>
             <Text mt={4} mb={4}>

--- a/src/pages/UserSettings/content/formSections/WorkspaceMapPin.section.tsx
+++ b/src/pages/UserSettings/content/formSections/WorkspaceMapPin.section.tsx
@@ -25,7 +25,7 @@ export const WorkspaceMapPinSection = observer((props: IProps) => {
   return (
     <FlexSectionContainer>
       <Flex sx={{ justifyContent: 'space-between' }}>
-        <Heading variant="small" id="your-map-pin">
+        <Heading as="h2" variant="small" id="your-map-pin">
           {title}
         </Heading>
       </Flex>

--- a/src/pages/UserSettings/labels.ts
+++ b/src/pages/UserSettings/labels.ts
@@ -71,7 +71,7 @@ export const fields: ILabels = {
   impact: {
     description:
       "Let's track our collective positive impact! Add data about your recycling work and show the world the power of a movement of small scale recyclers!",
-    title: 'Positive impact &#129305;',
+    title: 'Positive impact 🤙',
   },
   links: {
     placeholder: 'Link',


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [?] Bug fix (non-breaking change which fixes an issue)
- [?] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_
This PR update all Heading tags in the User settings sections and forms to specific html heading tags from the default h2 to h1, h2 or h3. It should respect a correct hierarchical structure. To sum up, all sections have a confirmed h2, and every other heading in the card is now a h3 and the title of the page is now a h1.

## Git Issues

Helps to close #3424

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
