### PR TITLE
feat: show unsubscribed on notification setting

### DIFF
--- a/src/models/user.models.tsx
+++ b/src/models/user.models.tsx
@@ -50,7 +50,7 @@ export interface IUser {
   profileCreated?: ISODateString
   profileCreationTrigger?: string
   // Used to generate an encrypted unsubscribe url in emails
-  unsubscribeToken?: string
+  unsubscribeToken?: string | null
   impact?: IUserImpact
   isBlockedFromMessaging?: boolean
   isContactableByPublic?: boolean

--- a/src/pages/UserSettings/SettingsPageNotifications.test.tsx
+++ b/src/pages/UserSettings/SettingsPageNotifications.test.tsx
@@ -40,4 +40,23 @@ describe('SettingsPageNotifications', () => {
       expect(wrapper.queryByText('Weekly')).toBeNull()
     })
   })
+
+  it('renders the option as never when a unsubscribe token is present', async () => {
+    mockUser = FactoryUser({
+      notification_settings: {
+        emailFrequency: EmailNotificationFrequency.MONTHLY,
+      },
+      unsubscribeToken: 'something',
+    })
+    // Act
+    let wrapper
+    act(() => {
+      wrapper = FormProvider(mockUser, <SettingsPageNotifications />)
+    })
+
+    await waitFor(() => {
+      expect(wrapper.getAllByText('Never', { exact: false })).toHaveLength(1)
+      expect(wrapper.queryByText('Weekly')).toBeNull()
+    })
+  })
 })

--- a/src/pages/UserSettings/SettingsPageNotifications.tsx
+++ b/src/pages/UserSettings/SettingsPageNotifications.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Form } from 'react-final-form'
 import { Loader } from 'oa-components'
+import { EmailNotificationFrequency } from 'oa-shared'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import {
   buttons,
@@ -33,13 +34,20 @@ export const SettingsPageNotifications = () => {
         ...user,
         notification_settings,
       }
-      await userStore.updateUserNotificationSettings(updatingUser)
+      const updatedUser =
+        await userStore.updateUserNotificationSettings(updatingUser)
 
       setNotification({
         message: notificationForm.succesfulSave,
         icon: 'check',
         show: true,
         variant: 'success',
+      })
+      setInitialValues({
+        notification_settings: {
+          ...updatedUser.notification_settings,
+          emailFrequency,
+        },
       })
     } catch (error) {
       setNotification({
@@ -54,9 +62,17 @@ export const SettingsPageNotifications = () => {
 
   if (!user) return null
 
-  const initialValues = {
-    notification_settings: user.notification_settings || undefined,
-  }
+  const isUnsubscribed = !!user.unsubscribeToken
+  const emailFrequency = isUnsubscribed
+    ? EmailNotificationFrequency.NEVER
+    : user.notification_settings?.emailFrequency
+
+  const [initialValues, setInitialValues] = useState({
+    notification_settings: {
+      ...user.notification_settings,
+      emailFrequency,
+    },
+  })
 
   return (
     <Flex

--- a/src/pages/UserSettings/content/sections/EmailNotifications.section.tsx
+++ b/src/pages/UserSettings/content/sections/EmailNotifications.section.tsx
@@ -15,7 +15,7 @@ const emailFrequencyOptions: {
   value: EmailNotificationFrequency
   label: string
 }[] = [
-  { value: EmailNotificationFrequency.NEVER, label: 'Never' },
+  { value: EmailNotificationFrequency.NEVER, label: 'Never (Unsubscribed)' },
   { value: EmailNotificationFrequency.DAILY, label: 'Daily' },
   { value: EmailNotificationFrequency.WEEKLY, label: 'Weekly' },
   { value: EmailNotificationFrequency.MONTHLY, label: 'Monthly' },

--- a/src/stores/User/user.store.test.tsx
+++ b/src/stores/User/user.store.test.tsx
@@ -456,6 +456,33 @@ describe('userStore', () => {
       )
     })
 
+    it('clears the unsubscribe token', async () => {
+      const userProfile = FactoryUser({
+        _id: 'my-user-profile',
+        notification_settings: {
+          emailFrequency: EmailNotificationFrequency.NEVER,
+        },
+        unsubscribeToken: 'anything',
+      })
+      store.activeUser = userProfile
+
+      const notification_settings = {
+        emailFrequency: EmailNotificationFrequency.DAILY,
+      }
+      const updateValues = {
+        _id: userProfile._id,
+        notification_settings,
+      }
+      await store.updateUserNotificationSettings(updateValues)
+
+      expect(store.db.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notification_settings,
+          unsubscribeToken: null,
+        }),
+      )
+    })
+
     it('throws an error is no user id is provided', async () => {
       const values = {}
 

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -257,8 +257,14 @@ export class UserStore extends ModuleStore {
       throw new Error('notification_settings not found')
     }
 
+    const unsubscribeToken =
+      notification_settings.emailFrequency === EmailNotificationFrequency.NEVER
+        ? this.activeUser.unsubscribeToken
+        : null
+
     await this._updateUserRequest(_id, {
       notification_settings,
+      unsubscribeToken,
     })
     await this.refreshActiveUserDetails()
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [x] Feature (adds functionality)


## What is the current behavior?

An admin was recently confused that they weren't recieving notification emails. It turns out they'd been unsubscribed at somepoint. But there's no way they could have known this from their user settings.

## What is the new behavior?

As in our functions, if an unsubscribe token is present then that overrides the notification frequency preference. Now this is shown to the user by displaying the requency as 'never' and clearing `unsubscribeToken` if changed from never. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
