### PR TITLE
test: update jest max test time to 10 seconds

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from 'ts-jest'
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testTimeout: 10000,
 }
 
 export default config


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

We've started to get some flaky tests that time out at the jest default of 5000ms. Set a suite wide setting to x2 that (10000ms).
