### PR TITLE
fix: email link to PK header image

### DIFF
--- a/functions/src/emailNotifications/constants.ts
+++ b/functions/src/emailNotifications/constants.ts
@@ -1,6 +1,6 @@
 export const NOTIFICATION_LIST_IMAGE = `http://cdn.mcauto-images-production.sendgrid.net/cb5a685b085b7e7c/1e6f3be3-e6fd-46c5-b30f-bcde950b0dbc/165x131.png`
 
-export const PK_PROJECT_IMAGE = `https://community.projectkamp.com/static/media/project-kamp-header.f521707366facac45443.png`
+export const PK_PROJECT_IMAGE = `https://firebasestorage.googleapis.com/v0/b/project-kamp-community.appspot.com/o/uploads%2Fproject-kamp-header.png?alt=media&token=2260f4bc-cec1-432f-82c5-433c4c73a292`
 export const PP_PROJECT_IMAGE = `http://cdn.mcauto-images-production.sendgrid.net/cb5a685b085b7e7c/f48e2455-6dbb-4102-bde9-2ee07d3008c4/859x860.png`
 
 export const PK_PROJECT_NAME = 'Project Kamp'


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

The PK email template currently links to a now deleted (for whatever reason) asset library. 

## What is the new behavior?

I've uploaded the same image directly to the firebase image store so this new url shouldn't change.
