### PR TITLE
feat: use cdn images for map pin calls

### DIFF
--- a/packages/components/src/CardListItem/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardListItem/CardDetailsMemberProfile.tsx
@@ -4,7 +4,7 @@ import { Category } from '../Category/Category'
 import { MemberBadge } from '../MemberBadge/MemberBadge'
 import { Username } from '../Username/Username'
 
-import type { IProfileCreator } from './types'
+import type { IProfileCreator } from 'oa-shared'
 
 interface IProps {
   creator: IProfileCreator

--- a/packages/components/src/CardListItem/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardListItem/CardDetailsSpaceProfile.tsx
@@ -4,7 +4,7 @@ import { Category } from '../Category/Category'
 import { MemberBadge } from '../MemberBadge/MemberBadge'
 import { Username } from '../Username/Username'
 
-import type { IProfileCreator } from './types'
+import type { IProfileCreator } from 'oa-shared'
 
 interface IProps {
   creator: IProfileCreator

--- a/packages/components/src/CardListItem/types.ts
+++ b/packages/components/src/CardListItem/types.ts
@@ -1,23 +1,4 @@
-import type { ProfileTypeName } from 'oa-shared'
-
-type UserBadges = {
-  verified: boolean
-  supporter: boolean
-}
-
-export interface IProfileCreator {
-  _id: string
-  _lastActive: string
-  about?: string
-  badges?: UserBadges
-  countryCode: string
-  coverImage?: string
-  displayName: string
-  isContactableByPublic: boolean
-  profileType: ProfileTypeName
-  subType?: string
-  userImage?: string
-}
+import type { IProfileCreator, ProfileTypeName } from 'oa-shared'
 
 export interface ListItem {
   _id: string

--- a/shared/models/maps.ts
+++ b/shared/models/maps.ts
@@ -1,3 +1,10 @@
+import type { ProfileTypeName } from './user'
+
+type UserBadges = {
+  verified: boolean
+  supporter: boolean
+}
+
 export interface IBoundingBox {
   _northEast: ILatLng
   _southWest: ILatLng
@@ -22,4 +29,18 @@ export interface IMapPinDetail {
   profileUrl: string
   shortDescription: string
   verifiedBadge?: boolean
+}
+
+export interface IProfileCreator {
+  _id: string
+  _lastActive: string
+  about?: string
+  badges?: UserBadges
+  countryCode: string
+  coverImage?: string
+  displayName: string
+  isContactableByPublic: boolean
+  profileType: ProfileTypeName
+  subType?: string
+  userImage?: string
 }

--- a/src/models/maps.models.tsx
+++ b/src/models/maps.models.tsx
@@ -3,6 +3,7 @@ import type {
   IMapPinDetail,
   IModerationStatus,
   IPinGrouping,
+  IProfileCreator,
   ProfileTypeName,
 } from 'oa-shared'
 import type { WorkspaceType } from './userPreciousPlastic.models'
@@ -31,6 +32,7 @@ export interface IMapPin {
   verified: boolean
   subType?: IMapPinSubtype
   comments?: string
+  creator?: IProfileCreator
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)


## What is the current behavior?

Slow loading on prod of the workspace cover images for the map pin list.

## What is the new behavior?

Using the CDN smaller versions of the images should speed things up.
