### PR TITLE
feat(seo): update headings for user profiles

### DIFF
--- a/src/pages/User/contact/UserContactForm.tsx
+++ b/src/pages/User/contact/UserContactForm.tsx
@@ -66,7 +66,7 @@ export const UserContactForm = observer(({ user }: Props) => {
 
   return (
     <Flex my={2} sx={{ flexDirection: 'column' }}>
-      <Heading variant="small" my={2}>
+      <Heading as="h3" variant="small" my={2}>
         {`${title} ${user.userName}`}
       </Heading>
       <Form

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -127,6 +127,7 @@ export const MemberProfile = ({ user, docs }: IProps) => {
             </Flex>
             <Box sx={{ flexDirection: 'column' }} mb={3}>
               <Heading
+                as="h1"
                 color={'black'}
                 style={{ wordWrap: 'break-word' }}
                 data-cy="userDisplayName"

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -250,6 +250,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                 }}
               />
               <Heading
+                as="h1"
                 color={'black'}
                 mb={3}
                 style={{ wordBreak: 'break-word' }}

--- a/src/pages/User/content/UserCreatedDocuments.tsx
+++ b/src/pages/User/content/UserCreatedDocuments.tsx
@@ -20,7 +20,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
               mb={6}
               sx={{ flexDirection: 'column', flexBasis: '50%' }}
             >
-              <Heading variant="small" mb={1}>
+              <Heading as="h3" variant="small" mb={1}>
                 How-To's
               </Heading>
               {docs?.howtos.map((item) => {
@@ -36,7 +36,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
           )}
           {docs?.research.length > 0 && (
             <Flex my={2} sx={{ flexDirection: 'column', flexBasis: '50%' }}>
-              <Heading variant="small" mb={1}>
+              <Heading as="h3" variant="small" mb={1}>
                 Research
               </Heading>
               {docs?.research.map((item) => {

--- a/src/pages/User/content/UserCreatedDocumentsItem.tsx
+++ b/src/pages/User/content/UserCreatedDocumentsItem.tsx
@@ -38,6 +38,7 @@ const UserDocumentItem = ({ type, item }: IProps) => {
           }}
         >
           <Heading
+            as="p"
             color={'black'}
             sx={{
               fontSize: ['12px', '12px', '16px'],

--- a/src/pages/User/impact/ImpactItem.tsx
+++ b/src/pages/User/impact/ImpactItem.tsx
@@ -31,7 +31,9 @@ export const ImpactItem = ({ fields, user, year }: Props) => {
   return (
     <Box sx={outterBox} cy-data="ImpactItem">
       <Box sx={innerBox}>
-        <Heading variant="small">{year}</Heading>
+        <Heading as="h3" variant="small">
+          {year}
+        </Heading>
         {visibleFields && visibleFields.length > 0 ? (
           visibleFields.map((field, index) => {
             return <ImpactField field={field} key={index} />


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [?] Bug fix (non-breaking change which fixes an issue)
- [?] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

_What this PR does_
This PR update all Heading tags in the User (members and others) profile to specific html heading tags from the default h2 to h1, h2 or h3. It should respect a correct hierarchical structure. To sum up, all tabs are now confirmed h2, and every other heading in the card is now a h3 and the name of the user is now a h1.

## Git Issues

Helps to close #3424

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
