### PR TITLE
fix: improve comments performance

### DIFF
--- a/packages/components/src/CreateComment/CreateComment.tsx
+++ b/packages/components/src/CreateComment/CreateComment.tsx
@@ -50,7 +50,9 @@ export const CreateComment = (props: Props) => {
             },
           }}
         >
-          {isLoggedIn ? (
+          {!isLoggedIn ? (
+            <LoginPrompt />
+          ) : (
             <>
               <Textarea
                 value={comment}
@@ -83,22 +85,6 @@ export const CreateComment = (props: Props) => {
                 {comment.length}/{maxLength}
               </Text>
             </>
-          ) : (
-            <Box sx={{ padding: [3, 4] }}>
-              <Text data-cy="comments-login-prompt">
-                Hi there!{' '}
-                <Link
-                  to="/sign-in"
-                  style={{
-                    textDecoration: 'underline',
-                    color: 'inherit',
-                  }}
-                >
-                  Login
-                </Link>{' '}
-                to leave a comment
-              </Text>
-            </Box>
           )}
         </Box>
       </Flex>
@@ -119,5 +105,25 @@ export const CreateComment = (props: Props) => {
         </Button>
       </Flex>
     </Flex>
+  )
+}
+
+const LoginPrompt = () => {
+  return (
+    <Box sx={{ padding: [3, 4] }}>
+      <Text data-cy="comments-login-prompt">
+        Hi there!{' '}
+        <Link
+          to="/sign-in"
+          style={{
+            textDecoration: 'underline',
+            color: 'inherit',
+          }}
+        >
+          Login
+        </Link>{' '}
+        to leave a comment
+      </Text>
+    </Box>
   )
 }

--- a/packages/components/src/DiscussionContainer/DiscussionContainer.stories.tsx
+++ b/packages/components/src/DiscussionContainer/DiscussionContainer.stories.tsx
@@ -31,6 +31,7 @@ export const Default: Story = {
         onMoreComments={() => null}
         onSubmit={() => null}
         onSubmitReply={() => Promise.resolve()}
+        isSubmitting={false}
         isLoggedIn={false}
       />
     )
@@ -51,6 +52,7 @@ export const NoComments: Story = {
         onMoreComments={() => null}
         onSubmit={() => null}
         onSubmitReply={() => Promise.resolve()}
+        isSubmitting={false}
         isLoggedIn={false}
       />
     )
@@ -73,6 +75,7 @@ export const LoggedIn: Story = {
         onMoreComments={() => null}
         onSubmit={() => null}
         onSubmitReply={() => Promise.resolve()}
+        isSubmitting={false}
         isLoggedIn={true}
       />
     )
@@ -95,6 +98,7 @@ export const Expandable: Story = {
         onMoreComments={() => null}
         onSubmit={() => null}
         onSubmitReply={() => Promise.resolve()}
+        isSubmitting={false}
         isLoggedIn={true}
       />
     )
@@ -121,6 +125,7 @@ export const WithReplies: Story = {
         onMoreComments={() => null}
         onSubmit={() => null}
         isLoggedIn={true}
+        isSubmitting={false}
         onSubmitReply={async (commentId, comment) =>
           alert(`reply to commentId: ${commentId} with comment: ${comment}`)
         }

--- a/packages/components/src/DiscussionContainer/DiscussionContainer.tsx
+++ b/packages/components/src/DiscussionContainer/DiscussionContainer.tsx
@@ -21,6 +21,7 @@ export interface IProps {
   onMoreComments: () => void
   onSubmit: (comment: string) => void
   onSubmitReply: (_id: string, reply: string) => Promise<void>
+  isSubmitting: boolean
   supportReplies?: boolean
 }
 
@@ -38,11 +39,12 @@ export const DiscussionContainer = (props: IProps) => {
     onMoreComments,
     onSubmit,
     isLoggedIn,
+    isSubmitting,
     supportReplies = false,
   } = props
 
   const [commentBeingRepliedTo, setCommentBeingRepliedTo] = useState<
-    null | string
+    string | null
   >(null)
   const structuredComments = useMemo(
     () => transformToTree(comments),
@@ -51,7 +53,8 @@ export const DiscussionContainer = (props: IProps) => {
 
   const handleSetCommentBeingRepliedTo = (commentId: string | null): void => {
     if (commentId === commentBeingRepliedTo) {
-      return setCommentBeingRepliedTo(null)
+      setCommentBeingRepliedTo(null)
+      return
     }
     setCommentBeingRepliedTo(commentId)
   }
@@ -85,6 +88,7 @@ export const DiscussionContainer = (props: IProps) => {
         }}
       >
         <CreateComment
+          isLoading={isSubmitting}
           maxLength={maxLength}
           comment={comment}
           onChange={onChange}

--- a/src/common/DiscussionWrapper.tsx
+++ b/src/common/DiscussionWrapper.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { observer } from 'mobx-react'
 import { DiscussionContainer, Loader } from 'oa-components'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { transformToUserComments } from 'src/common/transformToUserComments'
@@ -18,9 +19,9 @@ const LOADING_LABEL = 'Loading the awesome discussion'
 interface IProps {
   sourceType: IDiscussion['sourceType']
   sourceId: string
-  setTotalCommentsCount: (number) => void
-  canHideComments?: boolean
+  setTotalCommentsCount: (number: number) => void
   showComments?: boolean
+  canHideComments?: boolean
   primaryContentId?: string | undefined
 }
 
@@ -32,7 +33,7 @@ const getHighlightedCommentId = () => {
   return filterOutResearchUpdate.replace('#comment:', '')
 }
 
-export const DiscussionWrapper = (props: IProps) => {
+export const DiscussionWrapper = observer((props: IProps) => {
   const {
     canHideComments,
     primaryContentId,
@@ -45,6 +46,7 @@ export const DiscussionWrapper = (props: IProps) => {
   const [comment, setComment] = useState('')
   const [discussion, setDiscussion] = useState<IDiscussion | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const { discussionStore } = useCommonStores().stores
   const highlightedCommentId = getHighlightedCommentId()
@@ -86,6 +88,7 @@ export const DiscussionWrapper = (props: IProps) => {
   const handleEdit = async (_id: string, comment: string) => {
     if (!discussion) return
 
+    setIsSubmitting(true)
     const updatedDiscussion = await discussionStore.editComment(
       discussion,
       _id,
@@ -96,6 +99,8 @@ export const DiscussionWrapper = (props: IProps) => {
     if (updatedDiscussion) {
       transformComments(updatedDiscussion)
     }
+
+    setIsSubmitting(false)
   }
 
   const handleEditRequest = async () => {
@@ -105,6 +110,7 @@ export const DiscussionWrapper = (props: IProps) => {
   const handleDelete = async (_id: string) => {
     if (!discussion) return
 
+    setIsSubmitting(true)
     const updatedDiscussion = await discussionStore.deleteComment(
       discussion,
       _id,
@@ -114,10 +120,14 @@ export const DiscussionWrapper = (props: IProps) => {
     if (updatedDiscussion) {
       transformComments(updatedDiscussion)
     }
+
+    setIsSubmitting(false)
   }
 
   const onSubmit = async (comment: string) => {
     if (!comment || !discussion) return
+
+    setIsSubmitting(true)
 
     const updatedDiscussion = await discussionStore.addComment(
       discussion,
@@ -131,10 +141,14 @@ export const DiscussionWrapper = (props: IProps) => {
     if (updatedDiscussion) {
       setComment('')
     }
+
+    setIsSubmitting(false)
   }
 
-  const handleSubmitReply = async (commentId: string, reply) => {
+  const handleSubmitReply = async (commentId: string, reply: string) => {
     if (!discussion) return
+
+    setIsSubmitting(true)
 
     const updatedDiscussion = await discussionStore.addComment(
       discussion,
@@ -146,6 +160,8 @@ export const DiscussionWrapper = (props: IProps) => {
     if (updatedDiscussion) {
       transformComments(updatedDiscussion)
     }
+
+    setIsSubmitting(false)
   }
 
   const discussionProps = {
@@ -161,6 +177,7 @@ export const DiscussionWrapper = (props: IProps) => {
     highlightedCommentId,
     onSubmit,
     onSubmitReply: handleSubmitReply,
+    isSubmitting,
     isLoggedIn: discussionStore?.activeUser
       ? !!discussionStore.activeUser
       : false,
@@ -183,4 +200,4 @@ export const DiscussionWrapper = (props: IProps) => {
       )}
     </>
   )
-}
+})

--- a/src/common/HideDiscussionContainer.tsx
+++ b/src/common/HideDiscussionContainer.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Button } from 'oa-components'
 import { Box } from 'theme-ui'
 
 interface IProps {
-  children
   commentCount: number
+  children: React.ReactNode | React.ReactNode[]
   showComments?: boolean
 }
 
@@ -13,13 +13,9 @@ export const HideDiscussionContainer = ({
   commentCount,
   showComments,
 }: IProps) => {
-  const [viewComments, setViewComments] = useState(showComments || false)
+  const [viewComments, setViewComments] = useState(() => showComments || false)
 
-  const onButtonClick = () => {
-    setViewComments(!viewComments)
-  }
-
-  const setButtonText = () => {
+  const buttonText = useMemo(() => {
     if (!viewComments) {
       switch (commentCount) {
         case 0:
@@ -32,7 +28,7 @@ export const HideDiscussionContainer = ({
     }
 
     return 'Collapse Comments'
-  }
+  }, [viewComments])
 
   return (
     <Box
@@ -53,14 +49,14 @@ export const HideDiscussionContainer = ({
           display: 'block',
           marginBottom: viewComments ? 2 : 0,
         }}
-        onClick={onButtonClick}
+        onClick={() => setViewComments((prev) => !prev)}
         backgroundColor={viewComments ? '#c2daf0' : '#e2edf7'}
         className={viewComments ? 'viewComments' : ''}
         data-cy={`HideDiscussionContainer: button ${
           !viewComments && 'open-comments'
         }`}
       >
-        <>{setButtonText()}</>
+        {buttonText}
       </Button>
       {viewComments && children}
     </Box>

--- a/src/stores/Discussions/discussionEvents.ts
+++ b/src/stores/Discussions/discussionEvents.ts
@@ -74,7 +74,9 @@ export const updateDiscussionMetadata = async (
       const researchRef = db.collection('research').doc(primaryContentId)
       const research = toJS(await researchRef.get('server')) as IResearch.Item
 
-      if (!research || !research.updates) return
+      if (!research || !research.updates || research.updates.length === 0) {
+        return
+      }
 
       const updates = research.updates.map((update) => {
         return update._id === sourceId ? { ...update, commentCount } : update


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [x] Feature (adds functionality)
- [x] Refactoring (no functional changes)

## What is the current behavior?

Adding comments is very slow (13 seconds in a particular case!).
Due to notifications, the more contributors it has, the worse it gets!

Lack of loading indicators makes it worse.

## What is the new behavior?

Does not await discussion metadata updates and user notifications.
Locally it reduces the time from 4s to 1s.
1 second should be constant now, so for prod it would reduce from 13s to 1s.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Git Issues

Closes #
