### PR TITLE
feat: move email notification setting to own tab

### DIFF
--- a/packages/components/src/SettingsFormWrapper/SettingsFormTab.tsx
+++ b/packages/components/src/SettingsFormWrapper/SettingsFormTab.tsx
@@ -25,7 +25,7 @@ export const SettingsFormTab = (props: IProps) => {
     borderRadius: 3,
     marginBottom: 3,
     padding: [2, 4],
-    overflow: 'hidden',
+    overflow: 'visible',
   }
 
   return (

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -125,6 +125,14 @@ describe('[Settings]', () => {
       cy.get('[data-cy=remove-map-pin]').click()
       cy.get('[data-cy="Confirm.modal: Confirm"]').click()
       cy.contains('No location data currently saved')
+
+      cy.step('Can update email notification preference')
+      cy.get('[data-cy="tab-Notifications"]').click()
+      cy.get('.data-cy__single-value').last().should('have.text', 'Weekly')
+      cy.selectTag('Daily', '[data-cy=NotificationSettingsSelect]')
+      cy.get('[data-cy=save-notification-settings]').click()
+      cy.contains('Notification setting saved successfully')
+      cy.get('.data-cy__single-value').last().should('have.text', 'Daily')
     })
   })
 

--- a/src/pages/UserSettings/SettingsPage.tsx
+++ b/src/pages/UserSettings/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { Box, Flex, Text } from 'theme-ui'
 import { AccountSettingsSection } from './content/formSections/AccountSettings.section'
 import { ImpactSection } from './content/formSections/Impact/Impact.section'
 import { SettingsMapPinSection } from './content/formSections/SettingsMapPin.section'
+import { SettingsNotifications } from './content/formSections/SettingsNotifications.section'
 import { UserProfile } from './content/formSections/UserProfile.section'
 
 import type { availableGlyphs, ITab } from 'oa-components'
@@ -49,6 +50,12 @@ export const SettingsPage = () => {
     glyph: 'impact' as availableGlyphs,
   }
 
+  const NotificationsTabs = {
+    title: 'Notifications',
+    body: <SettingsNotifications />,
+    glyph: 'thunderbolt' as availableGlyphs,
+  }
+
   const accountTab = {
     title: 'Account',
     body: <AccountSettingsSection />,
@@ -59,6 +66,7 @@ export const SettingsPage = () => {
     profileTab,
     showMapTab ? mapTab : undefined,
     showImpactTab ? impactTab : undefined,
+    NotificationsTabs,
     accountTab,
   ].filter((tab) => tab !== undefined) as ITab[]
 

--- a/src/pages/UserSettings/content/formSections/EmailNotifications.section.tsx
+++ b/src/pages/UserSettings/content/formSections/EmailNotifications.section.tsx
@@ -3,10 +3,7 @@ import { Field } from 'react-final-form'
 import { observer } from 'mobx-react'
 import { Select } from 'oa-components'
 import { EmailNotificationFrequency } from 'oa-shared'
-import { fields } from 'src/pages/UserSettings/labels'
-import { Box, Heading, Text } from 'theme-ui'
-
-import { FlexSectionContainer } from './elements'
+import { FieldContainer } from 'src/common/Form/FieldContainer'
 
 import type { INotificationSettings } from 'src/models/user.models'
 
@@ -25,7 +22,6 @@ const emailFrequencyOptions: {
 ]
 
 export const EmailNotificationsSection = observer((props: IProps) => {
-  const { description, title } = fields.emailNotifications
   const defaultValue = React.useMemo(
     () =>
       emailFrequencyOptions.find(
@@ -37,26 +33,18 @@ export const EmailNotificationsSection = observer((props: IProps) => {
     [props.notificationSettings?.emailFrequency],
   )
   return (
-    <FlexSectionContainer>
-      <Heading as="h2" variant="small">
-        {title}
-      </Heading>
-      <Text mt={4} mb={4} sx={{ display: 'block' }}>
-        {`${description}:`}
-      </Text>
-      <Box mt={2} sx={{ width: '40%' }}>
-        <Field name="notification_settings.emailFrequency">
-          {({ input }) => {
-            return (
-              <Select
-                options={emailFrequencyOptions}
-                defaultValue={defaultValue}
-                onChange={({ value }) => input.onChange(value)}
-              />
-            )
-          }}
-        </Field>
-      </Box>
-    </FlexSectionContainer>
+    <FieldContainer data-cy="NotificationSettingsSelect">
+      <Field name="notification_settings.emailFrequency">
+        {({ input }) => {
+          return (
+            <Select
+              options={emailFrequencyOptions}
+              defaultValue={defaultValue}
+              onChange={({ value }) => input.onChange(value)}
+            />
+          )
+        }}
+      </Field>
+    </FieldContainer>
   )
 })

--- a/src/pages/UserSettings/content/formSections/SettingsMapPin.section.tsx
+++ b/src/pages/UserSettings/content/formSections/SettingsMapPin.section.tsx
@@ -115,7 +115,7 @@ const DeleteMapPin = (props: IPropsDeletePin) => {
     try {
       const updatedUser = await userStore.deleteUserLocation(user)
       if (updatedUser) {
-        mapsStore.setUserPin(toJS(updatedUser))
+        await mapsStore.deleteUserPin(toJS(updatedUser))
       }
       setNotification({
         message: mapForm.sucessfulDelete,

--- a/src/pages/UserSettings/content/formSections/SettingsNotifications.section.tsx
+++ b/src/pages/UserSettings/content/formSections/SettingsNotifications.section.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { Form } from 'react-final-form'
+import { Loader } from 'oa-components'
+import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import {
+  buttons,
+  fields,
+  notificationForm,
+} from 'src/pages/UserSettings/labels'
+import { Button, Flex, Heading, Text } from 'theme-ui'
+
+import { EmailNotificationsSection } from './EmailNotifications.section'
+import { SettingsFormNotifications } from './SettingsFormNotifications'
+
+import type { IFormNotification } from './SettingsFormNotifications'
+
+export const SettingsNotifications = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [notification, setNotification] = useState<
+    IFormNotification | undefined
+  >(undefined)
+
+  const { userStore } = useCommonStores().stores
+  const user = userStore.activeUser
+  const { description, title } = fields.emailNotifications
+
+  const formId = 'Notifications'
+
+  if (!user) return
+
+  const onSubmit = async ({ notification_settings }) => {
+    setIsLoading(true)
+    try {
+      const updatingUser = {
+        ...user,
+        notification_settings,
+      }
+      await userStore.updateUserNotificationSettings(updatingUser)
+
+      setNotification({
+        message: notificationForm.succesfulSave,
+        icon: 'check',
+        show: true,
+        variant: 'success',
+      })
+    } catch (error) {
+      setNotification({
+        message: `Save Failed - ${error.message} `,
+        icon: 'close',
+        show: true,
+        variant: 'failure',
+      })
+    }
+    setIsLoading(false)
+  }
+
+  const initialValues = {
+    notification_settings: user.notification_settings || undefined,
+  }
+
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        gap: 4,
+      }}
+    >
+      <Heading as="h2" variant="small">
+        {title}
+      </Heading>
+      <Text variant="quiet">{description}</Text>
+
+      <Form
+        id={formId}
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        render={({
+          errors,
+          submitFailed,
+          submitting,
+          handleSubmit,
+          values,
+        }) => {
+          if (isLoading)
+            return (
+              <Loader
+                label={notificationForm.loading}
+                sx={{ alignSelf: 'center' }}
+              />
+            )
+
+          return (
+            <>
+              <SettingsFormNotifications
+                errors={errors}
+                notification={notification}
+                submitFailed={submitFailed}
+              />
+
+              <EmailNotificationsSection
+                notificationSettings={values.notification_settings}
+              />
+
+              <Button
+                type="submit"
+                form={formId}
+                data-cy="save-notification-settings"
+                variant="primary"
+                onClick={handleSubmit}
+                disabled={submitting}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                {buttons.notifications}
+              </Button>
+            </>
+          )
+        }}
+      />
+    </Flex>
+  )
+}

--- a/src/pages/UserSettings/content/formSections/UserProfile.section.tsx
+++ b/src/pages/UserSettings/content/formSections/UserProfile.section.tsx
@@ -17,7 +17,6 @@ import { buttons } from '../../labels'
 import INITIAL_VALUES from '../../Template'
 import { CollectionSection } from './Collection.section'
 import { FlexSectionContainer } from './elements'
-import { EmailNotificationsSection } from './EmailNotifications.section'
 import { ExpertiseSection } from './Expertise.section'
 import { FocusSection } from './Focus.section'
 import { PublicContactSection } from './PublicContact.section'
@@ -211,9 +210,6 @@ export const UserProfile = () => {
                   />
                 </Flex>
 
-                <EmailNotificationsSection
-                  notificationSettings={values.notification_settings}
-                />
                 {!isMember && (
                   <FlexSectionContainer>
                     <PublicContactSection

--- a/src/pages/UserSettings/labels.ts
+++ b/src/pages/UserSettings/labels.ts
@@ -22,6 +22,7 @@ export const buttons = {
     type: 'type',
   },
   map: 'Add a map pin',
+  notifications: 'Update notifications',
   editPin: 'Save map pin',
   removePin: 'Remove map pin',
   save: 'Save profile',
@@ -62,7 +63,7 @@ export const fields: ILabels = {
   },
   emailNotifications: {
     description:
-      "We send an email with all the notifications you've missed. Select how often you want to receive this",
+      "We can send you emails with all the notifications you've missed.",
     title: 'Email notifications',
   },
   expertise: {
@@ -153,6 +154,11 @@ export const headings = {
       'In order to have your pin accepted on our map you have to collect at least 6 stars in the Ally Checklist. Learn more about the Community Program and how you can join.',
     title: 'Your map pin',
   },
+}
+
+export const notificationForm = {
+  loading: 'Loading your notification setting',
+  succesfulSave: 'Notification setting saved successfully - whoop',
 }
 
 export const mapForm = {

--- a/src/stores/Maps/maps.store.test.ts
+++ b/src/stores/Maps/maps.store.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MapsStore } from './maps.store'
 
+import type { IUserPPDB } from 'src/models'
+
 vi.mock('../common/module.store')
 
 describe('maps.store', () => {
@@ -190,6 +192,25 @@ describe('maps.store', () => {
       expect(store.db.set).toHaveBeenCalledWith(
         expect.not.objectContaining({
           subType: 'shredder',
+        }),
+      )
+    })
+  })
+
+  describe('deleteUserPin', () => {
+    it('marks a pin as _deleted', async () => {
+      // Arrange
+      store.db.get = vi.fn().mockResolvedValue([{ _id: 'existing' }])
+
+      // Act
+      await store.deleteUserPin({
+        userName: 'existing',
+      } as IUserPPDB)
+
+      // Assert
+      expect(store.db.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _deleted: true,
         }),
       )
     })

--- a/src/stores/Maps/maps.store.ts
+++ b/src/stores/Maps/maps.store.ts
@@ -213,6 +213,16 @@ export class MapsStore extends ModuleStore {
     await this.db.collection<IMapPin>(COLLECTION_NAME).doc(pin._id).set(pin)
   }
 
+  public async deleteUserPin(user: IUserPP) {
+    const pin = await this.getPin(user.userName, 'server')
+
+    logger.debug('marking user pin deleted', pin)
+
+    await this.db.collection<IMapPin>(COLLECTION_NAME).doc(pin._id).update({
+      _deleted: true,
+    })
+  }
+
   // return subset of profile info used when displaying map pins
   private async getUserProfilePin(username: string): Promise<IMapPinDetail> {
     const u = await this.userStore.getUserProfile(username)

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -268,6 +268,22 @@ export class UserStore extends ModuleStore {
     return this.activeUser
   }
 
+  public async updateUserNotificationSettings(user: Partial<IUserPPDB>) {
+    const { _id, notification_settings } = user
+
+    if (!_id) throw new Error('User not found')
+    if (!notification_settings) {
+      throw new Error('notification_settings not found')
+    }
+
+    await this._updateUserRequest(_id, {
+      notification_settings,
+    })
+    await this.refreshActiveUserDetails()
+
+    return this.activeUser
+  }
+
   public async deleteUserLocation(user: Partial<IUserPPDB>) {
     const { _id } = user
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the current behavior?

Email notification nested in the user profile tab.

## What is the new behavior?

In it's own tab with own store method. 

<img width="1129" alt="Screenshot 2024-07-25 at 14 31 50" src="https://github.com/user-attachments/assets/adf58ad3-e7cd-4716-81a3-2ce95aa136bf">
