### PR TITLE
chore: change circle storybook command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
       - attach_workspace:
           at: '.'
       - run:
-          command: yarn storybook:chromatic
+          command: yarn build-storybook
   release:
     docker: *docker
     resource_class: medium+


### PR DESCRIPTION
Current error on CircleCI for storybook:
```
Usage Error: Couldn't find a script named "storybook:chromatic".

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...

Exited with code exit status 1
```
Had changed command in #3689 but not the ci script.