### PR TITLE
fix: responsive design of tabs on profile

### DIFF
--- a/packages/components/src/TabbedContent/TabbedContent.stories.tsx
+++ b/packages/components/src/TabbedContent/TabbedContent.stories.tsx
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker'
+import { Box } from 'theme-ui'
 
 import { Tab, TabPanel, Tabs, TabsList } from './TabbedContent'
 
@@ -10,35 +11,44 @@ export default {
 
 export const Default: StoryFn = () => {
   return (
-    <Tabs defaultValue={0}>
-      <TabsList>
-        <Tab>Tab #1</Tab>
-        <Tab>Tab #2</Tab>
-        <Tab>Tab #3</Tab>
-        <Tab>Tab #4</Tab>
-        <Tab>Tab #5</Tab>
-      </TabsList>
+    <Box
+      sx={{
+        background: 'white',
+        maxWidth: '1000px',
+        margin: '0 auto',
+        padding: 6,
+      }}
+    >
+      <Tabs defaultValue={0}>
+        <TabsList>
+          <Tab>Tab #1</Tab>
+          <Tab>Tab #2</Tab>
+          <Tab>Tab #3</Tab>
+          <Tab>Tab #4</Tab>
+          <Tab>Tab #5</Tab>
+        </TabsList>
 
-      <TabPanel>
-        <p>Tab Panel #1</p>
-        <p>{faker.lorem.paragraphs(3)}</p>
-      </TabPanel>
-      <TabPanel>
-        <p>Tab Panel #2</p>
-        <p>{faker.lorem.paragraphs(3)}</p>
-      </TabPanel>
-      <TabPanel>
-        <p>Tab Panel #3</p>
-        <p>{faker.lorem.paragraphs(3)}</p>
-      </TabPanel>
-      <TabPanel>
-        <p>Tab Panel #4</p>
-        <p>{faker.lorem.paragraphs(3)}</p>
-      </TabPanel>
-      <TabPanel>
-        <p>Tab Panel #5</p>
-        <p>{faker.lorem.paragraphs(3)}</p>
-      </TabPanel>
-    </Tabs>
+        <TabPanel>
+          <p>Tab Panel #1</p>
+          <p>{faker.lorem.paragraphs(3)}</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Tab Panel #2</p>
+          <p>{faker.lorem.paragraphs(3)}</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Tab Panel #3</p>
+          <p>{faker.lorem.paragraphs(3)}</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Tab Panel #4</p>
+          <p>{faker.lorem.paragraphs(3)}</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Tab Panel #5</p>
+          <p>{faker.lorem.paragraphs(3)}</p>
+        </TabPanel>
+      </Tabs>
+    </Box>
   )
 }

--- a/packages/components/src/TabbedContent/TabbedContent.tsx
+++ b/packages/components/src/TabbedContent/TabbedContent.tsx
@@ -6,8 +6,6 @@ import { TabsList } from '@mui/base/TabsList'
 
 import type { PlatformTheme } from 'oa-themes/dist'
 
-export { Tabs, TabsList }
-
 type Theme = PlatformTheme['styles']
 
 export const Tab = styled(MuiTab)`
@@ -27,14 +25,23 @@ export const Tab = styled(MuiTab)`
     text-decoration: underline;
   }
 
-  &:first-of-type {
-    margin-left: 0;
-    position: relative;
+  @media (min-width: 52em) {
+    &:first-of-type {
+      margin-left: 0;
+      position: relative;
+    }
+  }
+
+  @media (max-width: 52em) {
+    border: 1px solid ${(p) => (p.theme as Theme)?.colors?.grey};
+    border-radius: ${(p) => (p.theme as Theme)?.space?.[2]}px;
+    margin-bottom: ${(p) => (p.theme as Theme)?.space?.[2]}px;
   }
 
   &.base--selected {
     background-color: ${(p) => (p.theme as Theme)?.colors.background};
     text-decoration: none;
+    border: none;
 
     &:after {
       content: '';
@@ -54,3 +61,5 @@ export const TabPanel = styled(MuiTabPanel)`
   border-radius: ${(p) => (p.theme as Theme)?.space?.[2]}px;
   padding: ${(p) => (p.theme as Theme)?.space?.[3]}px;
 `
+
+export { Tabs, TabsList }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

On small screens:
<img width="434" alt="Screenshot 2024-07-17 at 15 32 43" src="https://github.com/user-attachments/assets/0ee9b1c9-6a16-425f-9560-cd1e7748f3a0">

## What is the new behavior?

A more graceful display on small screens.

<img width="436" alt="Screenshot 2024-07-17 at 15 29 39" src="https://github.com/user-attachments/assets/15795600-167c-47c3-a430-5275995c40b5">
<img width="811" alt="Screenshot 2024-07-17 at 15 30 39" src="https://github.com/user-attachments/assets/0a2214c8-267d-497e-9709-5b6f14cd9f85">


## Does this PR introduce a breaking change?

- [x] No
