### PR TITLE
chore: disable url preview

### DIFF
--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -95,7 +95,7 @@ export const notifyResearchUpdatePublished = functions
       const response = await axios.post(DISCORD_WEBHOOK_URL, {
         content:
           `📝 New update from ${author} in their research: ${title}\n` +
-          `Learn about it here: ${SITE_URL}/research/${slug}`,
+          `Learn about it here: <${SITE_URL}/research/${slug}>`,
       })
       handleResponse(response)
     } catch (error) {


### PR DESCRIPTION
PR Type
bug fix, kinda

## Description
Dave said to wrap the url in <> to avoid previews, which I originally didn't do.

Here is how it is currently: https://discord.com/channels/586676777334865928/599259846767935519/1255595823690158141

see the "Things to keep in mind" section, in this ticket: https://github.com/ONEARMY/community-platform/issues/3533