### PR TITLE
Chore/further emulator cleanup 1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build:
       context: ./
       dockerfile: ./functions/emulator/Dockerfile
+    depends_on:
+      simulated-webhook-receiver:
+        condition: service_healthy
     ports:
     - 4001-4008:4001-4008
     volumes:

--- a/packages/simulated-webhook-receiver/Dockerfile
+++ b/packages/simulated-webhook-receiver/Dockerfile
@@ -17,9 +17,12 @@ WORKDIR /app
 
 RUN \
   apt-get update && \
+  apt-get -y install curl && \
   # For debugging
   apt-get -y install nano && \
   apt-get clean
+
+HEALTHCHECK CMD curl --fail http://localhost:30102/health || exit 1
 
 COPY ./package.json ./package.json
 RUN yarn install


### PR DESCRIPTION
PR Type
- dev chore

## Description
Wait for the simulated-webhook-reciever container to be running before we start the backend.

Not really needed, but feels like good practice for where I want to take things.