### PR TITLE
fix: always getting server version of document

### DIFF
--- a/src/stores/Discussions/discussionEvents.ts
+++ b/src/stores/Discussions/discussionEvents.ts
@@ -48,7 +48,7 @@ export const updateDiscussionMetadata = async (
     case 'research':
       const researchRef = db.collection(collectionName).doc(primaryContentId)
 
-      const research = toJS(await researchRef.get()) as IResearch.Item
+      const research = toJS(await researchRef.get('server')) as IResearch.Item
 
       if (research) {
         // This approach is open to error but is better than making lots of DBs

--- a/src/stores/Howto/howto.store.tsx
+++ b/src/stores/Howto/howto.store.tsx
@@ -248,7 +248,7 @@ export class HowtoStore extends ModuleStore {
       }
     })
 
-    const $doc = await dbRef.get()
+    const $doc = await dbRef.get('server')
     return $doc ? $doc : null
   }
 
@@ -285,7 +285,7 @@ export class HowtoStore extends ModuleStore {
       .doc((values as IHowtoDB)._id)
     const id = dbRef.id
 
-    const existingDoc = await dbRef.get()
+    const existingDoc = await dbRef.get('server')
     logger.debug('uploadHowto.existingDoc', { existingDoc })
 
     const user = this.activeUser as IUser

--- a/src/stores/Question/question.store.tsx
+++ b/src/stores/Question/question.store.tsx
@@ -123,7 +123,7 @@ export class QuestionStore extends ModuleStore {
 
     logger.info(`upsertQuestion.set`, { dbRef })
 
-    return dbRef.get() || null
+    return dbRef.get('server') || null
   }
 
   public async toggleSubscriberStatusByUserName() {

--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -229,7 +229,7 @@ export class ResearchStore extends ModuleStore {
       .collection<IResearch.Item>(COLLECTION_NAME)
       .doc(values._id)
     const user = this.activeUser as IUser
-    const updates = (await dbRef.get())?.updates || [] // save old updates when editing
+    const updates = (await dbRef.get('server'))?.updates || [] // save old updates when editing
     const collaborators = await this._setCollaborators(values.collaborators)
 
     try {
@@ -365,7 +365,7 @@ export class ResearchStore extends ModuleStore {
         await this._updateResearchItem(dbRef, newItem, true)
         logger.debug('populate db ok')
         this.updateUpdateUploadStatus('Database')
-        const createdItem = (await dbRef.get()) as IResearch.ItemDB
+        const createdItem = (await dbRef.get('server')) as IResearch.ItemDB
         runInAction(() => {
           this.activeResearchItem = createdItem
         })
@@ -710,7 +710,7 @@ export class ResearchStore extends ModuleStore {
       )
     }
 
-    return await dbRef.get()
+    return await dbRef.get('server')
   }
 
   private async _getResearchItemBySlug(

--- a/src/stores/Research/researchEvents.ts
+++ b/src/stores/Research/researchEvents.ts
@@ -8,7 +8,7 @@ export const setCollaboratorPermission = async (
   userId: string,
 ) => {
   const userRef = db.collection<IUserDB>('users').doc(userId)
-  const user = toJS(await userRef.get())
+  const user = toJS(await userRef.get('server'))
   const role = 'research_creator' as UserRole.RESEARCH_CREATOR
 
   if (!user) return

--- a/src/stores/common/toggleDocSubscriberStatusByUserName.ts
+++ b/src/stores/common/toggleDocSubscriberStatusByUserName.ts
@@ -25,5 +25,5 @@ export const toggleDocSubscriberStatusByUserName = async (
 
   await dbRef.update(subscribersUpdated as any)
 
-  return await dbRef.get()
+  return await dbRef.get('server')
 }

--- a/src/stores/databaseV2/DocReference.ts
+++ b/src/stores/databaseV2/DocReference.ts
@@ -97,7 +97,7 @@ export class DocReference<T> {
    */
   async delete() {
     const { serverDB, serverCacheDB } = this.clients
-    const doc = (await this.get()) as any
+    const doc = (await this.get('server')) as any
     await serverDB.setDoc(`_archived/${this.endpoint}/summary`, {
       _archived: new Date().toISOString(),
       _id: this.id,


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the current behavior?

We had a recent issue with discussion document updates being lost because the store wasn't using the saved version to perform the update on.

## What is the new behavior?

This picks off the remaining uses on the app of getting a document from the cache rather than the server. So now`doc.get('server')` is always used.


## Does this PR introduce a breaking change?

- [x] No

## Git Issues

