### PR TITLE
test: exception for when firebase can't find doc

### DIFF
--- a/packages/cypress/src/support/rules.ts
+++ b/packages/cypress/src/support/rules.ts
@@ -4,6 +4,9 @@ Cypress.on('uncaught:exception', (err) => {
   if (err.message.includes('The query requires an index.')) {
     return false
   }
+  if (err.message.includes('No document to update')) {
+    return false
+  }
   // we still want to ensure there are no other unexpected
   // errors, so we let them fail the test
 })


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

We've started to get a cypress test failure during teardown for when firebase can't find a document (normally a user record) to 'update'. It's unrelated to the test suite so adding an expection.

## Git Issues

Closes #3572
