### PR TITLE
chore: remove build-context for test, which is only possible for memb…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,7 +424,6 @@ workflows:
           name: 'Cloud Function tests'
           requires:
             - 'Lint code'
-          context: build-context
       - test_functions_upload_coverage:
           name: 'Upload Cloud Function coverage'
           requires:


### PR DESCRIPTION
PR Type
- chore

## Description
remove build-context, as you have to be a github/circleci member to execute it, and it only has the `REACT_APP_SUPPORTED_MODULES` variable set. https://app.circleci.com/settings/organization/github/ONEARMY/contexts/811c9776-f0ae-4980-b971-9a060afb76ec?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2FONEARMY%2Fcommunity-platform%2F9658%2Fworkflows%2Ffb548842-8083-4561-8550-ebfd7b093730

how to test: if ci passes, merge, remove me from GitHub thingy, I push test branch, and test.