### PR TITLE
feat: add responsive views for new map

### DIFF
--- a/packages/components/assets/icons/step.svg
+++ b/packages/components/assets/icons/step.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 4.5H15.75" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 9H15.75" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 13.5H15.75" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.25 4.5H2.2575" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.25 9H2.2575" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.25 13.5H2.2575" stroke="#1B1B1B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/components/src/CardList/CardList.stories.tsx
+++ b/packages/components/src/CardList/CardList.stories.tsx
@@ -16,15 +16,17 @@ const allItems = [
 ]
 
 export const Default: StoryFn<typeof CardList> = () => {
-  return <CardList list={allItems} filteredList={null} />
+  return <CardList dataCy="stories" list={allItems} filteredList={null} />
 }
 
 export const FiltedDisplay: StoryFn<typeof CardList> = () => {
   const filteredList = [allItems[0], allItems[2]]
 
-  return <CardList list={allItems} filteredList={filteredList} />
+  return (
+    <CardList dataCy="stories" list={allItems} filteredList={filteredList} />
+  )
 }
 
 export const WhenFiltedDisplayIsZero: StoryFn<typeof CardList> = () => {
-  return <CardList list={allItems} filteredList={[]} />
+  return <CardList dataCy="stories" list={allItems} filteredList={[]} />
 }

--- a/packages/components/src/CardList/CardList.tsx
+++ b/packages/components/src/CardList/CardList.tsx
@@ -1,4 +1,4 @@
-import Masonry from 'react-responsive-masonry'
+import Masonry, { ResponsiveMasonry } from 'react-responsive-masonry'
 import { Flex, Text } from 'theme-ui'
 
 import { CardListItem } from '../CardListItem/CardListItem'
@@ -8,6 +8,8 @@ import { Loader } from '../Loader/Loader'
 import type { ListItem } from '../CardListItem/types'
 
 export interface IProps {
+  columnsCountBreakPoints?: { [key: number]: number }
+  dataCy: string
   filteredList: ListItem[] | null
   list: ListItem[]
 }
@@ -15,7 +17,7 @@ export interface IProps {
 export const EMPTY_LIST = 'Oh nos! Nothing to show!'
 
 export const CardList = (props: IProps) => {
-  const { filteredList, list } = props
+  const { columnsCountBreakPoints, dataCy, filteredList, list } = props
 
   const listToShow = filteredList === null ? list : filteredList
   const displayItems = listToShow
@@ -34,7 +36,7 @@ export const CardList = (props: IProps) => {
 
   return (
     <Flex
-      data-cy="CardList"
+      data-cy={`CardList-${dataCy}`}
       sx={{
         flexDirection: 'column',
         gap: 2,
@@ -57,7 +59,17 @@ export const CardList = (props: IProps) => {
             </Flex>
           </Flex>
           {isListEmpty && EMPTY_LIST}
-          {!isListEmpty && <Masonry columnsCount={2}>{displayItems}</Masonry>}
+          {!isListEmpty && (
+            <ResponsiveMasonry
+              columnsCountBreakPoints={
+                columnsCountBreakPoints
+                  ? columnsCountBreakPoints
+                  : { 600: 1, 1100: 2, 1600: 3 }
+              }
+            >
+              <Masonry>{displayItems}</Masonry>
+            </ResponsiveMasonry>
+          )}
         </>
       )}
     </Flex>

--- a/packages/components/src/Icon/Icon.tsx
+++ b/packages/components/src/Icon/Icon.tsx
@@ -21,7 +21,6 @@ import { MdEdit } from '@react-icons/all-files/md/MdEdit'
 import { MdFileDownload } from '@react-icons/all-files/md/MdFileDownload'
 import { MdImage } from '@react-icons/all-files/md/MdImage'
 import { MdKeyboardArrowDown } from '@react-icons/all-files/md/MdKeyboardArrowDown'
-import { MdList } from '@react-icons/all-files/md/MdList'
 import { MdLocationOn } from '@react-icons/all-files/md/MdLocationOn'
 import { MdLock } from '@react-icons/all-files/md/MdLock'
 import { MdMail } from '@react-icons/all-files/md/MdMail'
@@ -109,7 +108,7 @@ export const glyphs: IGlyphs = {
   slack: <FaSlack />,
   star: iconMap.star,
   'star-active': iconMap.starActive,
-  step: <MdList />,
+  step: iconMap.step,
   thunderbolt: iconMap.thunderbolt,
   'thunderbolt-grey': iconMap.thunderboltGrey,
   time: <MdAccessTime />,

--- a/packages/components/src/Icon/svgs.tsx
+++ b/packages/components/src/Icon/svgs.tsx
@@ -29,6 +29,7 @@ import patreonSVG from '../../assets/icons/patreon.svg'
 import plasticSVG from '../../assets/icons/plastic.svg'
 import profileSVG from '../../assets/icons/profile.svg'
 import revenueSVG from '../../assets/icons/revenue.svg'
+import stepSVG from '../../assets/icons/step.svg'
 import supporterSVG from '../../assets/icons/supporter.svg'
 import thunderboltSVG from '../../assets/icons/thunderbolt.svg'
 import thunderboltGreySVG from '../../assets/icons/thunderbolt-grey.svg'
@@ -74,6 +75,7 @@ export const iconMap = {
   socialMedia: <ImageIcon src={socialMediaSVG} />,
   star: <ImageIcon src={starSVG} />,
   starActive: <ImageIcon src={starActiveSVG} />,
+  step: <ImageIcon src={stepSVG} />,
   supporter: <ImageIcon src={supporterSVG} />,
   thunderbolt: <ImageIcon src={thunderboltSVG} />,
   thunderboltGrey: <ImageIcon src={thunderboltGreySVG} />,

--- a/packages/cypress/src/integration/map.spec.ts
+++ b/packages/cypress/src/integration/map.spec.ts
@@ -19,16 +19,13 @@ describe('[Map]', () => {
     cy.get('[data-cy=MapMemberCard]').should('not.exist')
     cy.url().should('not.include', `#${userId}`)
 
-    cy.step('Link to new map only visible and clickable on desktop')
-    cy.viewport('samsung-note9')
-    cy.get('[data-cy=Banner]').should('not.be.visible')
-    cy.viewport('ipad-2')
-    cy.get('[data-cy=Banner]').should('not.be.visible')
-    cy.viewport('macbook-16')
+    cy.step('Link to new map visible and clickable')
     cy.get('[data-cy=Banner]').contains('Test it out!').click()
+    cy.get('[data-cy=Banner]').contains('go back to the old one!')
 
     cy.step('New map shows the cards')
     cy.get('[data-cy="welome-header"]').should('be.visible')
+    cy.get('[data-cy="CardList-desktop"]').should('be.visible')
     cy.get('[data-cy="list-results"]').contains('51 results')
 
     cy.step('As the user moves in the list updates')
@@ -36,13 +33,15 @@ describe('[Map]', () => {
       cy.get('.leaflet-control-zoom-in').click()
     }
     cy.get('[data-cy="list-results"]').contains('1 result')
-    cy.get('[data-cy=CardListItem]')
-      .within(() => {
-        cy.contains(userId)
-        cy.get('[data-cy="MemberBadge-member"]')
-      })
-      .should('have.attr', 'href')
-      .and('include', `/u/${userId}`)
+    cy.get('[data-cy="CardList-desktop"]').within(() => {
+      cy.get('[data-cy=CardListItem]')
+        .within(() => {
+          cy.contains(userId)
+          cy.get('[data-cy="MemberBadge-member"]')
+        })
+        .should('have.attr', 'href')
+        .and('include', `/u/${userId}`)
+    })
 
     cy.step('New map pins can be clicked on')
     cy.get(`[data-cy=pin-${userId}]`).click()
@@ -55,5 +54,24 @@ describe('[Map]', () => {
     cy.get('.markercluster-map').click(0, 0)
     cy.get('[data-cy=MapMemberCard]').should('not.exist')
     cy.url().should('not.include', `#${userId}`)
+
+    cy.step('Mobile list view can be shown/hidden')
+    cy.viewport('samsung-note9')
+    cy.get('[data-cy="CardList-desktop"]').should('not.be.visible')
+    cy.get('[data-cy="CardList-mobile"]').should('not.be.visible')
+
+    cy.get('[data-cy="ShowMobileListButton"]').click()
+    cy.get('[data-cy="CardList-mobile"]').within(() => {
+      cy.get('[data-cy=CardListItem]')
+        .within(() => {
+          cy.contains(userId)
+          cy.get('[data-cy="MemberBadge-member"]')
+        })
+        .should('have.attr', 'href')
+        .and('include', `/u/${userId}`)
+    })
+
+    cy.get('[data-cy="ShowMapButton"]').click()
+    cy.get('[data-cy="CardList-mobile"]').should('not.be.visible')
   })
 })

--- a/src/pages/Maps/Content/Controls/Controls.tsx
+++ b/src/pages/Maps/Content/Controls/Controls.tsx
@@ -61,7 +61,7 @@ export const Controls = ({
         justifyContent: 'center',
         width: '100%',
         position: 'absolute',
-        top: ['25px', '25px', '25px', '60px'],
+        top: '60px',
         zIndex: 2000,
         transform: 'translateX("-50%")',
       }}

--- a/src/pages/Maps/Content/MapView/MapWithList.tsx
+++ b/src/pages/Maps/Content/MapView/MapWithList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { CardList, Map } from 'oa-components'
+import { Button, CardList, Map } from 'oa-components'
 import { Box, Flex, Heading } from 'theme-ui'
 
 import { Clusters } from './Cluster'
@@ -15,6 +15,7 @@ interface IProps {
   activePin: IMapPin | null
   center: ILatLng
   mapRef: React.RefObject<MapType>
+  notification?: string
   pins: IMapPin[]
   zoom: number
   onPinClicked: (pin: IMapPin) => void
@@ -24,10 +25,12 @@ interface IProps {
 
 export const MapWithList = (props: IProps) => {
   const [filteredPins, setFilteredPins] = useState<IMapPin[] | null>(null)
+  const [showMobileList, setShowMobileList] = useState<boolean>(false)
   const {
     activePin,
     center,
     mapRef,
+    notification,
     onBlur,
     onPinClicked,
     pins,
@@ -48,6 +51,8 @@ export const MapWithList = (props: IProps) => {
   const mapCenter: LatLngExpression = center ? [center.lat, center.lng] : [0, 0]
   const mapZoom = center ? zoom : 2
 
+  const mobileListDisplay = showMobileList ? 'block' : 'none'
+
   return (
     <Flex
       sx={{
@@ -55,8 +60,10 @@ export const MapWithList = (props: IProps) => {
         height: '100%',
       }}
     >
+      {/* Desktop list view */}
       <Box
         sx={{
+          display: ['none', 'none', 'block', 'block'],
           background: 'white',
           flex: 1,
           overflow: 'scroll',
@@ -67,8 +74,55 @@ export const MapWithList = (props: IProps) => {
           Welcome to our world!{' '}
           {pins && `${pins.length} members (and counting...)`}
         </Heading>
-        <CardList list={pins} filteredList={filteredPins} />
+        <CardList dataCy="desktop" list={pins} filteredList={filteredPins} />
       </Box>
+
+      {/* Mobile/tablet list view */}
+      <Box
+        sx={{
+          display: [mobileListDisplay, mobileListDisplay, 'none', 'none'],
+          background: 'white',
+          width: '100%',
+          overflow: 'scroll',
+          padding: 2,
+        }}
+      >
+        <Flex
+          sx={{
+            justifyContent: 'center',
+            paddingBottom: 2,
+            position: 'absolute',
+            zIndex: 1000,
+            width: '100%',
+          }}
+        >
+          <Button
+            data-cy="ShowMapButton"
+            icon="map"
+            sx={{ position: 'sticky' }}
+            onClick={() => setShowMobileList(false)}
+            small
+          >
+            Show map view
+          </Button>
+        </Flex>
+        <Heading
+          data-cy="welome-header"
+          variant="small"
+          sx={{ padding: 2, paddingTop: '50px' }}
+        >
+          Welcome to our world!{' '}
+          {pins && `${pins.length} members (and counting...)`}
+        </Heading>
+        <CardList
+          columnsCountBreakPoints={{ 300: 1, 600: 2 }}
+          dataCy="mobile"
+          list={pins}
+          filteredList={filteredPins}
+        />
+      </Box>
+
+      {/* Same map for all viewports */}
       <Map
         ref={mapRef}
         className="markercluster-map"
@@ -82,6 +136,29 @@ export const MapWithList = (props: IProps) => {
         ondragend={handleLocationFilter}
         onzoomend={handleLocationFilter}
       >
+        <Flex
+          sx={{
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: 2,
+            gap: 2,
+          }}
+        >
+          <Button
+            data-cy="ShowMobileListButton"
+            icon="step"
+            sx={{ display: ['flex', 'flex', 'none'], zIndex: 1000 }}
+            onClick={() => setShowMobileList(true)}
+            small
+          >
+            Show list view
+          </Button>
+          {notification && notification !== '' && (
+            <Button sx={{ zIndex: 1000 }} variant="subtle">
+              {notification}
+            </Button>
+          )}
+        </Flex>
         <Clusters pins={pins} onPinClick={onPinClicked} prefix="new" />
         {activePin && <Popup activePin={activePin} mapRef={mapRef} />}
       </Map>

--- a/src/pages/Maps/Content/NewMapBanner.tsx
+++ b/src/pages/Maps/Content/NewMapBanner.tsx
@@ -1,5 +1,5 @@
-import { Banner, ExternalLink } from 'oa-components'
-import { Text } from 'theme-ui'
+import { Banner, ExternalLink, Icon } from 'oa-components'
+import { Flex, Text } from 'theme-ui'
 
 interface IProps {
   showNewMap: boolean
@@ -9,29 +9,30 @@ interface IProps {
 export const NewMapBanner = (props: IProps) => {
   const { showNewMap, setShowNewMap } = props
   const sx = { '&:hover': { textDecoration: 'underline', cursor: 'pointer' } }
+
   return (
-    <Banner
-      variant="accent"
-      sx={{ display: ['none', 'none', 'none', 'inherit'] }}
-    >
-      {showNewMap ? (
-        <Text>
-          🗺 We're still working on this.{' '}
-          <ExternalLink
-            href="https://github.com/ONEARMY/community-platform"
-            sx={{ ...sx, color: 'black', fontWeight: 'bold' }}
-          >
-            Help us develop it
-          </ExternalLink>{' '}
-          <Text onClick={() => setShowNewMap(false)} sx={sx}>
-            or go back to the old one!
+    <Banner variant="accent">
+      <Flex sx={{ justifyItems: 'center', gap: 1 }}>
+        <Icon glyph="map" />
+        {showNewMap ? (
+          <Text>
+            We're still working on this.{' '}
+            <ExternalLink
+              href="https://github.com/ONEARMY/community-platform"
+              sx={{ ...sx, color: 'black', fontWeight: 'bold' }}
+            >
+              Help us develop it
+            </ExternalLink>{' '}
+            <Text onClick={() => setShowNewMap(false)} sx={sx}>
+              or go back to the old one!
+            </Text>
           </Text>
-        </Text>
-      ) : (
-        <Text onClick={() => setShowNewMap(true)} sx={sx}>
-          🗺 We're developing new map interface. Test it out!
-        </Text>
-      )}
+        ) : (
+          <Text onClick={() => setShowNewMap(true)} sx={sx}>
+            We're developing new map interface. Test it out!
+          </Text>
+        )}
+      </Flex>
     </Banner>
   )
 }

--- a/src/pages/Maps/Maps.tsx
+++ b/src/pages/Maps/Maps.tsx
@@ -1,11 +1,10 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { observer } from 'mobx-react'
-import { Button } from 'oa-components'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { filterMapPinsByType } from 'src/stores/Maps/filter'
 import { MAP_GROUPINGS } from 'src/stores/Maps/maps.groupings'
-import { Box, Flex } from 'theme-ui'
+import { Box } from 'theme-ui'
 
 import { logger } from '../../logger'
 import { transformAvailableFiltersToGroups } from './Content/Controls/transformAvailableFiltersToGroups'
@@ -28,6 +27,7 @@ const MapsPage = observer(() => {
   const [activePinFilters, setActivePinFilters] = useState<string[]>([])
   const [center, setCenter] = useState<ILatLng>(INITIAL_CENTER)
   const [mapPins, setMapPins] = useState<IMapPin[]>([])
+  const [notification, setNotification] = useState<string>('')
   const [selectedPin, setSelectedPin] = useState<IMapPin | null>(null)
   const [showNewMap, setShowNewMap] = useState<boolean>(false)
   const [zoom, setZoom] = useState<number>(INITIAL_ZOOM)
@@ -46,8 +46,10 @@ const MapsPage = observer(() => {
   }
 
   const fetchMapPins = async () => {
+    setNotification('Loading...')
     const pins = await mapPinService.getMapPins()
-    setMapPins([...mapPins, ...pins])
+    setMapPins(pins)
+    setNotification('')
   }
 
   useEffect(() => {
@@ -67,9 +69,7 @@ const MapsPage = observer(() => {
   }, [user])
 
   useEffect(() => {
-    if (mapPins.length === 0) {
-      fetchMapPins()
-    }
+    fetchMapPins()
 
     const showPin = async () => {
       await showPinFromURL()
@@ -153,7 +153,7 @@ const MapsPage = observer(() => {
 
   return (
     // the calculation for the height is kind of hacky for now, will set properly on final mockups
-    <Box id="mapPage" sx={{ height: 'calc(100vh - 80px)', width: '100%' }}>
+    <Box id="mapPage" sx={{ height: 'calc(100vh - 150px)', width: '100%' }}>
       <NewMapBanner showNewMap={showNewMap} setShowNewMap={setShowNewMap} />
       {!showNewMap && (
         <>
@@ -179,40 +179,19 @@ const MapsPage = observer(() => {
         </>
       )}
       {showNewMap && (
-        <>
-          <Flex
-            sx={{
-              display: ['none', 'none', 'none', 'inherit'],
-              flexDirection: 'row',
-              height: '100%',
-            }}
-          >
-            <MapWithList
-              activePin={selectedPin}
-              mapRef={newMapRef}
-              pins={visibleMapPins}
-              onPinClicked={(pin) => {
-                getPinByUserId(pin._id)
-              }}
-              onBlur={onBlur}
-              center={center}
-              zoom={zoom}
-              setZoom={setZoom}
-            />
-          </Flex>
-          <Box
-            sx={{
-              display: ['inherit', 'inherit', 'inherit', 'none'],
-              padding: 2,
-              justifyContent: 'center',
-            }}
-          >
-            Not yet setup of this size screen yet, but we will be very soon!{' '}
-            <Button onClick={() => setShowNewMap(!showNewMap)}>
-              Back to the old map
-            </Button>
-          </Box>
-        </>
+        <MapWithList
+          activePin={selectedPin}
+          center={center}
+          mapRef={newMapRef}
+          notification={notification}
+          onPinClicked={(pin) => {
+            getPinByUserId(pin._id)
+          }}
+          onBlur={onBlur}
+          pins={visibleMapPins}
+          setZoom={setZoom}
+          zoom={zoom}
+        />
       )}
     </Box>
   )


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [x] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
No new map at mobile/tablet viewports.

## What is the new behavior?

1. Map at mobile/tablet viewports (with button).
2. Quick loading indicator.
3. Updated map icon on banner.

<img width="1903" alt="Screenshot 2024-09-02 at 14 15 42" src="https://github.com/user-attachments/assets/476eacf3-377b-48a3-a7ee-e843f1c5270e">

<img width="1576" alt="Screenshot 2024-09-02 at 14 15 56" src="https://github.com/user-attachments/assets/dc6662e6-2fe4-405a-a886-cc48cca8d9d6">

<img width="1085" alt="Screenshot 2024-09-02 at 14 16 14" src="https://github.com/user-attachments/assets/fe4d6697-a266-4756-bdfe-0d09124a6fa9">

<img width="776" alt="Screenshot 2024-09-02 at 14 17 02" src="https://github.com/user-attachments/assets/649c4c38-aa4a-4928-b98a-06e428acb311">

<img width="547" alt="Screenshot 2024-09-02 at 14 17 20" src="https://github.com/user-attachments/assets/fc36842f-3563-4f43-a512-9d7446e612e6">

<img width="743" alt="Screenshot 2024-09-02 at 14 20 28" src="https://github.com/user-attachments/assets/78b88d5f-a205-42d5-8be8-51467e6a8d12">

