### PR TITLE
fix: display the active nav blob again

### DIFF
--- a/src/pages/common/Header/Menu/MenuDesktop.tsx
+++ b/src/pages/common/Header/Menu/MenuDesktop.tsx
@@ -17,7 +17,7 @@ const MenuLink = styled(NavLink)`
       opacity: 0.7;
     }
   }
-  &.current {
+  &.active {
     &:after {
       content: '';
       width: 70px;
@@ -38,30 +38,24 @@ const MenuLink = styled(NavLink)`
 `
 
 export const MenuDesktop = () => (
-  <>
-    <Flex sx={{ alignItems: 'center', width: '100%' }}>
-      {getAvailablePageList(getSupportedModules()).map((page) => {
-        const link = (
-          <Flex key={page.path}>
-            <MenuLink
-              to={page.path}
-              data-cy="page-link"
-              className={({ isActive }) => (isActive ? 'current' : '')}
-            >
-              <Flex>{page.title}</Flex>
-            </MenuLink>
-          </Flex>
-        )
-        return page.requiredRole ? (
-          <AuthWrapper roleRequired={page.requiredRole} key={page.path}>
-            {link}
-          </AuthWrapper>
-        ) : (
-          link
-        )
-      })}
-    </Flex>
-  </>
+  <Flex sx={{ alignItems: 'center', width: '100%' }}>
+    {getAvailablePageList(getSupportedModules()).map((page) => {
+      const link = (
+        <Flex key={page.path}>
+          <MenuLink to={page.path} data-cy="page-link">
+            <Flex>{page.title}</Flex>
+          </MenuLink>
+        </Flex>
+      )
+      return page.requiredRole ? (
+        <AuthWrapper roleRequired={page.requiredRole} key={page.path}>
+          {link}
+        </AuthWrapper>
+      ) : (
+        link
+      )
+    })}
+  </Flex>
 )
 
 export default MenuDesktop


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

Displays the "blob" for the active navigation.
![image](https://github.com/ONEARMY/community-platform/assets/8073622/5e7fd106-269f-4ff7-adcd-4e158e291a6b)

@davehakkens is not going crazy (yet!).
The cause was the router migration 6 months ago.
Solution found [here](https://stackoverflow.com/a/73508812)

## Git Issues

Closes #3605