### PR TITLE
feat: still display replies for deleted comment

### DIFF
--- a/packages/components/src/ButtonShowReplies/ButtonShowReplies.stories.tsx
+++ b/packages/components/src/ButtonShowReplies/ButtonShowReplies.stories.tsx
@@ -61,3 +61,16 @@ export const NoReplies: StoryFn<typeof ButtonShowReplies> = () => {
     />
   )
 }
+
+export const NoCreatorName: StoryFn<typeof ButtonShowReplies> = () => {
+  const replies = createFakeComments(1)
+
+  return (
+    <ButtonShowReplies
+      creatorName={null}
+      isShowReplies={false}
+      replies={replies}
+      setIsShowReplies={mockSetIsShowReplies}
+    />
+  )
+}

--- a/packages/components/src/ButtonShowReplies/ButtonShowReplies.stories.tsx
+++ b/packages/components/src/ButtonShowReplies/ButtonShowReplies.stories.tsx
@@ -70,7 +70,7 @@ export const NoCreatorName: StoryFn<typeof ButtonShowReplies> = () => {
       creatorName={null}
       isShowReplies={false}
       replies={replies}
-      setIsShowReplies={mockSetIsShowReplies}
+      setIsShowReplies={() => null}
     />
   )
 }

--- a/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
+++ b/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
@@ -3,7 +3,7 @@ import { Button } from '../Button/Button'
 import type { IComment } from '../CommentItem/types'
 
 export interface Props {
-  creatorName: string
+  creatorName: string | null
   isShowReplies: boolean
   replies: IComment[]
   setIsShowReplies: () => void
@@ -28,7 +28,7 @@ export const ButtonShowReplies = (props: Props) => {
       variant="outline"
       small
     >
-      {`${text} to ${creatorName}`}
+      {text} {creatorName && ` to ${creatorName}`}
     </Button>
   )
 }

--- a/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
+++ b/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
@@ -1,4 +1,5 @@
 import { Button } from '../Button/Button'
+import { nonDeletedCommentsCount } from '../DiscussionTitle/DiscussionTitle'
 
 import type { IComment } from '../CommentItem/types'
 
@@ -12,12 +13,10 @@ export interface Props {
 export const ButtonShowReplies = (props: Props) => {
   const { creatorName, isShowReplies, replies, setIsShowReplies } = props
 
-  const length = replies && replies.length ? replies.length : 0
+  const count = nonDeletedCommentsCount(replies)
   const icon = isShowReplies ? 'arrow-full-up' : 'arrow-full-down'
 
-  const text = length
-    ? `${length} ${length === 1 ? 'reply' : 'replies'}`
-    : `Reply`
+  const text = count ? `${count} ${count === 1 ? 'reply' : 'replies'}` : `Reply`
 
   return (
     <Button

--- a/packages/components/src/CommentItem/CommentItem.stories.tsx
+++ b/packages/components/src/CommentItem/CommentItem.stories.tsx
@@ -10,35 +10,74 @@ export default {
   component: CommentItem,
 } as Meta<typeof CommentItem>
 
+const handleEdit = () => {
+  return
+}
+
 export const Default: StoryFn<typeof CommentItem> = () => {
   const comment = fakeComment({ creatorImage: faker.image.avatar() })
 
-  return <CommentItem isReply={false} comment={comment} showAvatar />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={false}
+      showAvatar
+    />
+  )
 }
 
 export const WithoutAvatar: StoryFn<typeof CommentItem> = () => {
   const comment = fakeComment()
 
-  return <CommentItem isReply={false} comment={comment} showAvatar={false} />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={false}
+      showAvatar={false}
+    />
+  )
 }
 
 export const Editable: StoryFn<typeof CommentItem> = () => {
   const comment = fakeComment({ isEditable: true })
 
-  return <CommentItem isReply={false} comment={comment} showAvatar />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={false}
+      showAvatar
+    />
+  )
 }
 
 export const Edited: StoryFn<typeof CommentItem> = () => {
   const comment = fakeComment({ _edited: new Date().toISOString() })
 
-  return <CommentItem isReply={false} comment={comment} showAvatar />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={false}
+      showAvatar
+    />
+  )
 }
 
 export const LongText: StoryFn<typeof CommentItem> = () => {
   const text = `Ut dignissim, odio a cursus pretium, erat ex dictum quam, a eleifend augue mauris vel metus. Suspendisse pellentesque, elit efficitur rutrum maximus, arcu enim congue ipsum, vel aliquam ipsum urna quis tellus. Mauris at imperdiet nisi. Integer at neque ex. Nullam vel ipsum sodales, porttitor nulla vitae, tincidunt est. Pellentesque vitae lectus arcu. Integer dapibus rutrum facilisis. Nullam tincidunt quam at arcu interdum, vitae egestas libero vehicula. Morbi metus tortor, dapibus id finibus ac, egestas quis leo. Phasellus scelerisque suscipit mauris sed rhoncus. In quis ultricies ipsum. Integer vitae iaculis risus, sit amet elementum augue. Pellentesque vitae sagittis erat, eget consectetur lorem.\n\nUt pharetra molestie quam id dictum. In molestie, arcu sit amet faucibus pulvinar, eros erat egestas leo, at molestie nunc velit a arcu. Aliquam erat volutpat. Vivamus vehicula mi sit amet nibh auctor efficitur. Duis fermentum sem et nibh facilisis, ut tincidunt sem commodo. Nullam ornare ex a elementum accumsan. Etiam a neque ut lacus suscipit blandit. Maecenas id tortor velit.\n\nInterdum et malesuada fames ac ante ipsum primis in faucibus. Nam ut commodo tellus. Maecenas at leo metus. Vivamus ullamcorper ex purus, volutpat auctor nunc lobortis a. Integer sit amet ornare nisi, sed ultrices enim. Pellentesque ut aliquam urna, eu fringilla ante. Nullam dui nibh, feugiat id vestibulum nec, efficitur a lorem. In vitae pellentesque tellus. Pellentesque sed odio iaculis, imperdiet turpis at, aliquam ex. Praesent iaculis bibendum nibh, vel egestas turpis ultrices ac. Praesent tincidunt libero sed gravida ornare. Aliquam vehicula risus ut molestie suscipit. Nunc erat odio, venenatis nec posuere in, placerat eget massa. Sed in ultrices ex, vel egestas quam. Integer lectus magna, ornare at nisl sed, convallis euismod enim. Cras pretium commodo arcu non bibendum.\n\nNullam dictum lectus felis. Duis vitae lacus vitae nisl aliquet faucibus. Integer neque lacus, dignissim sed mi et, dignissim luctus metus. Cras sollicitudin vestibulum leo, ac ultrices sapien bibendum ac. Phasellus lobortis aliquam libero eu volutpat. Donec vitae rutrum tellus. Fusce vel ante ipsum. Suspendisse mollis tempus porta. Sed a orci tempor, rhoncus tortor eu, sodales justo.`
   const comment = fakeComment({ text })
 
-  return <CommentItem isReply={true} comment={comment} showAvatar />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={true}
+      showAvatar
+    />
+  )
 }
 
 export const ShortTextWithLink: StoryFn<typeof CommentItem> = () => {
@@ -46,5 +85,12 @@ export const ShortTextWithLink: StoryFn<typeof CommentItem> = () => {
     text: `Ut dignissim, odio a cursus pretium. https://example.com`,
   })
 
-  return <CommentItem isReply={true} comment={comment} showAvatar />
+  return (
+    <CommentItem
+      comment={comment}
+      handleEdit={handleEdit}
+      isReply={true}
+      showAvatar
+    />
+  )
 }

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -93,7 +93,7 @@ export const CommentItem = (props: IProps) => {
       <Flex sx={{ gap: 2 }}>
         {_deleted && (
           <Box sx={{ marginBottom: 2 }}>
-            <Text sx={{ color: 'grey' }}>{DELETED_COMMENT}</Text>
+            <Text sx={{ color: 'grey' }}>[{DELETED_COMMENT}]</Text>
           </Box>
         )}
 

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -11,6 +11,7 @@ import { Username } from '../Username/Username'
 import type { IComment } from './types'
 
 const SHORT_COMMENT = 129
+const DELETED_COMMENT = 'The original comment got deleted'
 
 export interface IProps {
   comment: IComment
@@ -53,6 +54,7 @@ export const CommentItem = (props: IProps) => {
     _created,
     _edited,
     _id,
+    _deleted,
   } = comment
 
   const user = {
@@ -89,106 +91,114 @@ export const CommentItem = (props: IProps) => {
       sx={{ flexDirection: 'column' }}
     >
       <Flex sx={{ gap: 2 }}>
-        {creatorImage && showAvatar && (
-          <Box data-cy="commentAvatar" data-testid="commentAvatar">
-            <Avatar
-              src={creatorImage}
-              sx={{
-                objectFit: 'cover',
-                width: ['30px', '50px'],
-                height: ['30px', '50px'],
-              }}
-            />
+        {_deleted && (
+          <Box sx={{ marginBottom: 2 }}>
+            <Text sx={{ color: 'grey' }}>{DELETED_COMMENT}</Text>
           </Box>
         )}
 
-        <Flex
-          sx={{
-            flexDirection: 'column',
-            flex: 1,
-          }}
-        >
+        {!_deleted && (
           <Flex
             sx={{
-              alignItems: 'stretch',
-              flexWrap: 'wrap',
-              justifyContent: 'flex-start',
-              flexDirection: ['column', 'row'],
-              gap: 2,
+              flexDirection: 'column',
+              flex: 1,
             }}
           >
+            {creatorImage && showAvatar && (
+              <Box data-cy="commentAvatar" data-testid="commentAvatar">
+                <Avatar
+                  src={creatorImage}
+                  sx={{
+                    objectFit: 'cover',
+                    width: ['30px', '50px'],
+                    height: ['30px', '50px'],
+                  }}
+                />
+              </Box>
+            )}
+
             <Flex
               sx={{
-                alignItems: 'baseline',
+                alignItems: 'stretch',
+                flexWrap: 'wrap',
+                justifyContent: 'flex-start',
+                flexDirection: ['column', 'row'],
                 gap: 2,
-                flexDirection: 'row',
               }}
             >
-              <Username user={user} />
-              {_edited && (
-                <Text sx={{ fontSize: 0, color: 'grey' }}>(Edited)</Text>
-              )}
-              <Text sx={{ fontSize: 1 }}>{date}</Text>
-            </Flex>
-
-            {isEditable && (
               <Flex
                 sx={{
-                  flexGrow: 1,
+                  alignItems: 'baseline',
                   gap: 2,
-                  justifyContent: ['flex-start', 'flex-end'],
-                  opacity: 0.5,
-                  ':hover': { opacity: 1 },
+                  flexDirection: 'row',
                 }}
               >
-                <Button
-                  data-cy="CommentItem: edit button"
-                  variant="outline"
-                  small={true}
-                  icon="edit"
-                  onClick={() => onEditRequest(_id)}
-                >
-                  edit
-                </Button>
-                <Button
-                  data-cy="CommentItem: delete button"
-                  variant={'outline'}
-                  small={true}
-                  icon="delete"
-                  onClick={() => setShowDeleteModal(true)}
-                >
-                  delete
-                </Button>
+                <Username user={user} />
+                {_edited && (
+                  <Text sx={{ fontSize: 0, color: 'grey' }}>(Edited)</Text>
+                )}
+                <Text sx={{ fontSize: 1 }}>{date}</Text>
               </Flex>
+
+              {isEditable && (
+                <Flex
+                  sx={{
+                    flexGrow: 1,
+                    gap: 2,
+                    justifyContent: ['flex-start', 'flex-end'],
+                    opacity: 0.5,
+                    ':hover': { opacity: 1 },
+                  }}
+                >
+                  <Button
+                    data-cy="CommentItem: edit button"
+                    variant="outline"
+                    small={true}
+                    icon="edit"
+                    onClick={() => onEditRequest(_id)}
+                  >
+                    edit
+                  </Button>
+                  <Button
+                    data-cy="CommentItem: delete button"
+                    variant={'outline'}
+                    small={true}
+                    icon="delete"
+                    onClick={() => setShowDeleteModal(true)}
+                  >
+                    delete
+                  </Button>
+                </Flex>
+              )}
+            </Flex>
+            <Text
+              data-cy="comment-text"
+              sx={{
+                fontFamily: 'body',
+                lineHeight: 1.3,
+                maxHeight,
+                overflow: 'hidden',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                marginY: 2,
+              }}
+              ref={textRef}
+            >
+              <LinkifyText>{text}</LinkifyText>
+            </Text>
+            {textHeight > SHORT_COMMENT && (
+              <a
+                onClick={showMore}
+                style={{
+                  color: 'gray',
+                  cursor: 'pointer',
+                }}
+              >
+                {isShowMore ? 'Show less' : 'Show more'}
+              </a>
             )}
           </Flex>
-          <Text
-            data-cy="comment-text"
-            sx={{
-              fontFamily: 'body',
-              lineHeight: 1.3,
-              maxHeight,
-              overflow: 'hidden',
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
-              marginY: 2,
-            }}
-            ref={textRef}
-          >
-            <LinkifyText>{text}</LinkifyText>
-          </Text>
-          {textHeight > SHORT_COMMENT && (
-            <a
-              onClick={showMore}
-              style={{
-                color: 'gray',
-                cursor: 'pointer',
-              }}
-            >
-              {isShowMore ? 'Show less' : 'Show more'}
-            </a>
-          )}
-        </Flex>
+        )}
       </Flex>
 
       <Modal width={600} isOpen={showEditModal}>

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -16,7 +16,7 @@ const DELETED_COMMENT = 'The original comment got deleted'
 export interface IProps {
   comment: IComment
   handleDelete?: (commentId: string) => Promise<void>
-  handleEdit?: (commentId: string, newCommentText: string) => void
+  handleEdit: (commentId: string, newCommentText: string) => void
   handleEditRequest?: (commentId: string) => Promise<void>
   isReply: boolean
   showAvatar: boolean
@@ -66,6 +66,7 @@ export const CommentItem = (props: IProps) => {
 
   const date = formatDate(_edited || _created)
   const maxHeight = isShowMore ? 'max-content' : '128px'
+  const item = isReply ? 'ReplyItem' : 'CommentItem'
 
   useEffect(() => {
     if (textRef.current) {
@@ -85,14 +86,10 @@ export const CommentItem = (props: IProps) => {
   }
 
   return (
-    <Flex
-      id={`comment:${_id}`}
-      data-cy="comment"
-      sx={{ flexDirection: 'column' }}
-    >
+    <Flex id={`comment:${_id}`} data-cy={item} sx={{ flexDirection: 'column' }}>
       <Flex sx={{ gap: 2 }}>
         {_deleted && (
-          <Box sx={{ marginBottom: 2 }}>
+          <Box sx={{ marginBottom: 2 }} data-cy="deletedComment">
             <Text sx={{ color: 'grey' }}>[{DELETED_COMMENT}]</Text>
           </Box>
         )}
@@ -151,7 +148,7 @@ export const CommentItem = (props: IProps) => {
                   }}
                 >
                   <Button
-                    data-cy="CommentItem: edit button"
+                    data-cy={`${item}: edit button`}
                     variant="outline"
                     small={true}
                     icon="edit"
@@ -160,7 +157,7 @@ export const CommentItem = (props: IProps) => {
                     edit
                   </Button>
                   <Button
-                    data-cy="CommentItem: delete button"
+                    data-cy={`${item}: delete button`}
                     variant={'outline'}
                     small={true}
                     icon="delete"
@@ -204,8 +201,8 @@ export const CommentItem = (props: IProps) => {
       <Modal width={600} isOpen={showEditModal}>
         <EditComment
           comment={text}
-          handleSubmit={(commentText) => {
-            handleEdit && handleEdit(_id, commentText)
+          handleSubmit={async (commentText) => {
+            await handleEdit(_id, commentText)
             setShowEditModal(false)
           }}
           handleCancel={() => setShowEditModal(false)}
@@ -218,8 +215,8 @@ export const CommentItem = (props: IProps) => {
         message="Are you sure you want to delete this comment?"
         confirmButtonText="Delete"
         handleCancel={() => setShowDeleteModal(false)}
-        handleConfirm={() => {
-          handleDelete && handleDelete(_id)
+        handleConfirm={async () => {
+          handleDelete && (await handleDelete(_id))
           setShowDeleteModal(false)
         }}
       />

--- a/packages/components/src/CommentItem/types.ts
+++ b/packages/components/src/CommentItem/types.ts
@@ -9,5 +9,6 @@ export interface IComment {
   _id: string
   _edited?: string
   _created?: string
+  _deleted?: boolean
   replies?: IComment[]
 }

--- a/packages/components/src/CommentList/CommentList.stories.tsx
+++ b/packages/components/src/CommentList/CommentList.stories.tsx
@@ -44,13 +44,16 @@ export const WithNestedComments: StoryFn<typeof CommentList> = () => {
     fakeComment({
       creatorImage:
         'https://oacpppprod-1fa0a.kxcdn.com/o/uploads%2Fhowtos%2FsEHCqVHlBmMRG8TG0CGN%2FToasteOvenMod-18cd7fc9c38.jpg?alt=media&token=1dd11c48-151a-49cc-9287-443f96a10840',
-
       replies: [
         fakeComment({
           creatorImage:
             'https://avatars.githubusercontent.com/u/16688508?s=80&u=7332d9d2a953c33179b428d2ee804bfc80a06f5d&v=4',
         }),
       ],
+      _deleted: true,
+    }),
+    fakeComment({
+      replies: [fakeComment()],
     }),
     fakeComment(),
   ]

--- a/packages/components/src/CommentList/CommentList.tsx
+++ b/packages/components/src/CommentList/CommentList.tsx
@@ -50,7 +50,7 @@ export const CommentContainer = (props: IPropsCommentContainer) => {
     onSubmitReply,
     showAvatar,
   } = props
-  const { _id, creatorName, replies } = comment
+  const { _id, _deleted, creatorName, replies } = comment
 
   const replyArrow = () => {
     return (
@@ -68,7 +68,7 @@ export const CommentContainer = (props: IPropsCommentContainer) => {
   const repliesButton = () => {
     return (
       <ButtonShowReplies
-        creatorName={creatorName}
+        creatorName={!_deleted ? creatorName : null}
         isShowReplies={isShowReplies}
         replies={replies || []}
         setIsShowReplies={() => setIsShowReplies(!isShowReplies)}
@@ -88,6 +88,8 @@ export const CommentContainer = (props: IPropsCommentContainer) => {
       )
     }
   }
+
+  if (_deleted && (!replies || replies.length === 0)) return null
 
   return (
     <Box
@@ -136,7 +138,7 @@ export const CommentContainer = (props: IPropsCommentContainer) => {
               showAvatar={showAvatar}
             />
 
-            {createReply()}
+            {!_deleted && createReply()}
 
             {repliesButton()}
           </Flex>

--- a/packages/components/src/CommentList/CommentList.tsx
+++ b/packages/components/src/CommentList/CommentList.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button/Button'
 import { ButtonShowReplies } from '../ButtonShowReplies/ButtonShowReplies'
 import { CommentItem } from '../CommentItem/CommentItem'
 import { CreateReply } from '../CreateReply/CreateReply'
+import { nonDeletedCommentsCount } from '../DiscussionTitle/DiscussionTitle'
 import { Icon } from '../Icon/Icon'
 
 import type { IComment } from '../CommentItem/types'
@@ -89,7 +90,9 @@ export const CommentContainer = (props: IPropsCommentContainer) => {
     }
   }
 
-  if (_deleted && (!replies || replies.length === 0)) return null
+  if (_deleted && (!replies || nonDeletedCommentsCount(replies) === 0)) {
+    return null
+  }
 
   return (
     <Box

--- a/packages/components/src/CreateComment/CreateComment.tsx
+++ b/packages/components/src/CreateComment/CreateComment.tsx
@@ -7,6 +7,7 @@ export interface Props {
   maxLength: number
   isLoggedIn: boolean
   isLoading?: boolean
+  isReply?: boolean
   onSubmit: (value: string) => void
   onChange: (value: string) => void
   comment: string
@@ -16,7 +17,7 @@ export interface Props {
 }
 
 export const CreateComment = (props: Props) => {
-  const { comment, isLoggedIn, maxLength, onSubmit, isLoading } = props
+  const { comment, isLoggedIn, isReply, maxLength, onSubmit, isLoading } = props
   const userProfileType = props.userProfileType || 'member'
   const placeholder = props.placeholder || 'Leave your questions or feedback...'
   const buttonLabel = props.buttonLabel ?? 'Leave a comment'
@@ -58,7 +59,7 @@ export const CreateComment = (props: Props) => {
                   onChange && onChange(event.target.value)
                 }}
                 aria-label="Comment"
-                data-cy="comments-form"
+                data-cy={isReply ? 'reply-form' : 'comments-form'}
                 placeholder={placeholder}
                 sx={{
                   background: 'none',
@@ -104,7 +105,7 @@ export const CreateComment = (props: Props) => {
 
       <Flex sx={{ alignSelf: 'flex-end' }}>
         <Button
-          data-cy="comment-submit"
+          data-cy={isReply ? 'reply-submit' : 'comment-submit'}
           disabled={!comment.trim() || !isLoggedIn || isLoading}
           variant="primary"
           onClick={() => {

--- a/packages/components/src/CreateReply/CreateReply.tsx
+++ b/packages/components/src/CreateReply/CreateReply.tsx
@@ -45,6 +45,7 @@ export const CreateReply = (props: Props) => {
         onSubmit={handleSubmit}
         isLoggedIn={isLoggedIn}
         isLoading={isLoading}
+        isReply
         buttonLabel="Leave a reply"
       />
       {isError ? (

--- a/packages/components/src/DiscussionContainer/DiscussionContainer.tsx
+++ b/packages/components/src/DiscussionContainer/DiscussionContainer.tsx
@@ -60,7 +60,7 @@ export const DiscussionContainer = (props: IProps) => {
 
   return (
     <Flex sx={{ flexDirection: 'column', gap: 2 }}>
-      <DiscussionTitle length={comments.length} />
+      <DiscussionTitle comments={comments} />
 
       <CommentList
         supportReplies={supportReplies}

--- a/packages/components/src/DiscussionTitle/DiscussionTitle.stories.tsx
+++ b/packages/components/src/DiscussionTitle/DiscussionTitle.stories.tsx
@@ -1,6 +1,7 @@
 import { DiscussionTitle } from './DiscussionTitle'
 
 import type { Meta, StoryFn } from '@storybook/react'
+import type { IComment } from '../CommentItem/types'
 
 export default {
   title: 'Components/DiscussionTitle',
@@ -8,13 +9,16 @@ export default {
 } as Meta<typeof DiscussionTitle>
 
 export const NoComments: StoryFn<typeof DiscussionTitle> = () => (
-  <DiscussionTitle length={0} />
+  <DiscussionTitle comments={[]} />
 )
 
-export const OneComment: StoryFn<typeof DiscussionTitle> = () => (
-  <DiscussionTitle length={1} />
-)
+export const OneComment: StoryFn<typeof DiscussionTitle> = () => {
+  const comment = {} as IComment
 
-export const MultipleComments: StoryFn<typeof DiscussionTitle> = () => (
-  <DiscussionTitle length={45} />
-)
+  return <DiscussionTitle comments={[comment]} />
+}
+
+export const MultipleComments: StoryFn<typeof DiscussionTitle> = () => {
+  const comment = {} as IComment
+  return <DiscussionTitle comments={[comment, comment, comment]} />
+}

--- a/packages/components/src/DiscussionTitle/DiscussionTitle.test.tsx
+++ b/packages/components/src/DiscussionTitle/DiscussionTitle.test.tsx
@@ -34,6 +34,6 @@ describe('DiscussionTitle', () => {
       <MultipleComments {...(MultipleComments.args as IProps)} />,
     )
 
-    expect(getByText(`45 ${COMMENTS}`)).toBeInTheDocument()
+    expect(getByText(`3 ${COMMENTS}`)).toBeInTheDocument()
   })
 })

--- a/packages/components/src/DiscussionTitle/DiscussionTitle.tsx
+++ b/packages/components/src/DiscussionTitle/DiscussionTitle.tsx
@@ -1,23 +1,31 @@
 import { Heading } from 'theme-ui'
 
+import type { IComment } from '../CommentItem/types'
+
 export const NO_COMMENTS = 'Start the discussion'
 export const ONE_COMMENT = '1 Comment'
 export const COMMENTS = 'Comments'
 
 export interface IProps {
-  length: number
+  comments: IComment[]
 }
 
-export const DiscussionTitle = ({ length }: IProps) => {
+export const nonDeletedCommentsCount = (comments: IComment[]) => {
+  return comments.filter(({ _deleted }) => _deleted !== true).length
+}
+
+export const DiscussionTitle = ({ comments }: IProps) => {
+  const commentCount = nonDeletedCommentsCount(comments)
+
   const setTitle = () => {
-    if (length === 0) {
+    if (commentCount === 0) {
       return NO_COMMENTS
     }
-    if (length === 1) {
+    if (commentCount === 1) {
       return ONE_COMMENT
     }
 
-    return `${length} ${COMMENTS}`
+    return `${commentCount} ${COMMENTS}`
   }
 
   const title = setTitle()

--- a/packages/components/src/EditComment/EditComment.tsx
+++ b/packages/components/src/EditComment/EditComment.tsx
@@ -51,6 +51,7 @@ export const EditComment = (props: IProps) => {
         comment,
       }}
       validate={validateEditedComment}
+      data-cy="EditCommentForm"
       render={({ invalid, handleSubmit, values }) => {
         const disabled = invalid
         return (

--- a/packages/cypress/src/integration/howto/discussions.spec.ts
+++ b/packages/cypress/src/integration/howto/discussions.spec.ts
@@ -17,8 +17,8 @@ describe('[Howto.Discussions]', () => {
 
     cy.signUpNewUser()
     cy.visit(`/how-to/${item.slug}#comment:${firstComment._id}`)
-    cy.get('[data-cy="comment"]').should('have.length.gte', 2)
-    cy.get('[data-cy="comment"]')
+    cy.get('[data-cy="CommentItem"]').should('have.length.gte', 2)
+    cy.get('[data-cy="CommentItem"]')
       .first()
       .scrollIntoView()
       .should('be.inViewport', 10)
@@ -57,8 +57,8 @@ describe('[Howto.Discussions]', () => {
 
     cy.step('Can add reply')
     cy.get('[data-cy=show-replies]:first').click()
-    cy.get('[data-cy=comments-form]:first').type(newReply)
-    cy.get('[data-cy=comment-submit]:first').click()
+    cy.get('[data-cy=reply-form]:first').type(newReply)
+    cy.get('[data-cy=reply-submit]:first').click()
     cy.contains(`${howtoDiscussion.comments.length + 1} comments`)
     cy.contains(newReply)
     cy.queryDocuments('howtos', '_id', '==', item._id).then((docs) => {
@@ -69,14 +69,14 @@ describe('[Howto.Discussions]', () => {
     })
 
     cy.step('Can edit their reply')
-    cy.get('[data-cy="CommentItem: edit button"]:first').click()
+    cy.get('[data-cy="ReplyItem: edit button"]:first').click()
     cy.get('[data-cy=edit-comment]').clear().type(updatedNewReply)
     cy.get('[data-cy=edit-comment-submit]').click()
     cy.contains(updatedNewReply)
     cy.contains(newReply).should('not.exist')
 
     cy.step('Can delete their reply')
-    cy.get('[data-cy="CommentItem: delete button"]:first').click()
+    cy.get('[data-cy="ReplyItem: delete button"]:first').click()
     cy.get('[data-cy="Confirm.modal: Confirm"]:first').click()
     cy.contains(updatedNewReply).should('not.exist')
     cy.contains(`${howtoDiscussion.comments.length} comments`)

--- a/packages/cypress/src/integration/research/discussions.spec.ts
+++ b/packages/cypress/src/integration/research/discussions.spec.ts
@@ -15,8 +15,10 @@ const firstComment = discussion.comments[0]
 describe('[Research.Discussions]', () => {
   it('can open using deep links', () => {
     cy.visit(`/research/${item.slug}#update-0-comment:${firstComment._id}`)
-    cy.get('[data-cy="comment"]').should('have.length.gte', 1)
-    cy.get('[data-cy="comment"]').scrollIntoView().should('be.inViewport', 10)
+    cy.get('[data-cy="CommentItem"]').should('have.length.gte', 1)
+    cy.get('[data-cy="CommentItem"]')
+      .scrollIntoView()
+      .should('be.inViewport', 10)
     cy.contains(firstComment.text)
   })
 
@@ -38,10 +40,10 @@ describe('[Research.Discussions]', () => {
     cy.get('[data-cy="comments-form"]').type(comment)
     cy.get('[data-cy="comment-submit"]').click()
     cy.get('[data-cy=update_0]').contains('2 Comments')
-    cy.get('[data-cy="comment"]').last().should('contain', comment)
+    cy.get('[data-cy="CommentItem"]').last().should('contain', comment)
 
     cy.step('Can edit their own comment')
-    cy.get('[data-cy="comment"]')
+    cy.get('[data-cy="CommentItem"]')
       .last()
       .get(`[data-cy="CommentItem: edit button"]`)
       .click()
@@ -57,8 +59,8 @@ describe('[Research.Discussions]', () => {
 
     cy.step('Can add reply')
     cy.get('[data-cy=show-replies]:first').click()
-    cy.get('[data-cy=comments-form]:first').type(reply)
-    cy.get('[data-cy=comment-submit]:first').click()
+    cy.get('[data-cy=reply-form]:first').type(reply)
+    cy.get('[data-cy=reply-submit]:first').click()
     cy.contains(`${discussion.comments.length + 1} Comments`)
     cy.contains(reply)
     cy.queryDocuments('research', '_id', '==', item._id).then((docs) => {
@@ -69,14 +71,14 @@ describe('[Research.Discussions]', () => {
     })
 
     cy.step('Can edit their reply')
-    cy.get('[data-cy="CommentItem: edit button"]:first').click()
+    cy.get('[data-cy="ReplyItem: edit button"]:first').click()
     cy.get('[data-cy=edit-comment]').clear().type(updatedReply)
     cy.get('[data-cy=edit-comment-submit]').click()
     cy.contains(updatedReply)
     cy.contains(reply).should('not.exist')
 
     cy.step('Can delete their reply')
-    cy.get('[data-cy="CommentItem: delete button"]:first').click()
+    cy.get('[data-cy="ReplyItem: delete button"]:first').click()
     cy.get('[data-cy="Confirm.modal: Confirm"]:first').click()
     cy.contains(updatedReply).should('not.exist')
     cy.contains(`1 Comment`)

--- a/src/common/DiscussionWrapper.tsx
+++ b/src/common/DiscussionWrapper.tsx
@@ -4,6 +4,7 @@ import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { transformToUserComments } from 'src/common/transformToUserComments'
 import { MAX_COMMENT_LENGTH } from 'src/constants'
 import { logger } from 'src/logger'
+import { nonDeletedCommentsCount } from 'src/utils/nonDeletedCommentsCount'
 import { Text } from 'theme-ui'
 
 import { AuthWrapper } from './AuthWrapper'
@@ -47,7 +48,8 @@ export const DiscussionWrapper = (props: IProps) => {
       discussion.comments,
       discussionStore.activeUser,
     )
-    setTotalCommentsCount(comments.length)
+    const count = nonDeletedCommentsCount(comments)
+    setTotalCommentsCount(count)
 
     return setDiscussion({ ...discussion, comments })
   }

--- a/src/models/discussion.models.tsx
+++ b/src/models/discussion.models.tsx
@@ -1,3 +1,4 @@
+import type { DBDoc } from '../stores/databaseV2/types'
 import type { IQuestion } from './question.models'
 
 export type IComment = {
@@ -24,5 +25,7 @@ export type IDiscussion = {
   sourceId: string
   sourceType: 'howto' | 'question' | 'researchUpdate'
 }
+
+export type IDiscussionDB = IDiscussion & DBDoc
 
 export type IDiscussionSourceModelOptions = IQuestion.Item

--- a/src/models/question.models.tsx
+++ b/src/models/question.models.tsx
@@ -18,6 +18,7 @@ export namespace IQuestion {
     _createdBy: string
     _deleted: boolean
     subscribers?: UserIdList
+    commentCount?: number
   } & DBDoc &
     FormInput &
     ISharedFeatures

--- a/src/pages/Question/QuestionPage.tsx
+++ b/src/pages/Question/QuestionPage.tsx
@@ -57,6 +57,7 @@ export const QuestionPage = () => {
       })
 
       setQuestion(foundQuestion)
+      setTotalCommentsCount(foundQuestion.commentCount || totalCommentsCount)
       setIsLoading(false)
     }
 

--- a/src/stores/Discussions/discussion.store.test.ts
+++ b/src/stores/Discussions/discussion.store.test.ts
@@ -316,7 +316,7 @@ describe('discussion.store', () => {
       expect(discussionItem.contributorIds).not.toEqual(
         expect.arrayContaining([comment._creatorId]),
       )
-      expect(setFn.mock.calls[0][0].comments).toHaveLength(0)
+      expect(setFn.mock.calls[0][0].comments[0]._deleted).toEqual(true)
     })
 
     it('allows admin to remove a comment', async () => {
@@ -337,7 +337,7 @@ describe('discussion.store', () => {
 
       // Asert
       expect(setFn).toHaveBeenCalledTimes(1)
-      expect(setFn.mock.calls[0][0].comments).toHaveLength(0)
+      expect(setFn.mock.calls[0][0].comments[0]._deleted).toEqual(true)
     })
 
     it('throws an error for a different user', async () => {

--- a/src/stores/Discussions/discussionEvents.ts
+++ b/src/stores/Discussions/discussionEvents.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-case-declarations */
 import { toJS } from 'mobx'
 import { logger } from 'src/logger'
+import { filterNonDeletedComments } from 'src/utils/filterNonDeletedComments'
 
 import type { IDiscussion, IResearch } from 'src/models'
 import type { DatabaseV2 } from '../databaseV2/DatabaseV2'
@@ -35,9 +36,13 @@ export const updateDiscussionMetadata = async (
     )
   }
 
-  const commentCount = comments.length
+  const nonDeletedComments = filterNonDeletedComments(comments)
+  const commentCount = nonDeletedComments.length
+
   const latestCommentDate =
-    commentCount > 0 ? calculateLastestCommentDate(comments) : undefined
+    commentCount > 0
+      ? calculateLastestCommentDate(nonDeletedComments)
+      : undefined
 
   switch (collectionName) {
     case 'research':

--- a/src/utils/filterNonDeletedComments.test.ts
+++ b/src/utils/filterNonDeletedComments.test.ts
@@ -1,0 +1,19 @@
+import { filterNonDeletedComments } from './filterNonDeletedComments'
+
+import type { IComment } from 'src/models'
+
+describe('nonDeletedCommentsCount', () => {
+  it('returns the full total when no comments are marked as deleted', () => {
+    const comments = [{ _id: '1' }, { _id: '2' }, { _id: '3' }] as IComment[]
+    expect(filterNonDeletedComments(comments)).toEqual(comments)
+  })
+
+  it('returns the reduced total when comments are marked as deleted', () => {
+    const comments = [
+      { _id: '1', _deleted: true },
+      { _id: '2', _deleted: true },
+      { _id: '3' },
+    ] as IComment[]
+    expect(filterNonDeletedComments(comments)).toEqual([comments[2]])
+  })
+})

--- a/src/utils/filterNonDeletedComments.test.ts
+++ b/src/utils/filterNonDeletedComments.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { filterNonDeletedComments } from './filterNonDeletedComments'
 
 import type { IComment } from 'src/models'

--- a/src/utils/filterNonDeletedComments.ts
+++ b/src/utils/filterNonDeletedComments.ts
@@ -1,0 +1,5 @@
+import type { IComment } from 'src/models'
+
+export const filterNonDeletedComments = (comments: IComment[]): IComment[] => {
+  return comments.filter(({ _deleted }) => _deleted !== true)
+}

--- a/src/utils/nonDeletedCommentsCount.test.ts
+++ b/src/utils/nonDeletedCommentsCount.test.ts
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom/vitest'
+
+import { describe, expect, it } from 'vitest'
+
+import { nonDeletedCommentsCount } from './nonDeletedCommentsCount'
+
+import type { IComment } from 'src/models'
+
+describe('nonDeletedCommentsCount', () => {
+  it('returns the full total when no comments are marked as deleted', () => {
+    const comments = [{}, {}, {}, {}] as IComment[]
+    expect(nonDeletedCommentsCount(comments)).toEqual(4)
+  })
+
+  it('returns the reduced total when comments are marked as deleted', () => {
+    const comments = [
+      { _deleted: true },
+      { _deleted: true },
+      {},
+      {},
+    ] as IComment[]
+    expect(nonDeletedCommentsCount(comments)).toEqual(2)
+  })
+})

--- a/src/utils/nonDeletedCommentsCount.ts
+++ b/src/utils/nonDeletedCommentsCount.ts
@@ -1,0 +1,7 @@
+import { filterNonDeletedComments } from './filterNonDeletedComments'
+
+import type { IComment } from 'src/models'
+
+export const nonDeletedCommentsCount = (comments: IComment[]): number => {
+  return filterNonDeletedComments(comments).length
+}


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Still show the nest comments (replies) when a parent comment is deleted. 

## Git Issues

Closes #

## Screenshots/Videos


https://github.com/ONEARMY/community-platform/assets/16688508/02b19d97-57ce-447b-92eb-963e9f22718b