### PR TITLE
Fix/research thumbnails

### DIFF
--- a/src/pages/Research/Content/EditUpdate/index.tsx
+++ b/src/pages/Research/Content/EditUpdate/index.tsx
@@ -110,7 +110,7 @@ const EditUpdate = observer((props: IProps) => {
   return (
     <ResearchUpdateForm
       formValues={state.formValues}
-      redirectUrl={'/research/' + store.activeResearchItem?.slug + '/edit'}
+      redirectUrl={'/research/' + store.activeResearchItem?.slug}
       parentType="edit"
     />
   )

--- a/src/pages/Research/Content/EditUpdate/index.tsx
+++ b/src/pages/Research/Content/EditUpdate/index.tsx
@@ -110,7 +110,7 @@ const EditUpdate = observer((props: IProps) => {
   return (
     <ResearchUpdateForm
       formValues={state.formValues}
-      redirectUrl={'/research/' + store.activeResearchItem!.slug + '/edit'}
+      redirectUrl={'/research/' + store.activeResearchItem?.slug + '/edit'}
       parentType="edit"
     />
   )

--- a/src/pages/Research/Content/ResearchListItem.tsx
+++ b/src/pages/Research/Content/ResearchListItem.tsx
@@ -18,7 +18,7 @@ import { formatDate } from 'src/utils/date'
 import { Box, Card, Flex, Grid, Heading, Image, Text } from 'theme-ui'
 
 import defaultResearchThumbnail from '../../../assets/images/default-research-thumbnail.jpg'
-import { getPublicUpdates, researchStatusColour } from '../researchHelpers'
+import { researchStatusColour } from '../researchHelpers'
 
 import type { IResearch } from 'src/models/research.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
@@ -284,15 +284,21 @@ const ResearchListItem = ({ item }: IProps) => {
 }
 
 const getItemThumbnail = (researchItem: IResearch.Item): string => {
-  if (researchItem.updates?.length) {
-    const latestImage = getPublicUpdates(researchItem)
-      ?.map((u) => (u.images?.[0] as IUploadedFileMeta)?.downloadUrl)
-      .filter((url: string) => !!url)
-      .pop()
-    return latestImage ?? defaultResearchThumbnail
-  } else {
-    return defaultResearchThumbnail
-  }
+  const publishedUpdates = researchItem.updates?.filter(
+    (update) =>
+      !update._deleted &&
+      update.status === ResearchUpdateStatus.PUBLISHED &&
+      update.images.length > 0,
+  )
+
+  const latestPublishedUpdate = publishedUpdates?.sort(
+    (a, b) => new Date(b._created).getTime() - new Date(a._created).getTime(),
+  )?.[0]
+
+  return (
+    (latestPublishedUpdate?.images[0] as IUploadedFileMeta)?.downloadUrl ||
+    defaultResearchThumbnail
+  )
 }
 
 const getItemDate = (item: IResearch.Item, variant: string): string => {

--- a/src/stores/common/module.store.ts
+++ b/src/stores/common/module.store.ts
@@ -199,12 +199,12 @@ export class ModuleStore {
       file.type,
     )
   }
-  public async uploadCollectionBatch(
+  public uploadCollectionBatch(
     files: (File | IConvertedFileMeta)[],
     collection: string,
     id: string,
   ) {
-    const promises = files.map(async (file) => {
+    const promises = files.map((file) => {
       return this.uploadFileToCollection(file, collection, id)
     })
     return Promise.all(promises)


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
Users reported some weird/inconsistent behavior on displaying the research image thumbnail

## What is the new behavior?
This might fix the issue but I wasn't able to replicate it.
Why it might fix? No longer using `getPublicUpdates` which had complex logic and unnecessary for choosing thumbnails.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #