### PR TITLE
feat: send notification to discussion contributors

### DIFF
--- a/shared/mocks/data/discussions.ts
+++ b/shared/mocks/data/discussions.ts
@@ -4,16 +4,13 @@ export const discussions = {
     _deleted: false,
     _id: '06fjiZWeyxxMkE0brp6n',
     _modified: '2023-02-15T02:45:15.500Z',
-    contributorIds: [
-      'Q1sgtnNTPBSYCKEXCOWaOMcPqZD3',
-      'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
-    ],
+    contributorIds: ['howto_creator', 'benfurber', 'davehakkens'],
     sourceId: '3s7Fyn6Jf8ryANJM6Jf6',
     sourceType: 'question',
     comments: [
       {
         _created: '2022-02-10T20:22:15.500Z',
-        _creatorId: 'Q1sgtnNTPBSYCKEXCOWaOMcPqZD3',
+        _creatorId: 'howto_creator',
         _edited: '2022-02-10T20:22:15.500Z',
         _id: 'ZAB2SoUZtzUyeYLg9Cro',
         creatorCountry: 'af',
@@ -25,7 +22,7 @@ export const discussions = {
       },
       {
         _created: '2023-02-10T20:22:15.500Z',
-        _creatorId: 'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+        _creatorId: 'benfurber',
         _id: 'ZtzUyeYLgZAB2SoU9Cro',
         creatorCountry: 'uk',
         creatorName: 'benfurber',
@@ -34,7 +31,7 @@ export const discussions = {
       },
       {
         _created: '2023-02-11T02:22:15.500Z',
-        _creatorId: 'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+        _creatorId: 'benfurber',
         _id: 'BtzUAB2SoU9CroyeYLgZ',
         creatorCountry: 'uk',
         creatorName: 'benfurber',
@@ -44,7 +41,7 @@ export const discussions = {
       {
         _created: '2023-02-12T02:22:19.500Z',
         _edited: '2023-02-12T02:22:43.500Z',
-        _creatorId: 'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+        _creatorId: 'davehakkens',
         _id: 'Bt9CroyeYLgZ55555',
         creatorCountry: '',
         creatorName: 'davehakkens',
@@ -53,7 +50,7 @@ export const discussions = {
       },
       {
         _created: '2023-02-15T02:45:15.500Z',
-        _creatorId: 'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+        _creatorId: 'benfurber',
         _id: 'fBtzUAB23royeYLgZ',
         creatorCountry: 'uk',
         creatorName: 'benfurber',
@@ -70,6 +67,7 @@ export const discussions = {
     contributorIds: [
       'Q1sgtnNTPBSYCKEXCOWaOMcPqZD3',
       'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
+      'demo_admin',
     ],
     sourceId: 'ERO3RibAuvz7Wt12LfTb',
     sourceType: 'researchUpdate',
@@ -126,7 +124,7 @@ export const discussions = {
     _deleted: false,
     _id: 'w21vbdxc4t3',
     _modified: '2022-03-27T22:10:12.271Z',
-    contributorIds: ['Q1sgtnNTPBSYCKEXCOWaOMcPqZD3'],
+    contributorIds: ['demo_admin'],
     sourceId: '213hrandom-id',
     sourceType: 'researchUpdate',
     primaryContentId: '0up6oJCPP3M9bDYx34Et',
@@ -160,10 +158,7 @@ export const discussions = {
     _deleted: false,
     _id: 'lkjsad897234b',
     _modified: '2022-03-27T22:10:12.271Z',
-    contributorIds: [
-      'Q1sgtnNTPBSYCKEXCOWaOMcPqZD3',
-      'TPBSYCKEXCOWaOMcPqZD3Q1sgtnN',
-    ],
+    contributorIds: ['demo_admin'],
     sourceId: 'random-23456',
     sourceType: 'researchUpdate',
     primaryContentId: '0up6oJCPP3M9bDYx34Et',
@@ -193,7 +188,7 @@ export const discussions = {
     _created: '2022-04-27T22:10:11.271Z',
     _deleted: false,
     _id: 'ljerqw7234asdf',
-    contributorIds: ['demo_admin'],
+    contributorIds: ['demo_admin', 'benfurber'],
     sourceId: 'gPpPDEvfNT9a6w5FWzaj',
     sourceType: 'howto',
     primaryContentId: 'gPpPDEvfNT9a6w5FWzaj',

--- a/src/stores/Discussions/discussion.store.test.ts
+++ b/src/stores/Discussions/discussion.store.test.ts
@@ -150,12 +150,27 @@ describe('discussion.store', () => {
       )
     })
 
+    it('notifies all contributors of a new comment (except the commenter)', async () => {
+      const discussions = [
+        FactoryDiscussion({ contributorIds: ['1', '2', '3'] }),
+      ]
+      const { store, discussionItem } = factory(discussions)
+
+      //Act
+      await store.addComment(discussionItem, 'New comment')
+
+      expect(
+        store.userNotificationsStore.triggerNotification,
+      ).toHaveBeenCalledTimes(4)
+    })
+
     it('adds a reply to a comment', async () => {
-      const { store, discussionItem, setFn } = factory([
-        FactoryDiscussion({
-          comments: [FactoryDiscussionComment({ text: 'New comment' })],
-        }),
-      ])
+      const discussions = [
+        FactoryDiscussion({}, [
+          FactoryDiscussionComment({ text: 'New comment' }),
+        ]),
+      ]
+      const { store, discussionItem, setFn } = factory(discussions)
 
       //Act
       await store.addComment(
@@ -180,7 +195,7 @@ describe('discussion.store', () => {
         store.userNotificationsStore.triggerNotification,
       ).toHaveBeenCalledWith(
         'new_comment_discussion',
-        discussionItem.comments[0].creatorName,
+        discussionItem.comments[0]._creatorId,
         `/questions/undefined#comment:${discussionItem.comments[0]._id}`,
         undefined, // concern of another store
       )

--- a/src/stores/User/notifications.store.test.tsx
+++ b/src/stores/User/notifications.store.test.tsx
@@ -1,3 +1,4 @@
+import { logger } from 'src/logger'
 import { FactoryNotification } from 'src/test/factories/Notification'
 import { FactoryUser } from 'src/test/factories/User'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -65,16 +66,16 @@ describe('triggerNotification', () => {
     )
   })
 
-  it('throws error when invalid user passed', () => {
-    // Act
-    expect(
-      store.triggerNotification(
-        'howto_mention',
-        'non-existent-user',
-        'https://example.com',
-        'example',
-      ),
-    ).rejects.toThrow('User not found')
+  it('throws error when invalid user passed', async () => {
+    const loggerSpy = vi.spyOn(logger, 'error')
+
+    await store.triggerNotification(
+      'howto_mention',
+      'non-existent-user',
+      'https://example.com',
+      'example',
+    )
+    expect(loggerSpy).toBeCalled()
   })
 })
 

--- a/src/test/factories/Discussion.ts
+++ b/src/test/factories/Discussion.ts
@@ -10,7 +10,7 @@ export const FactoryDiscussion = (
 ): IDiscussion => ({
   _id: faker.string.uuid(),
   comments,
-  contributorIds: [],
+  contributorIds: comments.map((comment) => comment._creatorId),
   sourceId: faker.string.uuid(),
   primaryContentId: faker.string.uuid(),
   sourceType: 'question',

--- a/src/utils/getDiscussionContributorsToNotify.test.ts
+++ b/src/utils/getDiscussionContributorsToNotify.test.ts
@@ -1,0 +1,44 @@
+import {
+  FactoryDiscussion,
+  FactoryDiscussionComment,
+} from 'src/test/factories/Discussion'
+import { FactoryQuestionItem } from 'src/test/factories/Question'
+import { FactoryResearchItem } from 'src/test/factories/ResearchItem'
+import { describe, expect, it } from 'vitest'
+
+import { getDiscussionContributorsToNotify } from './getDiscussionContributorsToNotify'
+
+describe('getDiscussionContributorsToNotify', () => {
+  it('returns the ids of users to be notified', () => {
+    const contributorIds = ['1', '2', '3', '4']
+    const discussion = FactoryDiscussion({ contributorIds })
+    const comment = FactoryDiscussionComment()
+    const parentContent = FactoryQuestionItem({ _createdBy: '1' })
+
+    const toNotify = getDiscussionContributorsToNotify(
+      discussion,
+      parentContent,
+      comment,
+    )
+
+    expect(toNotify).toEqual(contributorIds)
+  })
+
+  it('adds research update collaborators not already included', () => {
+    const contributorIds = ['1', '2', '3', '4']
+    const discussion = FactoryDiscussion({ contributorIds })
+    const comment = FactoryDiscussionComment()
+    const parentContent = FactoryResearchItem()
+    const bonusIds = ['1', 'new-id']
+
+    const toNotify = getDiscussionContributorsToNotify(
+      discussion,
+      parentContent,
+      comment,
+      bonusIds,
+    )
+    const expectation = [parentContent._createdBy, ...contributorIds, 'new-id']
+
+    expect(toNotify).toEqual(expectation)
+  })
+})

--- a/src/utils/getDiscussionContributorsToNotify.ts
+++ b/src/utils/getDiscussionContributorsToNotify.ts
@@ -1,0 +1,23 @@
+import type {
+  IComment,
+  IDiscussion,
+  IDiscussionSourceModelOptions,
+} from 'src/models'
+
+export const getDiscussionContributorsToNotify = (
+  discussion: IDiscussion,
+  parentContent: IDiscussionSourceModelOptions,
+  comment: IComment,
+  bonusIds?: string[] | undefined,
+) => {
+  const allRecipients = [
+    parentContent._createdBy,
+    ...(discussion.contributorIds || []),
+    ...(bonusIds || []),
+  ]
+  const removeNewCommentCreator =
+    allRecipients?.filter((id) => id !== comment._creatorId) || []
+  const uniqueIds = [...new Set(removeNewCommentCreator)]
+
+  return uniqueIds
+}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the current behavior?

When a new discussion item is added, only the "comment parent" is notificied (content creator for comments, comment creator for replies). Plus for research, the research collaborators are notified. Therefore in most instances a new comment notifies only one person.

## What is the new behavior?

Now all users who have participated in the discussion will be notified... 
