### PR TITLE
chore: change notification after send to update

### DIFF
--- a/functions/src/emailNotifications/createSubmissionEmails.spec.ts
+++ b/functions/src/emailNotifications/createSubmissionEmails.spec.ts
@@ -1,19 +1,22 @@
-import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
-import { DB_ENDPOINTS, IMapPin, IMessageDB, IUserDB } from '../models'
-import {
-  HOW_TO_SUBMISSION_SUBJECT,
-  MAP_PIN_SUBMISSION_SUBJECT,
-} from './templateHelpers'
+import { IModerationStatus } from 'oa-shared'
+import { UserRole } from 'oa-shared/models'
+
 import { getMockHowto } from '../emulator/seed/content-generate'
+import { DB_ENDPOINTS } from '../models'
+import { FirebaseEmulatedTest } from '../test/Firebase/emulator'
+import { PP_SIGNOFF } from './constants'
 import {
   createHowtoSubmissionEmail,
   createMapPinSubmissionEmail,
   createMessageEmails,
 } from './createSubmissionEmails'
-import { PP_SIGNOFF } from './constants'
+import {
+  HOW_TO_SUBMISSION_SUBJECT,
+  MAP_PIN_SUBMISSION_SUBJECT,
+} from './templateHelpers'
 import * as utils from './utils'
-import { IModerationStatus } from 'oa-shared'
-import { UserRole } from 'oa-shared/models'
+
+import type { IMapPin, IMessageDB, IUserDB } from '../models'
 
 jest.mock('../Firebase/auth', () => ({
   firebaseAuth: {
@@ -159,7 +162,7 @@ describe('Message emails', () => {
   beforeEach(async () => {
     await FirebaseEmulatedTest.clearFirestoreDB()
     await FirebaseEmulatedTest.seedFirestoreDB('users', [user])
-    await FirebaseEmulatedTest.seedFirestoreDB('messages')
+    await FirebaseEmulatedTest.seedFirestoreDB('messages', [message])
     await FirebaseEmulatedTest.seedFirestoreDB('emails')
   })
 

--- a/functions/src/emailNotifications/createSubmissionEmails.ts
+++ b/functions/src/emailNotifications/createSubmissionEmails.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions'
-import { IHowtoDB, IMapPin, IMessageDB } from '../../../src/models'
 import { IModerationStatus } from 'oa-shared'
+
+import { withErrorAlerting } from '../alerting/errorAlerting'
 import { db } from '../Firebase/firestoreDB'
 import { DB_ENDPOINTS } from '../models'
 import {
@@ -10,7 +11,8 @@ import {
   getSenderMessageEmail,
 } from './templateHelpers'
 import { getUserAndEmail, isValidMessageRequest } from './utils'
-import { withErrorAlerting } from '../alerting/errorAlerting'
+
+import type { IHowtoDB, IMapPin, IMessageDB } from '../../../src/models'
 
 export async function createMessageEmails(message: IMessageDB) {
   const isValid = await isValidMessageRequest(message)
@@ -31,10 +33,7 @@ export async function createMessageEmails(message: IMessageDB) {
       to: email,
       message: getSenderMessageEmail(message),
     })
-    await db
-      .collection(DB_ENDPOINTS.messages)
-      .doc(_id)
-      .set({ ...message, isSent: true })
+    await db.collection(DB_ENDPOINTS.messages).doc(_id).update({ isSent: true })
   }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the current behavior?

The final step to create emails from messages involves updating the message doc to know that the message has been sent. This was done through a 'set()' command.

## What is the new behavior?

The message is now changed through an update command, which is safer. 

## Does this PR introduce a breaking change?

- [x] No
