### PR TITLE
fix: content updating when userImage changes

### DIFF
--- a/functions/src/userUpdates/hasKeyDetailsChanged.test.ts
+++ b/functions/src/userUpdates/hasKeyDetailsChanged.test.ts
@@ -1,6 +1,7 @@
 import {
-  hasCoverImagesChanged,
+  hasDetailsChanged,
   hasKeyDetailsChanged,
+  hasUserImageChanged,
 } from './hasKeyDetailsChanged'
 
 import type { IUserDB } from '../../../src/models'
@@ -13,11 +14,10 @@ describe('hasKeyDetailsChanged', () => {
     } as IUserDB
     const user = {
       displayName: 'new name',
-      coverImages: [
-        {
-          downloadUrl: 'http//etc.',
-        },
-      ],
+      userImage: {
+        downloadUrl: 'http//etc.',
+      },
+
       location: { countryCode: 'USA' },
       badges: { verified: true },
     } as IUserDB
@@ -29,11 +29,10 @@ describe('hasKeyDetailsChanged', () => {
     const user = {
       displayName: 'same name',
       location: { countryCode: 'USA' },
-      coverImages: [
-        {
-          downloadUrl: 'http://etc.',
-        },
-      ],
+      userImage: {
+        downloadUrl: 'http://etc.',
+      },
+
       badges: {
         verified: true,
         supporter: false,
@@ -45,22 +44,101 @@ describe('hasKeyDetailsChanged', () => {
 })
 
 describe('hasKeyDetailsChanged', () => {
-  it('returns false when coverImage array is missing from both', () => {
+  it('returns false when userImage array is missing from both', () => {
     const user = {} as IUserDB
-    expect(hasCoverImagesChanged(user, user)).toEqual(false)
+    expect(hasUserImageChanged(user, user)).toEqual(false)
   })
 
-  it('returns false when coverImage array is empty for both', () => {
+  it('returns false when userImage is empty for both', () => {
     const user = {
-      coverImages: [],
+      coverImages: {},
     } as IUserDB
-    expect(hasCoverImagesChanged(user, user)).toEqual(false)
+    expect(hasUserImageChanged(user, user)).toEqual(false)
   })
 
-  it('returns false when coverImage first item is the same for both', () => {
+  it('returns false when userImage is the same for both', () => {
     const user = {
-      coverImages: [{ downloadUrl: 'same' }],
+      userImage: { downloadUrl: 'same' },
     } as IUserDB
-    expect(hasCoverImagesChanged(user, user)).toEqual(false)
+    expect(hasUserImageChanged(user, user)).toEqual(false)
+  })
+
+  it('returns true when userImage is different', () => {
+    const prevUser = { userImage: { downloadUrl: 'old' } } as IUserDB
+    const user = { userImage: { downloadUrl: 'new' } } as IUserDB
+
+    expect(hasUserImageChanged(prevUser, user)).toEqual(true)
+  })
+
+  it('returns true when userImage goes from populated to not', () => {
+    const prevUser = { userImage: { downloadUrl: 'old' } } as IUserDB
+    const user = { userImage: null } as IUserDB
+
+    expect(hasUserImageChanged(prevUser, user)).toEqual(true)
+  })
+
+  it('returns true when userImage goes from empty to populated', () => {
+    const prevUser = { userImage: null } as IUserDB
+    const user = { userImage: { downloadUrl: 'new' } } as IUserDB
+
+    expect(hasUserImageChanged(prevUser, user)).toEqual(true)
+  })
+})
+
+describe('hasDetailsChanged', () => {
+  it("returns false for every field that's the same", () => {
+    const user = {
+      displayName: 'same',
+      location: { countryCode: 'same' },
+      userImage: {
+        downloadUrl: 'https://more.same/image.jpg',
+      },
+      badges: {
+        verified: true,
+        supporter: false,
+      },
+    } as IUserDB
+
+    expect(hasDetailsChanged(user, user)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ])
+  })
+
+  it("returns truw for every field that's different", () => {
+    const prevUser = {
+      displayName: 'old',
+      location: { countryCode: 'old' },
+      userImage: {
+        downloadUrl: 'https://more.old/image.jpg',
+      },
+      badges: {
+        verified: true,
+        supporter: true,
+      },
+    } as IUserDB
+
+    const user = {
+      displayName: 'new',
+      location: { countryCode: 'new' },
+      userImage: {
+        downloadUrl: 'https://more.new/image.jpg',
+      },
+      badges: {
+        verified: false,
+        supporter: false,
+      },
+    } as IUserDB
+
+    expect(hasDetailsChanged(prevUser, user)).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ])
   })
 })

--- a/functions/src/userUpdates/hasKeyDetailsChanged.ts
+++ b/functions/src/userUpdates/hasKeyDetailsChanged.ts
@@ -2,25 +2,39 @@ import { valuesAreDeepEqual } from '../Utils'
 
 import type { IUserDB } from '../models'
 
-export const hasKeyDetailsChanged = (prevUser: IUserDB, user: IUserDB) => {
-  const detailsChanged = [
+export const hasDetailsChanged = (
+  prevUser: IUserDB,
+  user: IUserDB,
+): boolean[] => {
+  return [
     prevUser.displayName !== user.displayName,
     prevUser.location?.countryCode !== user.location?.countryCode,
-    hasCoverImagesChanged(prevUser, user),
+    hasUserImageChanged(prevUser, user),
     prevUser.badges?.verified !== user.badges?.verified,
     prevUser.badges?.supporter !== user.badges?.supporter,
   ]
+}
+
+export const hasKeyDetailsChanged = (
+  prevUser: IUserDB,
+  user: IUserDB,
+): boolean => {
+  const detailsChanged = hasDetailsChanged(prevUser, user)
   return !!detailsChanged.find((detail) => detail === true)
 }
 
-export const hasCoverImagesChanged = (prevUser: IUserDB, user: IUserDB) => {
-  if (!prevUser.coverImages && !user.coverImages) return false
+export const hasUserImageChanged = (
+  prevUser: IUserDB,
+  user: IUserDB,
+): boolean => {
+  if (!prevUser.userImage && !user.userImage) return false
 
-  if (prevUser.coverImages && user.coverImages) {
-    if (!prevUser.coverImages[0] && !user.coverImages[0]) return false
-
-    return !valuesAreDeepEqual(prevUser.coverImages, user.coverImages)
+  if (prevUser.userImage && user.userImage) {
+    return !valuesAreDeepEqual(prevUser.userImage, user.userImage)
   }
+
+  if (prevUser.userImage && !user.userImage) return true
+  if (!prevUser.userImage && user.userImage) return true
 
   return false
 }

--- a/functions/src/userUpdates/updateDiscussionComments.ts
+++ b/functions/src/userUpdates/updateDiscussionComments.ts
@@ -22,7 +22,7 @@ export const updateDiscussionComments = async (
 
     const userDetails = {
       creatorCountry: location?.countryCode || '',
-      ...(creatorImage ? { creatorImage } : {}),
+      creatorImage,
       isUserVerified: !!badges?.verified,
       isUserSupporter: !!badges?.supporter,
     }
@@ -52,5 +52,5 @@ const getCreatorImage = (userImage: IUserDB['userImage']) => {
   if (userImage && userImage.downloadUrl) {
     return userImage.downloadUrl
   }
-  return undefined
+  return null
 }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the current behavior?

Comments not updating `creatorImage` when `userImage` is updated.

https://github.com/user-attachments/assets/356e96b6-8ada-4b4a-bf77-5a67a732c149

## What is the new behavior?

Comments updating `creatorImage` when `userImage` is updated.

https://github.com/user-attachments/assets/25f60506-f5ff-49ef-a0e4-21afa9f3d3a7



