### PR TITLE
fix: make edit and delete comment button subtle

### DIFF
--- a/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
+++ b/packages/components/src/ButtonShowReplies/ButtonShowReplies.tsx
@@ -24,8 +24,8 @@ export const ButtonShowReplies = (props: Props) => {
       data-cy="show-replies"
       icon={icon}
       onClick={setIsShowReplies}
-      sx={{ alignSelf: 'flex-start', border: 'none' }}
-      variant="outline"
+      sx={{ alignSelf: 'flex-start' }}
+      variant="subtle"
       small
     >
       {text} {creatorName && ` to ${creatorName}`}

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -118,9 +118,8 @@ export const CommentItem = (props: IProps) => {
             >
               <Flex
                 sx={{
-                  alignItems: 'stretch',
                   flexWrap: 'wrap',
-                  justifyContent: 'flex-start',
+                  justifyContent: 'space-between',
                   flexDirection: ['column', 'row'],
                   gap: 2,
                 }}
@@ -144,39 +143,31 @@ export const CommentItem = (props: IProps) => {
                 {isEditable && (
                   <Flex
                     sx={{
-                      flexGrow: 1,
-                      justifyContent: ['flex-start', 'flex-end'],
-                      position: ['static', 'relative'],
+                      alignItems: 'flex-end',
+                      gap: 2,
+                      paddingBottom: 2,
                     }}
                   >
-                    <Flex
-                      sx={{
-                        gap: 2,
-                        position: ['static', 'absolute'],
-                        right: 0,
-                      }}
+                    <Button
+                      type="button"
+                      data-cy={`${item}: edit button`}
+                      variant="subtle"
+                      small={true}
+                      icon="edit"
+                      onClick={() => onEditRequest(_id)}
                     >
-                      <Button
-                        type="button"
-                        data-cy={`${item}: edit button`}
-                        variant="subtle"
-                        small={true}
-                        icon="edit"
-                        onClick={() => onEditRequest(_id)}
-                      >
-                        edit
-                      </Button>
-                      <Button
-                        type="button"
-                        data-cy={`${item}: delete button`}
-                        variant="subtle"
-                        small={true}
-                        icon="delete"
-                        onClick={() => setShowDeleteModal(true)}
-                      >
-                        delete
-                      </Button>
-                    </Flex>
+                      edit
+                    </Button>
+                    <Button
+                      type="button"
+                      data-cy={`${item}: delete button`}
+                      variant="subtle"
+                      small={true}
+                      icon="delete"
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      delete
+                    </Button>
                   </Flex>
                 )}
               </Flex>

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -147,14 +147,12 @@ export const CommentItem = (props: IProps) => {
                       flexGrow: 1,
                       gap: 2,
                       justifyContent: ['flex-start', 'flex-end'],
-                      opacity: 0.5,
-                      ':hover': { opacity: 1 },
                     }}
                   >
                     <Button
                       type="button"
                       data-cy={`${item}: edit button`}
-                      variant="outline"
+                      variant="subtle"
                       small={true}
                       icon="edit"
                       onClick={() => onEditRequest(_id)}
@@ -164,7 +162,7 @@ export const CommentItem = (props: IProps) => {
                     <Button
                       type="button"
                       data-cy={`${item}: delete button`}
-                      variant={'outline'}
+                      variant="subtle"
                       small={true}
                       icon="delete"
                       onClick={() => setShowDeleteModal(true)}

--- a/packages/components/src/CommentItem/CommentItem.tsx
+++ b/packages/components/src/CommentItem/CommentItem.tsx
@@ -98,7 +98,7 @@ export const CommentItem = (props: IProps) => {
         )}
 
         {!_deleted && (
-          <Flex sx={{ gap: 2 }}>
+          <Flex sx={{ gap: 2, flexGrow: 1 }}>
             <Box data-cy="commentAvatar" data-testid="commentAvatar">
               <Avatar
                 src={creatorImage ?? defaultProfileImage}
@@ -145,30 +145,38 @@ export const CommentItem = (props: IProps) => {
                   <Flex
                     sx={{
                       flexGrow: 1,
-                      gap: 2,
                       justifyContent: ['flex-start', 'flex-end'],
+                      position: ['static', 'relative'],
                     }}
                   >
-                    <Button
-                      type="button"
-                      data-cy={`${item}: edit button`}
-                      variant="subtle"
-                      small={true}
-                      icon="edit"
-                      onClick={() => onEditRequest(_id)}
+                    <Flex
+                      sx={{
+                        gap: 2,
+                        position: ['static', 'absolute'],
+                        right: 0,
+                      }}
                     >
-                      edit
-                    </Button>
-                    <Button
-                      type="button"
-                      data-cy={`${item}: delete button`}
-                      variant="subtle"
-                      small={true}
-                      icon="delete"
-                      onClick={() => setShowDeleteModal(true)}
-                    >
-                      delete
-                    </Button>
+                      <Button
+                        type="button"
+                        data-cy={`${item}: edit button`}
+                        variant="subtle"
+                        small={true}
+                        icon="edit"
+                        onClick={() => onEditRequest(_id)}
+                      >
+                        edit
+                      </Button>
+                      <Button
+                        type="button"
+                        data-cy={`${item}: delete button`}
+                        variant="subtle"
+                        small={true}
+                        icon="delete"
+                        onClick={() => setShowDeleteModal(true)}
+                      >
+                        delete
+                      </Button>
+                    </Flex>
                   </Flex>
                 )}
               </Flex>

--- a/packages/themes/src/common/button.ts
+++ b/packages/themes/src/common/button.ts
@@ -18,32 +18,32 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
   primary: {
     ...BASE_BUTTON,
     color: colors.black,
-    bg: colors.accent.base,
+    backgroundColor: colors.accent.base,
     '&:hover': {
-      bg: colors.accent.hover,
+      backgroundColor: colors.accent.hover,
     },
     '&[disabled]': {
       opacity: 0.5,
       cursor: 'not-allowed',
     },
     '&[disabled]:hover': {
-      bg: colors.accent.base,
+      backgroundColor: colors.accent.base,
     },
   },
   secondary: {
     ...BASE_BUTTON,
     border: '2px solid ' + colors.black,
     color: colors.black,
-    bg: colors.softblue,
+    backgroundColor: colors.softblue,
     '&:hover': {
-      bg: colors.white,
+      backgroundColor: colors.white,
       cursor: 'pointer',
     },
     '&[disabled]': {
       opacity: 0.5,
     },
     '&[disabled]:hover': {
-      bg: colors.softblue,
+      backgroundColor: colors.softblue,
     },
   },
   destructive: {
@@ -81,18 +81,17 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
   },
   subtle: {
     ...BASE_BUTTON,
-    borderColor: colors.softblue,
+    borderWidth: 0,
     color: colors.black,
-    bg: colors.softblue,
+    backgroundColor: 'transparent',
     '&:hover': {
-      bg: colors.offwhite,
-      borderColor: colors.offwhite,
+      backgroundColor: colors.softblue,
     },
     '&[disabled]': {
       opacity: 0.5,
     },
     '&[disabled]:hover': {
-      bg: colors.softblue,
+      backgroundColor: colors.softblue,
     },
   },
   breadcrumb: {

--- a/src/common/HideDiscussionContainer.tsx
+++ b/src/common/HideDiscussionContainer.tsx
@@ -48,6 +48,7 @@ export const HideDiscussionContainer = ({
           textAlign: 'center',
           display: 'block',
           marginBottom: viewComments ? 2 : 0,
+          '&:hover': { bg: '#ececec' },
         }}
         onClick={() => setViewComments((prev) => !prev)}
         backgroundColor={viewComments ? '#c2daf0' : '#e2edf7'}


### PR DESCRIPTION
## PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [X] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
- Edit and Delete comment buttons use outlined variant
- Edit and Delete comment buttons increase the spacing between the username and the comment text


## What is the new behavior?

### Commit 1 [fix: make edit and delete comment button subtle](https://github.com/ONEARMY/community-platform/pull/3835/commits/48ac5c60f84ad41f4dbd764634c897ee3a6bf1f1)

Edit and Delete comment buttons use subtle variant:
![image](https://github.com/user-attachments/assets/c944729b-d0e3-4523-9bad-7c0f9b3f9d25)
on hover:
![image](https://github.com/user-attachments/assets/17137d08-6b87-4159-86aa-c1de9a0b377f)

Updated  [button.ts](https://github.com/ONEARMY/community-platform/compare/master...onim-at:3651-comment-button?expand=1#diff-55ca3b7df8d945246670eada2c5f2cd5061d1ee57aafacd6c1374495054f53dd) subtle variant to be consistent with the changes done in #3675 

Updated [HideDiscussionContainer.tsx](https://github.com/ONEARMY/community-platform/compare/master...onim-at:3651-comment-button?expand=1#diff-6663f7705972fd1b641a8cd254882f3c09a31c1d3b37d167bd8a78472ea3ff34) to avoid regression due to the button component changes

### Commit 2 [fix: edit and delete comment position does not increase spacing](https://github.com/ONEARMY/community-platform/pull/3835/commits/037bffad53e4ffe07ed943acb8fce40486fe3f71)

Comment with edit and delete buttons height:
![image](https://github.com/user-attachments/assets/5f1b07a2-a88b-49ae-a7a9-f15b14120899)

Comment without buttons height:
![image](https://github.com/user-attachments/assets/63f227ea-8a1c-4d5c-95aa-2668876935a0)

Bonus: the buttons have been moved to the right as per [figma design](https://www.figma.com/board/GfQPMs7PyC7jbkymDTco2D/CP-%2F-Nested-Comments-Improvements?node-id=0-1&node-type=CANVAS)

### Mobile view
<details>
<summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/fa847cd8-fd1b-46d8-9e8a-7134a4a8528c)

</details>

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Git Issues

Closes #3651

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
