### PR TITLE
fix: page link given to feedback button

### DIFF
--- a/packages/cypress/src/integration/common.spec.ts
+++ b/packages/cypress/src/integration/common.spec.ts
@@ -32,6 +32,36 @@ describe('[Common]', () => {
     cy.url().should('include', '/how-to')
   })
 
+  describe.only('[User feeback button]', () => {
+    it('[Desktop]', () => {
+      cy.visit('/how-to')
+      cy.get('[data-cy=feedback]').should('contain', 'Report a Problem')
+      cy.get('[data-cy=feedback]')
+        .should('have.attr', 'href')
+        .and('contain', '/how-to?sort=Newest')
+
+      cy.visit('/map')
+      cy.get('[data-cy=feedback]')
+        .should('have.attr', 'href')
+        .and('contain', '/map')
+    })
+
+    it('[Mobile]', () => {
+      cy.viewport('iphone-6')
+
+      cy.visit('/how-to')
+      cy.get('[data-cy=feedback]').should('contain', 'Problem?')
+      cy.get('[data-cy=feedback]')
+        .should('have.attr', 'href')
+        .and('contain', '/how-to?sort=Newest')
+
+      cy.visit('/map')
+      cy.get('[data-cy=feedback]')
+        .should('have.attr', 'href')
+        .and('contain', '/map')
+    })
+  })
+
   describe('[User Menu]', () => {
     it('[By Anonymous]', () => {
       cy.step('Login and Join buttons are available')

--- a/src/pages/common/StickyButton.tsx
+++ b/src/pages/common/StickyButton.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router'
 import { Button, ExternalLink } from 'oa-components'
 import { Box, Text } from 'theme-ui'
 
@@ -5,7 +7,14 @@ const FORM_URL =
   'https://onearmy.retool.com/form/c48a8f5a-4f53-4c58-adda-ef4f3cd8dee1'
 
 export const StickyButton = () => {
-  const href = `${FORM_URL}#page=${window.location.href}`
+  const location = useLocation()
+  const [page, setPage] = useState<string>(window.location.href)
+
+  useEffect(() => {
+    setPage(window.location.href)
+  }, [location])
+
+  const href = `${FORM_URL}#page=${page}`
 
   return (
     <Box


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

The page url given to the link to the feedback form was set on the first path viewed by the user. It was updated on refresh but not normal navigation around the site.
