### PR TITLE
[e2e] Fix to Write HowTo flaky

### DIFF
--- a/packages/cypress/src/integration/howto/write.spec.ts
+++ b/packages/cypress/src/integration/howto/write.spec.ts
@@ -290,6 +290,15 @@ describe('[How To]', () => {
 
       cy.step('Add extra step')
       cy.get('[data-cy=add-step]').click()
+      /*
+        Sometimes clicking on add-step trigger the Uploading How To modal
+        when it happens cypress will close it with the code below
+      */
+      cy.get('body').then(($body) => {
+        if ($body.text().includes('Uploading How To')) {
+          cy.get('[data-cy=close-upload-status]').click()
+        }
+      })
 
       deleteStep(4)
       cy.screenClick()

--- a/src/pages/Howto/Content/Common/SubmitStatus.tsx
+++ b/src/pages/Howto/Content/Common/SubmitStatus.tsx
@@ -22,7 +22,11 @@ const HowToSubmitStatus = observer((props: IProps) => {
         <Heading as="p" variant="small" sx={{ textAlign: 'center' }}>
           {headings.uploading}
         </Heading>
-        <Icon glyph="close" onClick={() => props.onClose()} />
+        <Icon
+          data-cy="close-upload-status"
+          glyph="close"
+          onClick={() => props.onClose()}
+        />
       </Flex>
       <Box margin="15px 0" p={0}>
         {Object.keys(uploadStatus).map((key) => (


### PR DESCRIPTION
PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

PR Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Developer experience (improves developer workflows for contributing to the project)

## Description

- Add `data-cy` to close icon on Uploading How to modal
- Add condition on the e2e test file in case the Uploading How to modal is being displayed to close it

## Observation

The submit modal is sometimes displayed when the user clicks the add step this is causing the flaky test. As you can see in [this execution](https://cloud.cypress.io/projects/4s5zgo/runs/5959/test-results/f4388e91-8408-4267-ae54-fb5c9c98d73a/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&testingTypesEnum=%5B%5D&ts=1720510477618.5017) (you can skip until the end of the video to see the status uploading how to)