### PR TITLE
fix: saving a research article as a draft does not trigger webhook

### DIFF
--- a/functions/src/Integrations/firebase-discord.test.ts
+++ b/functions/src/Integrations/firebase-discord.test.ts
@@ -1,3 +1,4 @@
+import { ResearchUpdateStatus } from 'oa-shared'
 import { handleResearchUpdatePublished } from './firebase-discord'
 
 import type { SimpleResearchArticle } from './firebase-discord'
@@ -54,6 +55,39 @@ describe('handle research article update change', () => {
           _id: 'bobmore',
           title: 'test',
           collaborators: ['Bob'],
+        },
+      ],
+    }
+
+    let wasMockSendMessagedCalled = false
+    const mockSendMessage = (_: string): Promise<any> => {
+      wasMockSendMessagedCalled = true
+      return Promise.resolve()
+    }
+
+    handleResearchUpdatePublished(
+      webhookUrl,
+      previousContent,
+      newContent,
+      mockSendMessage,
+    )
+    expect(wasMockSendMessagedCalled).toEqual(false)
+  })
+
+  it('should not send message when update is a draft', () => {
+    const webhookUrl = 'exmaple.com'
+    const previousContent: SimpleResearchArticle = {
+      slug: 'test',
+      updates: [],
+    }
+    const newContent: SimpleResearchArticle = {
+      slug: 'test',
+      updates: [
+        {
+          _id: 'bobmore',
+          title: 'test',
+          collaborators: ['Bob'],
+          status: ResearchUpdateStatus.DRAFT,
         },
       ],
     }

--- a/functions/src/Integrations/firebase-discord.ts
+++ b/functions/src/Integrations/firebase-discord.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import * as functions from 'firebase-functions'
-import { IModerationStatus } from 'oa-shared'
+import { IModerationStatus, ResearchUpdateStatus } from 'oa-shared'
 
 import { CONFIG } from '../config/config'
 
@@ -78,6 +78,7 @@ interface SimpleResearchArticleUpdate {
   _id: string
   title: string
   collaborators?: string[]
+  status?: ResearchUpdateStatus
 }
 
 export async function handleResearchUpdatePublished(
@@ -98,6 +99,11 @@ export async function handleResearchUpdatePublished(
 
   const newUpdateIndex = updatedContent.updates.length - 1
   const newUpdate = updatedContent.updates[newUpdateIndex]
+
+  if (newUpdate.status === ResearchUpdateStatus.DRAFT) {
+    console.log('Update is a draft')
+    return
+  }
 
   // On Research Updates, we actually expect the collaborators to be a single person
   // but it is a list.


### PR DESCRIPTION
## PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
Saving a research article as a draft triggers the discord webhook

## What is the new behavior?
Saving a research article as a draft does not trigger the discord webhook

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Git Issues

Closes #3740

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
