### PR TITLE
fix: adding contributorId when contributorIds is undefined

### DIFF
--- a/src/models/discussion.models.tsx
+++ b/src/models/discussion.models.tsx
@@ -20,7 +20,7 @@ export type IComment = {
 export type IDiscussion = {
   _id: string
   comments: IComment[]
-  contributorIds: string[]
+  contributorIds?: string[]
   primaryContentId?: string | undefined
   sourceId: string
   sourceType: 'howto' | 'question' | 'researchUpdate'

--- a/src/stores/Discussions/discussions.store.tsx
+++ b/src/stores/Discussions/discussions.store.tsx
@@ -72,11 +72,11 @@ export class DiscussionStore extends ModuleStore {
       contributorIds: [],
     }
 
-    const dbRef = await this.db
+    const dbRef = this.db
       .collection<IDiscussion>(COLLECTION_NAME)
       .doc(newDiscussion._id)
 
-    return this._updateDiscussion(dbRef, newDiscussion)
+    return await this._updateDiscussion(dbRef, newDiscussion)
   }
 
   public async addComment(

--- a/src/stores/Discussions/discussions.store.tsx
+++ b/src/stores/Discussions/discussions.store.tsx
@@ -115,7 +115,7 @@ export class DiscussionStore extends ModuleStore {
 
         currentDiscussion.comments.push(newComment)
         currentDiscussion.contributorIds = this._addContributorId(
-          currentDiscussion,
+          currentDiscussion.contributorIds || [],
           newComment,
         )
 
@@ -194,6 +194,10 @@ export class DiscussionStore extends ModuleStore {
             (comment) => comment._id === commentId,
           )
 
+          if (!targetComment) {
+            throw new Error('Cannot find comment')
+          }
+
           if (targetComment?._creatorId !== user._id && !hasAdminRights(user)) {
             logger.error('Comment can not be deleted by user', { user })
             throw new Error('Comment not editable by user')
@@ -206,8 +210,9 @@ export class DiscussionStore extends ModuleStore {
           )
 
           currentDiscussion.contributorIds = this._removeContributorId(
-            discussion,
-            targetComment?._creatorId,
+            discussion.comments,
+            discussion.contributorIds || [],
+            targetComment._creatorId,
           )
 
           return this._updateDiscussion(dbRef, currentDiscussion)
@@ -365,20 +370,33 @@ export class DiscussionStore extends ModuleStore {
     })
   }
 
-  private _addContributorId({ contributorIds }, comment) {
+  private _addContributorId(contributorIds: string[], comment: IComment) {
+    if (contributorIds.length === 0) {
+      return [comment._creatorId]
+    }
+
     const isIdAlreadyPresent = !contributorIds.find(
       (id) => id === comment._creatorId,
     )
-    if (!isIdAlreadyPresent) return contributorIds
+    if (!isIdAlreadyPresent) {
+      return contributorIds
+    }
 
     return [...contributorIds, comment._creatorId]
   }
 
-  private _removeContributorId({ comments, contributorIds }, _creatorId) {
+  private _removeContributorId(
+    comments: IComment[],
+    contributorIds: string[],
+    _creatorId: string,
+  ) {
     const isOtherUserCommentPresent = !comments.find(
       (comment) => comment._creatorId === _creatorId,
     )
-    if (isOtherUserCommentPresent) return contributorIds
+
+    if (isOtherUserCommentPresent) {
+      return contributorIds
+    }
 
     return contributorIds.filter((id) => id !== _creatorId)
   }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
Adding comments fails when the discussion contributorIds array is undefined.
Unsure how contributorIds could be null though. Couldn't replicate locally.

## What is the new behavior?

Comments can be added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #3804
