### PR TITLE
refactor: cy change shouldExist to beVisible

### DIFF
--- a/packages/cypress/src/integration/SignUp.spec.ts
+++ b/packages/cypress/src/integration/SignUp.spec.ts
@@ -12,23 +12,23 @@ describe('[User sign-up]', () => {
       cy.step('Username is too short')
       cy.get('[data-cy=username]').clear().type('a')
       cy.get('[data-cy=consent]').uncheck().check()
-      cy.contains('Username must be at least 2 characters').should('be.exist')
+      cy.contains('Username must be at least 2 characters').should('be.visible')
 
       cy.step('Email is invalid')
       cy.get('[data-cy=email]').clear().type('a')
       cy.get('[data-cy=consent]').uncheck().check()
-      cy.contains(FRIENDLY_MESSAGES['auth/invalid-email']).should('be.exist')
+      cy.contains(FRIENDLY_MESSAGES['auth/invalid-email']).should('be.visible')
 
       cy.step('Password is too short')
       cy.get('[data-cy=password]').clear().type('a')
       cy.get('[data-cy=consent]').uncheck().check()
-      cy.contains('Password must be at least 6 characters').should('be.exist')
+      cy.contains('Password must be at least 6 characters').should('be.visible')
 
       cy.step('Password confirmation does not match')
       cy.get('[data-cy=password]').clear().type('a')
       cy.get('[data-cy=confirm-password]').clear().type('b')
       cy.get('[data-cy=consent]').uncheck().check()
-      cy.contains('Your new password does not match').should('be.exist')
+      cy.contains('Your new password does not match').should('be.visible')
 
       cy.step('Using valid inputs')
       cy.signUpNewUser()
@@ -46,7 +46,7 @@ describe('[User sign-up]', () => {
       cy.logout()
       cy.fillSignupForm(username, email, password)
       cy.contains(FRIENDLY_MESSAGES['sign-up/username-taken']).should(
-        'be.exist',
+        'be.visible',
       )
     })
 
@@ -60,7 +60,7 @@ describe('[User sign-up]', () => {
       cy.get('[data-cy=submit]').click()
       cy.get('[data-cy=error-msg]')
         .contains(FRIENDLY_MESSAGES['auth/email-already-in-use'])
-        .should('be.exist')
+        .should('be.visible')
     })
   })
 

--- a/packages/cypress/src/integration/common.spec.ts
+++ b/packages/cypress/src/integration/common.spec.ts
@@ -11,7 +11,7 @@ describe('[Common]', () => {
     cy.visit(unknownUrl)
     cy.get('[data-test="NotFound: Heading"]')
       .contains(`Nada, page not found 💩`)
-      .should('be.exist')
+      .should('be.visible')
     cy.get('a').contains('home page').should('have.attr', 'href').and('eq', '/')
   })
 

--- a/packages/cypress/src/integration/howto/read.spec.ts
+++ b/packages/cypress/src/integration/howto/read.spec.ts
@@ -38,10 +38,10 @@ describe('[How To]', () => {
 
     //   cy.step('How-to cards has basic info')
     //   cy.get(`[data-cy=card][data-cy-howto-slug=${howtoSlug}]`).within(() => {
-    //     cy.contains('Make glass-like beams').should('be.exist')
+    //     cy.contains('Make glass-like beams').should('be.visible')
     //     cy.get('img').should('have.attr', 'src').and('match', coverFileRegex)
-    //     cy.contains('howto_creator').should('be.exist')
-    //     cy.contains('product').should('be.exist')
+    //     cy.contains('howto_creator').should('be.visible')
+    //     cy.contains('product').should('be.visible')
     //     cy.get('a').should('have.attr', 'href').and('eq', howtoUrl)
     //   })
 
@@ -149,14 +149,14 @@ describe('[How To]', () => {
         })
 
         cy.step(`Comment functionality prompts user to login`)
-        cy.get(`[data-cy="comments-login-prompt"]`).should('be.exist')
+        cy.get(`[data-cy="comments-login-prompt"]`).should('be.visible')
 
         cy.step('Video embed exists')
         cy.get('[data-testid="VideoPlayer"]').within(() => {
           cy.get('iframe').should('have.attr', 'src').and('include', 'youtube')
         })
         // This fails in firefox due to cross security, simply check url
-        // .should(iframe => expect(iframe.contents().find('video')).to.exist)
+        // .should(iframe => expect(iframe.contents().find('video')).to.visible)
       })
 
       it('[Delete button should not be visible to everyone', () => {
@@ -212,7 +212,7 @@ describe('[How To]', () => {
       it('[Delete button is visible]', () => {
         cy.step('Delete button should be visible to the author of the how-to')
 
-        cy.get('[data-cy="How-To: delete button"]').should('exist')
+        cy.get('[data-cy="How-To: delete button"]').should('be.visible')
       })
 
       it('[Edit button is visible]', () => {
@@ -233,7 +233,7 @@ describe('[How To]', () => {
       it('[Delete button is visible]', () => {
         cy.step('Delete button should be visible to the author of the article')
 
-        cy.get('[data-cy="How-To: delete button"]').should('exist')
+        cy.get('[data-cy="How-To: delete button"]').should('be.visible')
       })
     })
   })

--- a/packages/cypress/src/integration/howto/search.spec.ts
+++ b/packages/cypress/src/integration/howto/search.spec.ts
@@ -50,7 +50,7 @@
 
 //       cy.go('back')
 
-//       cy.get('[data-cy=card]').should('exist')
+//       cy.get('[data-cy=card]').should('be.visible')
 //     })
 //   })
 // })

--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -202,7 +202,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=loader]').should('not.exist')
       cy.step('Access the create-how-to')
       cy.get('[data-cy=create]').click()
-      cy.contains('Create a How-To').should('exist')
+      cy.contains('Create a How-To').should('be.visible')
 
       cy.step('Warn if title is identical with the existing ones')
       cy.get('[data-cy=intro-title]')
@@ -210,7 +210,7 @@ describe('[How To]', () => {
         .blur({ force: true })
       cy.contains(
         "Did you know there is an existing how-to with the title 'Make glass-like beams'? Using a unique title helps readers decide which how-to better meet their needs.",
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Warn if title is identical with a previously existing one')
       cy.get('[data-cy=intro-title]')
@@ -219,19 +219,21 @@ describe('[How To]', () => {
         .blur({ force: true })
       cy.contains(
         "Did you know there is an existing how-to with the title 'Make glassy beams'? Using a unique title helps readers decide which how-to better meet their needs.",
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Warn if title has less than minimum required characters')
       cy.get('[data-cy=intro-title]').clear().type('qwer').blur({ force: true })
       cy.contains(
         `Should be more than ${HOWTO_TITLE_MIN_LENGTH} characters`,
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Cannot be published yet')
       cy.get('[data-cy=submit]').click()
       cy.get('[data-cy=errors-container]').should('be.visible')
-      cy.contains(headings.errors).should('exist')
-      cy.contains('Make sure this field is filled correctly').should('exist')
+      cy.contains(headings.errors).should('be.visible')
+      cy.contains('Make sure this field is filled correctly').should(
+        'be.visible',
+      )
 
       cy.step('A basic draft was created')
       cy.get('[data-cy=intro-title]')
@@ -243,7 +245,7 @@ describe('[How To]', () => {
         .click()
         .url()
         .should('include', `/how-to/qwerty`)
-      cy.get('[data-cy=moderationstatus-draft]').should('exist')
+      cy.get('[data-cy=moderationstatus-draft]').should('be.visible')
 
       cy.step('Back to completing the how-to')
       cy.get('[data-cy=edit]').click()
@@ -258,8 +260,8 @@ describe('[How To]', () => {
       cy.contains(categoryGuidanceMain).should('not.exist')
       cy.contains(categoryGuidanceFiles).should('not.exist')
       selectCategory(category as Category)
-      cy.contains(categoryGuidanceMain).should('exist')
-      cy.contains(categoryGuidanceFiles).should('exist')
+      cy.contains(categoryGuidanceMain).should('be.visible')
+      cy.contains(categoryGuidanceFiles).should('be.visible')
 
       selectTimeDuration(time as Duration)
       selectDifficultLevel(difficulty_level)
@@ -306,7 +308,7 @@ describe('[How To]', () => {
       cy.step('Howto was created correctly')
       cy.get('[data-cy=file-download-counter]')
         .contains(total_downloads)
-        .should('exist')
+        .should('be.visible')
       cy.queryDocuments('howtos', 'title', '==', title).then((docs) => {
         cy.log('queryDocs', docs)
         expect(docs.length).to.equal(1)
@@ -449,7 +451,7 @@ describe('[How To]', () => {
     it('[By Anonymous]', () => {
       cy.step('Prevent anonymous access to edit howto')
       cy.visit(editHowtoUrl)
-      cy.get('[data-cy=BlockedRoute]').should('be.exist')
+      cy.get('[data-cy=BlockedRoute]').should('be.visible')
     })
 
     it('[By Authenticated]', () => {
@@ -478,7 +480,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=intro-title]').clear().type('qwer').blur({ force: true })
       cy.contains(
         `Should be more than ${HOWTO_TITLE_MIN_LENGTH} characters`,
-      ).should('exist')
+      ).should('be.visible')
 
       cy.get('[data-cy=intro-title]')
         .clear()
@@ -486,7 +488,7 @@ describe('[How To]', () => {
         .blur({ force: true })
       cy.contains(
         "Did you know there is an existing how-to with the title 'Make glass-like beams'? Using a unique title helps readers decide which how-to better meet their needs.",
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Update the intro')
       cy.get('[data-cy=intro-title]').clear().type(expected.title)
@@ -549,7 +551,7 @@ describe('[How To]', () => {
       cy.get('[data-cy=how-to-basis]').contains('This is an edit test')
       cy.get('[data-cy=file-download-counter]')
         .contains(expected.total_downloads)
-        .should('exist')
+        .should('be.visible')
       cy.queryDocuments('howtos', 'title', '==', 'This is an edit test').then(
         (docs) => {
           cy.log('queryDocs', docs)

--- a/packages/cypress/src/integration/notifications.spec.ts
+++ b/packages/cypress/src/integration/notifications.spec.ts
@@ -130,6 +130,6 @@ describe('[Notifications]', () => {
         })
       },
     )
-    cy.get('[data-cy="NotificationList: empty state"]').should('exist')
+    cy.get('[data-cy="NotificationList: empty state"]').should('be.visible')
   })
 })

--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -39,7 +39,7 @@ describe('[Profile]', () => {
       cy.clickMenuItem(UserMenuItem.Profile)
       cy.url().should('include', `/u/${subscriber.userName}`)
       cy.get('[data-cy=spaceProfile]').should('not.exist')
-      cy.get('[data-cy=MemberProfile]').should('exist')
+      cy.get('[data-cy=MemberProfile]').should('be.visible')
       cy.get('.beta-tester-feature').should('not.exist')
     })
 
@@ -50,7 +50,7 @@ describe('[Profile]', () => {
       cy.get('[data-cy="Username"]').should('contain.text', admin.userName)
       cy.get('[data-cy=adminEdit]').should('not.exist')
       cy.visit(`/u/${admin.userName}/edit`)
-      cy.get('[data-cy=BlockedRoute]').should('exist')
+      cy.get('[data-cy=BlockedRoute]').should('be.visible')
     })
 
     it('[Can contact profiles by default]', () => {
@@ -66,7 +66,7 @@ describe('[Profile]', () => {
 
       cy.step('Go to contact tab')
       cy.get('[data-cy=contact-tab]').click()
-      cy.contains(`${contact.title} ${machine.userName}`).should('exist')
+      cy.contains(`${contact.title} ${machine.userName}`).should('be.visible')
 
       cy.step('fill in contact form')
       cy.get('[data-cy=name]').type('Bob')
@@ -75,7 +75,7 @@ describe('[Profile]', () => {
 
       cy.step('Submit form')
       cy.get('[data-cy=contact-submit]').click()
-      cy.contains(contact.successMessage).should('exist')
+      cy.contains(contact.successMessage).should('be.visible')
 
       cy.step("Can't contact pages who opt-out")
       cy.visit(`/u/${userProfiletype.userName}`)
@@ -90,7 +90,7 @@ describe('[Profile]', () => {
       cy.step('Can go to impact data')
       cy.visit(`/u/${userProfiletype.userName}`)
       cy.get('[data-cy=ImpactTab]').click()
-      cy.get('[data-cy=ImpactPanel]').should('exist')
+      cy.get('[data-cy=ImpactPanel]').should('be.visible')
       cy.contains(missing.user.label)
       cy.contains('2021')
       cy.contains('3 full time employees')
@@ -106,7 +106,7 @@ describe('[Profile]', () => {
       cy.clickMenuItem(UserMenuItem.Profile)
       cy.url().should('include', `/u/${userProfiletype.userName}`)
       cy.get('[data-cy=MemberProfile]').should('not.exist')
-      cy.get('[data-cy=SpaceProfile]').should('exist')
+      cy.get('[data-cy=SpaceProfile]').should('be.visible')
     })
   })
 })

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -31,7 +31,7 @@ describe('[Question]', () => {
       cy.get('[data-cy=field-title]').type(item.title).blur({ force: true })
       cy.contains(
         'Titles must be unique, please try being more specific',
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Add title field')
       cy.get('[data-cy=field-title]').type(initialTitle).blur({ force: true })

--- a/packages/cypress/src/integration/research/follow.spec.ts
+++ b/packages/cypress/src/integration/research/follow.spec.ts
@@ -19,7 +19,7 @@ describe('[Research]', () => {
       cy.login('demo_beta_tester@example.com', 'demo_beta_tester')
       cy.get('[data-cy="follow-redirect"]').should('not.exist')
       cy.get('[data-cy="follow-button"]')
-        .should('exist')
+        .should('be.visible')
         .should('contain.text', 'Follow')
 
       cy.step('Should follow on click')

--- a/packages/cypress/src/integration/research/read.spec.ts
+++ b/packages/cypress/src/integration/research/read.spec.ts
@@ -55,7 +55,7 @@ describe('[Research]', () => {
       it('[Delete button is visible]', () => {
         cy.step('Delete button should be visible to the author of the article')
 
-        cy.get('[data-cy="Research: delete button"]').should('exist')
+        cy.get('[data-cy="Research: delete button"]').should('be.visible')
       })
     })
 
@@ -75,7 +75,7 @@ describe('[Research]', () => {
       it('[Delete button is visible]', () => {
         cy.step('Delete button should be visible to the author of the article')
 
-        cy.get('[data-cy="Research: delete button"]').should('exist')
+        cy.get('[data-cy="Research: delete button"]').should('be.visible')
       })
     })
   })

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -36,7 +36,7 @@ describe('[Research]', () => {
       cy.get('[data-cy=intro-title]').type('qwerty').blur({ force: true })
       cy.contains(
         'Titles must be unique, please try being more specific',
-      ).should('exist')
+      ).should('be.visible')
 
       cy.step('Warn if title not long enough')
       cy.get('[data-cy=intro-title').clear().type('Q').blur({ force: true })
@@ -50,7 +50,9 @@ describe('[Research]', () => {
 
       cy.step('Cannot be published without description')
       cy.get('[data-cy=submit]').click()
-      cy.contains('Make sure this field is filled correctly').should('exist')
+      cy.contains('Make sure this field is filled correctly').should(
+        'be.visible',
+      )
       cy.get('[data-cy=errors-container]').should('be.visible')
 
       cy.step('Draft is saved without description')
@@ -59,7 +61,7 @@ describe('[Research]', () => {
       cy.get('[data-cy=view-research]:enabled', { timeout: 20000 })
         .click()
         .url()
-      cy.get('[data-cy=moderationstatus-draft]').should('exist')
+      cy.get('[data-cy=moderationstatus-draft]').should('be.visible')
       cy.get('[data-cy=edit]').click()
 
       cy.step('Limit description text to maximum length')
@@ -122,7 +124,7 @@ describe('[Research]', () => {
       cy.step('Can access create form')
       cy.visit('/research')
       cy.get('[data-cy=loader]').should('not.exist')
-      cy.get('[data-cy=create]').should('exist')
+      cy.get('[data-cy=create]').should('be.visible')
 
       cy.step('Enter research article details')
       cy.visit('/research/create')
@@ -140,8 +142,8 @@ describe('[Research]', () => {
         .url()
         .should('include', `/research/${expectSlug}`)
 
-      cy.contains(title).should('exist')
-      cy.contains(description).should('exist')
+      cy.contains(title).should('be.visible')
+      cy.contains(description).should('be.visible')
 
       cy.step('Can add update')
       cy.get('[data-cy=addResearchUpdateButton]').click()
@@ -168,8 +170,8 @@ describe('[Research]', () => {
         .click()
         .url()
 
-      cy.contains(updateTitle).should('exist')
-      cy.contains(updateDescription).should('exist')
+      cy.contains(updateTitle).should('be.visible')
+      cy.contains(updateDescription).should('be.visible')
     })
 
     it('[Warning on leaving page]', () => {
@@ -211,7 +213,7 @@ describe('[Research]', () => {
     it('[By Anonymous]', () => {
       cy.step('Prevent anonymous access to edit research article')
       cy.visit(editResearchUrl)
-      cy.get('[data-cy=BlockedRoute]').should('be.exist')
+      cy.get('[data-cy=BlockedRoute]').should('be.visible')
     })
 
     it('[By Authenticated]', () => {
@@ -241,7 +243,9 @@ describe('[Research]', () => {
 
       cy.step('Cannot be published when empty')
       cy.get('[data-cy=submit]').click()
-      cy.contains('Make sure this field is filled correctly').should('exist')
+      cy.contains('Make sure this field is filled correctly').should(
+        'be.visible',
+      )
       cy.get('[data-cy=errors-container]').should('be.visible')
 
       cy.step('Enter update details')
@@ -263,8 +267,8 @@ describe('[Research]', () => {
         .click()
         .url()
 
-      cy.contains(title).should('exist')
-      cy.contains(description).should('exist')
+      cy.contains(title).should('be.visible')
+      cy.contains(description).should('be.visible')
     })
   })
 })

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -235,7 +235,7 @@ describe('[Settings]', () => {
       localStorage.setItem('platformTheme', 'project-kamp')
       cy.clickMenuItem(UserMenuItem.Settings)
       selectFocus(expected.profileType)
-      cy.get('[data-cy=location-dropdown]').should('exist')
+      cy.get('[data-cy=location-dropdown]').should('be.visible')
 
       cy.get('[data-cy="add-a-map-pin"]').click()
 
@@ -262,7 +262,7 @@ describe('[Settings]', () => {
 
       cy.step('Remove a user pin')
       cy.get('[data-cy="remove-a-member-map-pin"]').click()
-      cy.get('[data-cy=location-dropdown]').should('exist')
+      cy.get('[data-cy=location-dropdown]').should('be.visible')
 
       cy.get('[data-cy=save]').click()
       cy.get('[data-cy=save]').should('not.be.disabled')

--- a/packages/cypress/src/integration/unsubscribe.spec.ts
+++ b/packages/cypress/src/integration/unsubscribe.spec.ts
@@ -9,7 +9,7 @@ context('unsubscribe', () => {
   })
 
   it('should render Unsubscribe page', () => {
-    cy.get('[data-cy=unsubscribe]').should('exist')
+    cy.get('[data-cy=unsubscribe]').should('be.visible')
   })
 
   it('should unsubscribe user', () => {

--- a/packages/cypress/src/support/commandsUi.ts
+++ b/packages/cypress/src/support/commandsUi.ts
@@ -70,7 +70,7 @@ Cypress.Commands.add('signUpNewUser', (user?) => {
 
 Cypress.Commands.add('toggleUserMenuOn', () => {
   Cypress.log({ displayName: 'OPEN_USER_MENU' })
-  cy.get('[data-cy=user-menu]').should('be.exist')
+  cy.get('[data-cy=user-menu]').should('be.visible')
   cy.get('[data-cy=user-menu]').click()
 })
 


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This MR is an improvement in some asserts as they used `.should('exist')` instead of `.should('be.visible')`. When you use `should('exist')` cypress checks if the element exists in DOM, then cypress will NOT check if the element is visible.
