### PR TITLE
fix: discussion count on research updates

### DIFF
--- a/shared/mocks/data/research.ts
+++ b/shared/mocks/data/research.ts
@@ -31,7 +31,6 @@ export const research = {
         _id: 'ERO3RibAuvz7Wt12LfTb',
         _modified: '2022-03-27T22:10:11.271Z',
         description: 'qwerty',
-        status: 'published',
         collaborators: ['demo_user'],
         commentCount: 1,
         images: [

--- a/src/models/research.models.tsx
+++ b/src/models/research.models.tsx
@@ -67,7 +67,7 @@ export namespace IResearch {
     videoUrl?: string
     collaborators?: string[]
     commentCount?: number
-    status: ResearchUpdateStatus
+    status?: ResearchUpdateStatus
     researchStatus?: ResearchStatus
     locked?: ResearchDocumentLock
     _id: string

--- a/src/stores/Discussions/discussionEvents.test.ts
+++ b/src/stores/Discussions/discussionEvents.test.ts
@@ -17,20 +17,33 @@ describe('liveResearchUpdatesCommentCounts', () => {
 
   describe('_deleted', () => {
     it('ignores deleted updates', () => {
-      const deletedUpdate = FactoryResearchItemUpdate({
+      const deletedUpdateOne = FactoryResearchItemUpdate({
         _deleted: true,
         commentCount: 2,
       })
-      const liveUpdate = FactoryResearchItemUpdate({
-        _deleted: false,
+      const deletedUpdateTwo = FactoryResearchItemUpdate({
+        _deleted: true,
+        status: ResearchUpdateStatus.DRAFT,
+        commentCount: 5,
+      })
+      const deletedUpdateThree = FactoryResearchItemUpdate({
+        _deleted: true,
         status: ResearchUpdateStatus.PUBLISHED,
-        commentCount: 3,
+        commentCount: 4,
+      })
+      const liveUpdate = FactoryResearchItemUpdate({
+        commentCount: 1,
       })
       const research = FactoryResearchItem({
-        updates: [deletedUpdate, liveUpdate, liveUpdate],
+        updates: [
+          deletedUpdateOne,
+          deletedUpdateTwo,
+          deletedUpdateThree,
+          liveUpdate,
+        ],
       })
 
-      expect(liveResearchUpdatesCommentCounts(research.updates)).toEqual(6)
+      expect(liveResearchUpdatesCommentCounts(research.updates)).toEqual(1)
     })
   })
 
@@ -49,11 +62,19 @@ describe('liveResearchUpdatesCommentCounts', () => {
         _deleted: false,
         status: ResearchUpdateStatus.PUBLISHED,
       })
+      const oldUpdateWithoutStatus = FactoryResearchItemUpdate({
+        commentCount: 4,
+      })
       const research = FactoryResearchItem({
-        updates: [liveUpdate, draftUpdate, commentlessLiveUpdate],
+        updates: [
+          liveUpdate,
+          draftUpdate,
+          commentlessLiveUpdate,
+          oldUpdateWithoutStatus,
+        ],
       })
 
-      expect(liveResearchUpdatesCommentCounts(research.updates)).toEqual(5)
+      expect(liveResearchUpdatesCommentCounts(research.updates)).toEqual(9)
     })
   })
 })

--- a/src/stores/Discussions/discussionEvents.ts
+++ b/src/stores/Discussions/discussionEvents.ts
@@ -30,7 +30,7 @@ export const liveResearchUpdatesCommentCounts = (
 
   const publishedUpdates = updates.filter(
     ({ status, _deleted }) =>
-      status === ResearchUpdateStatus.PUBLISHED && _deleted != true,
+      _deleted === false && !(status === ResearchUpdateStatus.DRAFT),
   )
 
   const updatesCommentCount = publishedUpdates.map(

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { IModerationStatus, ResearchUpdateStatus } from 'oa-shared'
+import { IModerationStatus } from 'oa-shared'
 
 import type { IResearch, IResearchDB } from 'src/models/research.models'
 
@@ -20,9 +20,8 @@ export const FactoryResearchItemUpdate = (
   _id: faker.string.uuid(),
   _modified: faker.date.past().toString(),
   _created: faker.date.past().toString(),
-  _deleted: faker.datatype.boolean(),
+  _deleted: false,
   _contentModifiedTimestamp: faker.date.past().toString(),
-  status: faker.helpers.arrayElement(Object.values(ResearchUpdateStatus)),
   ...researchItemUpdateOverloads,
 })
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the new behavior?

While the typing for research updates stats that status is a required field... The actual prod data says different, so my last fix didn't work as old research updates on PK don't have the status set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
