### PR TITLE
chore: make format match other discord webhooks

### DIFF
--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -69,9 +69,7 @@ export const notifyAcceptedQuestion = functions
 
     try {
       const response = await axios.post(DISCORD_WEBHOOK_URL, {
-        json: {
-          text: `❓ ${username} has a new question: ${title}\n Help them out and answer here: ${SITE_URL}/questions/${slug}`,
-        },
+        content: `❓ ${username} has a new question: ${title}\nHelp them out and answer here: <${SITE_URL}/questions/${slug}>`,
       })
       handleResponse(response)
     } catch (error) {


### PR DESCRIPTION
PR Type
- bug fix (probably)

## Description
Well, I realized I originally copied the format of the slack webhook, which is different than the discord one. I didn't test it with an actual Discord channel though. (lol)