### PR TITLE
fix: let chromatic pass with unapproved ui changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:madge": "npx madge --circular --extensions ts,tsx ./ --exclude src/stores",
     "storybook": "yarn workspace oa-components start",
     "__note_build-storybook": "build-storybook is needed for the CI",
-    "build-storybook": "yarn run storybook:build",
+    "build-storybook": "yarn run storybook:build --exit-zero-on-changes",
     "storybook:build": "yarn build:themes && yarn workspace oa-components build:sb",
     "storybook:chromatic": "yarn workspace oa-components chromatic",
     "docs": "yarn workspace oa-docs start",


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [x] Developer experience (improves developer workflows for contributing to the project)

## Description

We're currently getting a red mark on our master ci build because of chromatic. This let's chromatic exit zero when there are unapproved ui changes.