### PR TITLE
fix: research show discussion comment count

### DIFF
--- a/src/common/DiscussionWrapper.tsx
+++ b/src/common/DiscussionWrapper.tsx
@@ -164,7 +164,7 @@ export const DiscussionWrapper = (props: IProps) => {
       {!isLoading && !discussion && <Text>{DISCUSSION_NOT_FOUND}</Text>}
       {discussion && canHideComments && (
         <HideDiscussionContainer
-          commentCount={discussion.comments.length}
+          commentCount={nonDeletedCommentsCount(discussion.comments)}
           showComments={showComments}
         >
           <AuthWrapper


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

Wrong comment count shown on button to show/hide discussion.

<img width="939" alt="Screenshot 2024-07-17 at 12 09 08" src="https://github.com/user-attachments/assets/609287e3-06a0-4b37-b0dc-0dd108a5d57e">
<img width="975" alt="Screenshot 2024-07-17 at 12 08 59" src="https://github.com/user-attachments/assets/c5dac61e-bea5-4b4a-b926-b9377e544c82">

## What is the new behavior?

The button now uses the util to check for deleted comments.
