### PR TITLE
fix: chromatic as separate ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,9 +326,6 @@ jobs:
       - firebase_deploy:
           # token: $FIREBASE_DEPLOY_TOKEN # This should be set as environment variable
           alias: << parameters.DEPLOY_ALIAS >>
-      # run chromatic
-      - run:
-          command: npm run storybook:chromatic
 
   # Run cypress e2e tests on chrome
   test_e2e:
@@ -367,6 +364,15 @@ jobs:
             CI_GROUP: ci-<< parameters.CI_BROWSER >>
       - store_artifacts:
           path: ./packages/cypress/src/screenshots/
+  chromatic:
+    docker: *docker
+    resource_class: medium
+    steps:
+      - setup_repo
+      - attach_workspace:
+          at: '.'
+      - run:
+          command: yarn storybook:chromatic
   release:
     docker: *docker
     resource_class: medium+
@@ -441,6 +447,13 @@ workflows:
             parameters:
               CI_NODE: [1, 2, 3, 4]
               CI_BROWSER: ['chrome']
+      - chromatic:
+          name: 'Release storybook to chromatic'
+          requires:
+            - test_e2e
+          context:
+            - e2e-tests
+          <<: *filter_only_default_branch
       #---------------------- Development Instances Build and Deploy ----------------------
       - deploy:
           name: 'Deploy: dev.onearmy.world'


### PR DESCRIPTION
PR Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Description

Sorting out the CI chromatic step as it's currently blocking deployment. This adds chromatic as a proper seperate step in the ci pipeline after the e2e complete.
