### PR TITLE
feat(platform): remove beta wrapper for 'pay as you can' feature

### DIFF
--- a/packages/cypress/src/integration/howto/read.spec.ts
+++ b/packages/cypress/src/integration/howto/read.spec.ts
@@ -158,27 +158,9 @@ describe('[How To]', () => {
         cy.signUpNewUser()
         cy.visit(specificHowtoUrl)
 
-        cy.step('Attachments are opened in new tabs')
-        cy.get(`a[href*="art%20final%201.skp"]`).should(
-          'have.attr',
-          'target',
-          '_blank',
-        )
-        cy.get(`a[href*="art%20final%202.skp"]`).should(
-          'have.attr',
-          'target',
-          '_blank',
-        )
-      })
-    })
-
-    describe('[By beta-tester]', () => {
-      it('[Presents the donation request before opening of attachments]', () => {
-        cy.login('demo_beta_tester@example.com', 'demo_beta_tester')
-        cy.visit('how-to/set-up-devsite-to-help-coding')
-
+        cy.step('[Presents the donation request before opening of attachments]')
         cy.step('Shows modal')
-        cy.get('[data-cy=downloadButton]').click()
+        cy.get('[data-cy=downloadButton]').first().click()
         cy.get('[data-cy=DonationRequest]').should('be.visible')
         cy.get('[data-cy=DonationRequest]').contains('Support our work')
 

--- a/src/common/DownloadWithDonationAsk.test.tsx
+++ b/src/common/DownloadWithDonationAsk.test.tsx
@@ -57,8 +57,8 @@ describe('DownloadFileFromLink', () => {
     expect(mockedUsedNavigate).toHaveBeenCalledWith('/sign-in')
   })
 
-  it('when a beta-tester (or any other role), opens the donation modal for fileLink', () => {
-    const user = FactoryUser({ userRoles: [UserRole.BETA_TESTER] })
+  it('when logged in, opens the donation modal for fileLink', () => {
+    const user = FactoryUser()
     userToMock(user)
 
     const handleClick = vi.fn()
@@ -82,10 +82,10 @@ describe('DownloadFileFromLink', () => {
       fileLink,
     )
     expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
-    // expect(handleClick).not.toHaveBeenCalled()
+    expect(handleClick).not.toHaveBeenCalled()
   })
 
-  it('when a beta-tester (or any other role), opens the donation modal for files', () => {
+  it('when logged in, opens the donation modal for files', () => {
     const user = FactoryUser({ userRoles: [UserRole.BETA_TESTER] })
     userToMock(user)
 
@@ -116,66 +116,6 @@ describe('DownloadFileFromLink', () => {
       downloadUrl,
     )
     expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
-    // expect(handleClick).not.toHaveBeenCalled()
-  })
-
-  it('when a research editor (or any other role), opens the donation modal for fileLink', () => {
-    const user = FactoryUser({ userRoles: [UserRole.RESEARCH_EDITOR] })
-    userToMock(user)
-
-    const handleClick = vi.fn()
-    const fileLink = 'http://youtube.com/'
-
-    const { getAllByTestId } = render(
-      <DownloadWithDonationAsk
-        handleClick={handleClick}
-        isLoggedIn={true}
-        fileDownloadCount={0}
-        fileLink={fileLink}
-        files={[]}
-      />,
-    )
-
-    const downloadButton = getAllByTestId('downloadButton')[0]
-    fireEvent.click(downloadButton)
-
-    expect(getAllByTestId('DonationRequestSkip')[0]).toHaveAttribute(
-      'href',
-      fileLink,
-    )
-    expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
-  })
-
-  it('when a subscriber (or any other role), opens the donation modal for files', () => {
-    const user = FactoryUser({ userRoles: [UserRole.SUBSCRIBER] })
-    userToMock(user)
-
-    const downloadUrl = 'http://great-url.com/'
-    const handleClick = vi.fn()
-
-    const { getAllByTestId } = render(
-      <DownloadWithDonationAsk
-        handleClick={handleClick}
-        isLoggedIn={true}
-        fileDownloadCount={0}
-        fileLink={undefined}
-        files={[
-          {
-            downloadUrl,
-            name: 'first-file',
-            size: 435435,
-          } as IUploadedFileMeta,
-        ]}
-      />,
-    )
-
-    const downloadButton = getAllByTestId('downloadButton')[0]
-    fireEvent.click(downloadButton)
-
-    expect(getAllByTestId('DonationRequestSkip')[0]).toHaveAttribute(
-      'href',
-      downloadUrl,
-    )
-    expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
+    expect(handleClick).not.toHaveBeenCalled()
   })
 })

--- a/src/common/DownloadWithDonationAsk.test.tsx
+++ b/src/common/DownloadWithDonationAsk.test.tsx
@@ -57,28 +57,7 @@ describe('DownloadFileFromLink', () => {
     expect(mockedUsedNavigate).toHaveBeenCalledWith('/sign-in')
   })
 
-  it('when logged in, opens via handleClick', () => {
-    const user = FactoryUser()
-    userToMock(user)
-
-    const handleClick = vi.fn()
-    const { getAllByTestId } = render(
-      <DownloadWithDonationAsk
-        handleClick={handleClick}
-        isLoggedIn={true}
-        fileDownloadCount={0}
-        fileLink="http://youtube.com/"
-        files={[]}
-      />,
-    )
-
-    const downloadButton = getAllByTestId('downloadButton')[0]
-    fireEvent.click(downloadButton)
-
-    expect(handleClick).toHaveBeenCalled()
-  })
-
-  it('when a beta-tester, opens the donation modal for fileLink', () => {
+  it('when a beta-tester (or any other role), opens the donation modal for fileLink', () => {
     const user = FactoryUser({ userRoles: [UserRole.BETA_TESTER] })
     userToMock(user)
 
@@ -103,10 +82,10 @@ describe('DownloadFileFromLink', () => {
       fileLink,
     )
     expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
-    expect(handleClick).not.toHaveBeenCalled()
+    // expect(handleClick).not.toHaveBeenCalled()
   })
 
-  it('when a beta-tester, opens the donation modal for files', () => {
+  it('when a beta-tester (or any other role), opens the donation modal for files', () => {
     const user = FactoryUser({ userRoles: [UserRole.BETA_TESTER] })
     userToMock(user)
 
@@ -137,6 +116,66 @@ describe('DownloadFileFromLink', () => {
       downloadUrl,
     )
     expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
-    expect(handleClick).not.toHaveBeenCalled()
+    // expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('when a research editor (or any other role), opens the donation modal for fileLink', () => {
+    const user = FactoryUser({ userRoles: [UserRole.RESEARCH_EDITOR] })
+    userToMock(user)
+
+    const handleClick = vi.fn()
+    const fileLink = 'http://youtube.com/'
+
+    const { getAllByTestId } = render(
+      <DownloadWithDonationAsk
+        handleClick={handleClick}
+        isLoggedIn={true}
+        fileDownloadCount={0}
+        fileLink={fileLink}
+        files={[]}
+      />,
+    )
+
+    const downloadButton = getAllByTestId('downloadButton')[0]
+    fireEvent.click(downloadButton)
+
+    expect(getAllByTestId('DonationRequestSkip')[0]).toHaveAttribute(
+      'href',
+      fileLink,
+    )
+    expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
+  })
+
+  it('when a subscriber (or any other role), opens the donation modal for files', () => {
+    const user = FactoryUser({ userRoles: [UserRole.SUBSCRIBER] })
+    userToMock(user)
+
+    const downloadUrl = 'http://great-url.com/'
+    const handleClick = vi.fn()
+
+    const { getAllByTestId } = render(
+      <DownloadWithDonationAsk
+        handleClick={handleClick}
+        isLoggedIn={true}
+        fileDownloadCount={0}
+        fileLink={undefined}
+        files={[
+          {
+            downloadUrl,
+            name: 'first-file',
+            size: 435435,
+          } as IUploadedFileMeta,
+        ]}
+      />,
+    )
+
+    const downloadButton = getAllByTestId('downloadButton')[0]
+    fireEvent.click(downloadButton)
+
+    expect(getAllByTestId('DonationRequestSkip')[0]).toHaveAttribute(
+      'href',
+      downloadUrl,
+    )
+    expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
   })
 })

--- a/src/common/DownloadWithDonationAsk.tsx
+++ b/src/common/DownloadWithDonationAsk.tsx
@@ -4,14 +4,12 @@ import {
   DonationRequestModal,
   DownloadButton,
   DownloadCounter,
-  DownloadFileFromLink,
   DownloadStaticFile,
 } from 'oa-components'
 
 import { useCommonStores } from './hooks/useCommonStores'
 import { AuthWrapper } from './AuthWrapper'
 
-import type { UserRole } from 'src/models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 
 export interface IProps {
@@ -28,7 +26,7 @@ export interface IProps {
   can/should move to the component library.
 */
 export const DownloadWithDonationAsk = (props: IProps) => {
-  const { handleClick, isLoggedIn, fileDownloadCount, fileLink, files } = props
+  const { handleClick, fileDownloadCount, fileLink, files } = props
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
   const [link, setLink] = useState<string>('')
   const navigate = useNavigate()
@@ -58,31 +56,11 @@ export const DownloadWithDonationAsk = (props: IProps) => {
       />
 
       <AuthWrapper
-        roleRequired={'beta-tester' as UserRole}
         fallback={
-          <>
-            {!isLoggedIn && (
-              <DownloadButton
-                onClick={async () => navigate('/sign-in')}
-                isLoggedIn={false}
-              />
-            )}
-
-            {isLoggedIn && fileLink && (
-              <DownloadFileFromLink handleClick={handleClick} link={fileLink} />
-            )}
-            {isLoggedIn &&
-              filteredFiles &&
-              filteredFiles.map((file, index) => (
-                <DownloadStaticFile
-                  allowDownload
-                  file={file}
-                  key={file ? file.name : `file-${index}`}
-                  handleClick={handleClick}
-                  isLoggedIn
-                />
-              ))}
-          </>
+          <DownloadButton
+            onClick={async () => navigate('/sign-in')}
+            isLoggedIn={false}
+          />
         }
       >
         <>

--- a/src/common/DownloadWithDonationAsk.tsx
+++ b/src/common/DownloadWithDonationAsk.tsx
@@ -8,7 +8,6 @@ import {
 } from 'oa-components'
 
 import { useCommonStores } from './hooks/useCommonStores'
-import { AuthWrapper } from './AuthWrapper'
 
 import type { IUploadedFileMeta } from 'src/stores/storage'
 
@@ -26,7 +25,7 @@ export interface IProps {
   can/should move to the component library.
 */
 export const DownloadWithDonationAsk = (props: IProps) => {
-  const { handleClick, fileDownloadCount, fileLink, files } = props
+  const { handleClick, fileDownloadCount, fileLink, files, isLoggedIn } = props
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
   const [link, setLink] = useState<string>('')
   const navigate = useNavigate()
@@ -55,14 +54,13 @@ export const DownloadWithDonationAsk = (props: IProps) => {
         onDidDismiss={() => toggleIsModalOpen()}
       />
 
-      <AuthWrapper
-        fallback={
-          <DownloadButton
-            onClick={async () => navigate('/sign-in')}
-            isLoggedIn={false}
-          />
-        }
-      >
+      {!isLoggedIn && (
+        <DownloadButton
+          onClick={async () => navigate('/sign-in')}
+          isLoggedIn={false}
+        />
+      )}
+      {isLoggedIn && (
         <>
           {fileLink && (
             <DownloadButton
@@ -87,7 +85,7 @@ export const DownloadWithDonationAsk = (props: IProps) => {
               />
             ))}
         </>
-      </AuthWrapper>
+      )}
       <DownloadCounter total={fileDownloadCount} />
     </>
   )


### PR DESCRIPTION
PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

This PR displays to any logged-in users, not only beta testers anymore, the "pay as you can" modal whenever they click a download button.

## Git Issues

Closes #3726

## Screenshots/Videos

![image](https://github.com/ONEARMY/community-platform/assets/89898967/a64612cf-d8bd-4c8c-a6f1-e2d619ead2de)

---

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
