### PR TITLE
refactor: split rules out to granular matching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
           at: '.'
       - run:
           name: Test Security Rules
-          command: yarn workspace security-rules test-with-emulator
+          command: yarn workspace security-rules test
   test_functions:
     docker:
       # use base image published by platform to ensure compatibility

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,15 +11,85 @@ service cloud.firestore {
       return request.auth.uid == request.resource.id
     }
 
-    match /v3_users/{userId} {
-      allow delete: if request.auth != null && request.auth.uid == userId;
+    function isPublicReadable() {
+      return true;
     }
 
-    match /{collectionId}/{document=**} {
-      allow get: if collectionId != 'user_integrations' || userIntegrationsRead()
+    function isPublicWritable() {
+      return true;
+    }
+
+    match /aggregations_rev20220126/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /discussions_rev20231022/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /emails/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if false;
+    }
+
+    match /question_categories_rev20231130/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /questions_rev20230926/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /research_categories_rev20221224/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /research_rev20201020/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /templates/{document=**} {
+      allow read: if false
+      allow write: if false
+    }
+
+    match /user_integrations/{document=**} {
+      allow get: if userIntegrationsRead()
       // Do not allow users to list all user integrations.
-      allow list: if collectionId != 'user_integrations'
-      allow write: if collectionId != 'emails' && (collectionId != 'user_integrations' || userIntegrationsWrite())
+      allow list: if false
+      allow write: if userIntegrationsWrite()
+    }
+
+    match /user_notifications_rev20221209/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /v3_howtos/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /v3_mappins/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /v3_tags/{document=**} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+    }
+
+    match /v3_users/{userId} {
+      allow read: if isPublicReadable();
+      allow write: if isPublicWritable();
+      allow delete: if request.auth != null && request.auth.uid == userId;
     }
   }
 }

--- a/packages/security-rules/README.md
+++ b/packages/security-rules/README.md
@@ -17,4 +17,4 @@ Create a `.env` file in the root of this project which contains:
 PROJECT_ID=<firebase-project-id>
 ```
 
-Run the tests against the project rules using `yarn test-with-emulator`
+Run the tests against the project rules using `yarn test`

--- a/packages/security-rules/package.json
+++ b/packages/security-rules/package.json
@@ -10,9 +10,7 @@
     "vitest": "^0.31.0"
   },
   "scripts": {
-    "test:watch": "vitest . --watch",
     "test": "vitest run .",
-    "test-with-emulator": "firebase emulators:exec --only firestore 'yarn test'",
-    "test-with-emulator:watch": "firebase emulators:exec --only firestore 'yarn test:watch'"
+    "test-with-emulator": "firebase emulators:exec --only firestore 'yarn test'"
   }
 }

--- a/packages/security-rules/package.json
+++ b/packages/security-rules/package.json
@@ -10,7 +10,7 @@
     "vitest": "^0.31.0"
   },
   "scripts": {
-    "test": "vitest run .",
-    "test-with-emulator": "firebase emulators:exec --only firestore 'yarn test'"
+    "test:unit": "vitest run .",
+    "test": "firebase emulators:exec --only firestore 'yarn test:unit'"
   }
 }

--- a/packages/security-rules/tests/general.spec.ts
+++ b/packages/security-rules/tests/general.spec.ts
@@ -42,6 +42,20 @@ describe('community platform', () => {
     })
   })
 
+  describe('templates', () => {
+    it('does not allow READ', async () => {
+      await assertFails(getDoc(doc(unauthedDb, 'templates/bar')))
+    })
+
+    it('does not allow WRITE', async () => {
+      await assertFails(
+        setDoc(doc(unauthedDb, 'templates/bar'), {
+          email: '',
+        }),
+      )
+    })
+  })
+
   describe('user_integrations', () => {
     beforeAll(async () => {
       // Set a doc for the authed user.
@@ -84,6 +98,37 @@ describe('community platform', () => {
           newIntegration: 'newIntegration',
         }),
       )
+    })
+  })
+
+  // Publicly accessible collections.
+  const publicCollections = [
+    'aggregations_rev20220126',
+    'discussions_rev20231022',
+    'question_categories_rev20231130',
+    'questions_rev20230926',
+    'research_categories_rev20221224',
+    'research_rev20201020',
+    'user_notifications_rev20221209',
+    'v3_howtos',
+    'v3_mappins',
+    'v3_tags',
+    'v3_users',
+  ]
+
+  publicCollections.forEach((collection) => {
+    describe(`${collection}`, () => {
+      it(`${collection} allows READ`, async () => {
+        await assertSucceeds(getDoc(doc(unauthedDb, collection, 'bar')))
+      })
+
+      it(`${collection} allows WRITE`, async () => {
+        await assertSucceeds(
+          setDoc(doc(unauthedDb, collection, 'bar'), {
+            email: '',
+          }),
+        )
+      })
     })
   })
 })

--- a/packages/security-rules/vite.config.mts
+++ b/packages/security-rules/vite.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    reporters: ['default','verbose'],
     coverage: {
       provider: 'c8',
       reporter: ['text', 'json', 'html'],

--- a/packages/security-rules/vite.config.mts
+++ b/packages/security-rules/vite.config.mts
@@ -1,16 +1,10 @@
-import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
-  plugins: [react()],
   test: {
     environment: 'jsdom',
     globals: true,
     reporters: ['default','verbose'],
-    coverage: {
-      provider: 'c8',
-      reporter: ['text', 'json', 'html'],
-    },
   },
 })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

In preparation for reviewing the permissions around each collection
we need to split the matches out to target an individual collection.

This allows us to apply rules in a granular fashion, based on the
following documented behaviour from Firestore:

> It's possible for a document to match more than one match
> statement. In the case where multiple allow expressions
> match a request, the access is allowed if any of the
> conditions is true.
https://firebase.google.com/docs/firestore/security/rules-structure#version-1