### PR TITLE
Feat: add edit profile button to profile

### DIFF
--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -8,16 +8,16 @@ import { Avatar, Box, Card, Flex, Heading, Paragraph } from 'theme-ui'
 import UserContactAndLinks from './UserContactAndLinks'
 import UserCreatedDocuments from './UserCreatedDocuments'
 
-import type { IUserPP } from 'src/models/userPreciousPlastic.models'
+import type { IUserPPDB } from 'src/models/userPreciousPlastic.models'
 import type { IUploadedFileMeta } from 'src/stores/storage'
 import type { UserCreatedDocs } from '../types'
 
 interface IProps {
-  user: IUserPP
   docs: UserCreatedDocs | undefined
+  user: IUserPPDB
 }
 
-export const MemberProfile = ({ user, docs }: IProps) => {
+export const MemberProfile = ({ docs, user }: IProps) => {
   const userLinks = (user?.links || []).filter(
     (linkItem) =>
       ![ExternalLinkLabel.DISCORD, ExternalLinkLabel.FORUM].includes(
@@ -34,12 +34,10 @@ export const MemberProfile = ({ user, docs }: IProps) => {
     <Card
       data-cy="MemberProfile"
       sx={{
+        display: 'flex',
+        flexDirection: 'column',
         position: 'relative',
         overflow: 'visible',
-        maxWidth: '42em',
-        width: '100%',
-        margin: '0 auto',
-        marginTop: [6, 8],
         padding: 2,
       }}
     >

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -172,18 +172,8 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
   )
 
   return (
-    <Container
-      mt={4}
-      mb={6}
-      sx={{
-        border: '2px solid black',
-        borderRadius: '10px',
-        overflow: 'hidden',
-        maxWidth: '1000px',
-      }}
-      data-cy="SpaceProfile"
-    >
-      <Box sx={{ lineHeight: 0 }}>
+    <Card data-cy="SpaceProfile">
+      <Box>
         {coverImage.length ? (
           <ImageGallery
             images={formatImagesForGallery(coverImage) as any}
@@ -208,9 +198,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
       </Box>
       <Flex
         sx={{
-          px: [2, 4],
-          py: 4,
-          background: 'white',
+          padding: [2, 4],
           borderTop: '2px solid',
         }}
       >

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -24,7 +24,7 @@ import { getUserCountry } from 'src/utils/getUserCountry'
 import {
   AspectRatio,
   Box,
-  Container,
+  Card,
   Flex,
   Heading,
   Image,
@@ -49,22 +49,6 @@ interface IProps {
   user: IUserPP
   docs: UserCreatedDocs | undefined
 }
-
-const MobileBadge = ({ children }) => (
-  <Flex
-    sx={{
-      alignItems: ['left', 'left', 'center'],
-      flexDirection: 'column',
-      marginBottom: 0,
-      marginLeft: [0, 0, 'auto'],
-      marginRight: [0, 0, 'auto'],
-      marginTop: [0, 0, '-50%'],
-      position: 'relative',
-    }}
-  >
-    {children}
-  </Flex>
-)
 
 const renderPlasticTypes = (plasticTypes: Array<PlasticTypeLabel>) => {
   const renderIcon = (type: string) => {
@@ -203,29 +187,27 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
         }}
       >
         <Box sx={{ width: '100%' }}>
-          <Box sx={{ display: ['block', 'block', 'none'] }}>
-            <MobileBadge>
-              <MemberBadge profileType={profileType} />
-            </MobileBadge>
-          </Box>
-
-          <Box
-            sx={{
-              position: 'relative',
-              pt: ['0', '40px', '0'],
-            }}
-          >
+          <Box sx={{ position: 'relative' }}>
             <Box
               sx={{
-                display: ['none', 'none', 'block'],
+                display: 'block',
                 position: 'absolute',
                 top: 0,
                 right: 0,
-                transform: 'translateY(-100px)',
+                transform: 'translateY(-50%)',
               }}
             >
-              <MemberBadge size={150} profileType={profileType} />
+              <Box sx={{ display: ['none', 'none', 'block'] }}>
+                <MemberBadge size={150} profileType={profileType} />
+              </Box>
+              <Box sx={{ display: ['none', 'block', 'none'] }}>
+                <MemberBadge size={100} profileType={profileType} />
+              </Box>
+              <Box sx={{ display: ['block', 'none', 'none'] }}>
+                <MemberBadge size={75} profileType={profileType} />
+              </Box>
             </Box>
+
             <Box>
               <Username
                 user={{
@@ -317,6 +299,6 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
           </Tabs>
         </Box>
       </Flex>
-    </Container>
+    </Card>
   )
 }

--- a/src/pages/User/content/UserProfile.tsx
+++ b/src/pages/User/content/UserProfile.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { observer } from 'mobx-react-lite'
-import { Loader } from 'oa-components'
+import { Button, InternalLink, Loader } from 'oa-components'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { ProfileType } from 'src/modules/profile/types'
 import { seoTagsUpdate } from 'src/utils/seo'
-import { Text } from 'theme-ui'
+import { Flex, Text } from 'theme-ui'
 
 import { logger } from '../../../logger'
 import { MemberProfile } from './MemberProfile'
 import { SpaceProfile } from './SpaceProfile'
 
-import type { IUserPP } from 'src/models'
+import type { IUserPPDB } from 'src/models'
 import type { UserCreatedDocs } from '../types'
 
 /**
@@ -21,7 +21,7 @@ import type { UserCreatedDocs } from '../types'
 export const UserProfile = observer(() => {
   const { id } = useParams()
   const { userStore } = useCommonStores().stores
-  const [user, setUser] = useState<IUserPP | undefined>()
+  const [user, setUser] = useState<IUserPPDB | undefined>()
   const [userCreatedDocs, setUserCreatedDocs] = useState<
     UserCreatedDocs | undefined
   >()
@@ -34,7 +34,7 @@ export const UserProfile = observer(() => {
       const fetchUserData = async () => {
         try {
           const userData = await userStore.getUserProfile(userId)
-          if (userData as IUserPP) {
+          if (userData as IUserPPDB) {
             setUser(userData)
 
             seoTagsUpdate({
@@ -79,10 +79,37 @@ export const UserProfile = observer(() => {
     )
   }
 
+  const isViewingOwnProfile =
+    userStore.activeUser && user && userStore.activeUser._id === user._id
+  const showMemberProfile =
+    user.profileType === ProfileType.MEMBER || user.profileType === undefined
+
   return (
-    <>
-      {user.profileType === ProfileType.MEMBER ||
-      user.profileType === undefined ? (
+    <Flex
+      sx={{
+        alignSelf: 'center',
+        maxWidth: showMemberProfile ? '42em' : '60em',
+        flexDirection: 'column',
+        width: '100%',
+        marginTop: isViewingOwnProfile ? 4 : [6, 8],
+        gap: 4,
+      }}
+    >
+      {isViewingOwnProfile && (
+        <InternalLink
+          sx={{
+            alignSelf: ['center', 'flex-end'],
+            marginBottom: showMemberProfile ? [2, 0] : 0,
+          }}
+          to="/settings"
+        >
+          <Button type="button" data-cy="EditYourProfile">
+            Edit Your Profile
+          </Button>
+        </InternalLink>
+      )}
+
+      {showMemberProfile ? (
         <MemberProfile
           data-cy="memberProfile"
           user={user}
@@ -95,6 +122,6 @@ export const UserProfile = observer(() => {
           docs={userCreatedDocs}
         />
       )}
-    </>
+    </Flex>
   )
 })


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)
- [x] Code style update

## What is the new behavior?

A suggestion from Dalibor was to add a profile update button to users on their own profile. It also does a responsive tidy-up to the display of the profile type icon on space profiles.


## Screenshots

### New Button
<img width="1067" alt="Screenshot 2024-07-17 at 13 56 19" src="https://github.com/user-attachments/assets/cfae4075-b576-490a-a4bf-60cdac3fcbc8">
<img width="1067" alt="Screenshot 2024-07-17 at 13 56 39" src="https://github.com/user-attachments/assets/4f4d7a21-2c7b-4eb0-860e-b062ac1d617d">
<img width="450" alt="Screenshot 2024-07-17 at 13 57 32" src="https://github.com/user-attachments/assets/bcd8a53b-f816-48bd-a2fc-c060e339dcd5">
<img width="450" alt="Screenshot 2024-07-17 at 13 57 46" src="https://github.com/user-attachments/assets/8c5c2a60-dff1-4105-9f05-d9a46514f9c4">

### Responsive tweak
#### Before:
<img width="450" alt="Screenshot 2024-07-17 at 14 07 00" src="https://github.com/user-attachments/assets/2466acc1-9c43-4329-bb3c-531cf12db4ad">

#### After:
<img width="450" alt="Screenshot 2024-07-17 at 14 07 28" src="https://github.com/user-attachments/assets/7316ed36-b69d-419b-8382-699cd823e4b2">

