### PR TITLE
fix: prod users seeing a dynamic import error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,13 @@ import { Pages } from './pages'
 
 export const App = observer(() => {
   const rootStore = useCommonStores()
+
+  // To handle when hosting deletes the assets from previous deployments
+  // https://vitejs.dev/guide/build#load-error-handling
+  window.addEventListener('vite:preloadError', () => {
+    window.location.reload()
+  })
+
   return (
     <rootStoreContext.Provider value={rootStore}>
       <ThemeProvider theme={rootStore.stores.themeStore.currentTheme.styles}>


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the current behavior?

A user reported this issue when clicking onto a how-to:
![dynam-eror](https://github.com/user-attachments/assets/e5a9bf0d-884a-4e53-9f63-09251c933dfb)


## What is the new behavior?

[From reading this](https://github.com/vitejs/vite/issues/11804), a possible reason for the issue is that our prod hosting provider deletes the old js files that the new build links to.

My fix causes a page level refresh (to get the most up to date js files) when that error occurs.