### PR TITLE
fix: add ci cache step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ commands:
       - checkout
       - *restore_yarn_cache
       - *install_packages
+      - *save_yarn_cache
   inject_instance_configuration:
     steps:
       - run:


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

Adds yarn caching step to setup command.

Findings:
- adding `- *save_yarn_cache` to the setup command improves each execution of `yarn install` by ~1min
- but ideally it would reduce to 0
- current theory why it's not 0 is that `yarn install` is different for each workspace

I see two ways to improve further:
1. have a dynamic cache key and path for each workspace (quick win, not sure it's possible)
2. migrate the solution to use a monorepo tool (nx or turborepo) where there is only 1 package.json with all the dependencies

## Git Issues

Closes #3596