### PR TITLE
fix: question form submitting not instantly set

### DIFF
--- a/src/pages/Question/Content/Common/QuestionForm.tsx
+++ b/src/pages/Question/Content/Common/QuestionForm.tsx
@@ -60,7 +60,7 @@ export const QuestionForm = (props: IProps) => {
       onSubmit={onSubmit}
       mutators={{ setAllowDraftSaveFalse }}
       initialValues={formValues}
-      render={({ submitting, handleSubmit, form, values }) => {
+      render={({ submitting, handleSubmit, pristine, valid, values }) => {
         const numberOfImageInputsAvailable = values?.images
           ? Math.min(values.images.length + 1, QUESTION_MAX_IMAGES)
           : 1
@@ -131,11 +131,8 @@ export const QuestionForm = (props: IProps) => {
                   mt={3}
                   variant="primary"
                   type="submit"
-                  disabled={submitting}
-                  onClick={(event) => {
-                    form.mutators.setAllowDraftSaveFalse()
-                    handleSubmit(event)
-                  }}
+                  disabled={submitting || pristine || !valid}
+                  onClick={handleSubmit}
                   sx={{
                     width: '100%',
                     mb: ['40px', '40px', 0],

--- a/src/stores/Question/question.store.tsx
+++ b/src/stores/Question/question.store.tsx
@@ -83,7 +83,7 @@ export class QuestionStore extends ModuleStore {
       .collection<IQuestion.Item>(COLLECTION_NAME)
       .doc(values?._id)
 
-    const isTitleAlreadyInUse = await !this.isTitleThatReusesSlug(
+    const isTitleAlreadyInUse = await this.isTitleThatReusesSlug(
       values.title,
       values?._id,
     )


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Description

Even after #3600 got merged in, it's happened again that a user has submitted duplicate questions (just this time changing the title to do it...). I did some more testing and it turns out that the submitting button isn't instantly disabled if you're on a low connection (I set to poor-3G for testing), thus maybe giving the user the view that the submission request has been handled. 

This change ensures the button is more quickly set.
