### PR TITLE
feat: show clearly when research update is draft

### DIFF
--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -276,7 +276,6 @@ describe('[Research]', () => {
       cy.get('[data-cy=create]').click()
 
       cy.step('Enter research article details')
-
       cy.get('[data-cy=intro-title').clear().type(expected.title).blur()
       cy.get('[data-cy=intro-description]').clear().type(expected.description)
       cy.get('[data-cy=submit]').click()
@@ -313,6 +312,24 @@ describe('[Research]', () => {
       cy.visit(`/research/${expected.slug}`)
 
       cy.contains(updateTitle)
+      cy.get('[data-cy=DraftUpdateLabel]').should('be.visible')
+
+      cy.step('Draft not visible to others')
+      cy.logout()
+      cy.visit(`/research/${expected.slug}`)
+      cy.get(updateTitle).should('not.exist')
+      cy.get('[data-cy=DraftUpdateLabel]').should('not.exist')
+
+      cy.step('Draft updates can be published')
+      cy.login(researcherEmail, researcherPassword)
+      cy.visit(`/research/${expected.slug}`)
+      cy.get('[data-cy=edit-update]').click()
+      cy.contains('Edit your update')
+      cy.get('[data-cy=videoUrl]').clear().type(updateVideoUrl).blur()
+      cy.get('[data-cy=submit]').click()
+      cy.get('[data-cy=view-research]:enabled', { timeout: 20000 }).click()
+      cy.contains(updateTitle)
+      cy.get('[data-cy=DraftUpdateLabel]').should('not.exist')
     })
   })
 })

--- a/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
+++ b/src/pages/Research/Content/Common/ResearchUpdate.form.tsx
@@ -258,40 +258,14 @@ export const ResearchUpdateForm = observer((props: IProps) => {
                 px={2}
                 mt={[0, 0, 4]}
               >
-                <Box
+                <Flex
                   sx={{
+                    flexDirection: 'column',
                     position: ['relative', 'relative', 'sticky'],
-                    top: 3,
+                    gap: 3,
                     maxWidth: ['inherit', 'inherit', '400px'],
                   }}
                 >
-                  <Button
-                    data-cy="draft"
-                    onClick={() => {
-                      trySubmitForm(true)
-                    }}
-                    variant="secondary"
-                    type="submit"
-                    disabled={submitting}
-                    sx={{ width: '100%', display: 'block', mt: 0 }}
-                  >
-                    <span>{draftButtonText}</span>
-                  </Button>
-                  {isEdit ? (
-                    <Button
-                      data-cy="delete"
-                      onClick={(evt) => {
-                        setShowDeleteModal(true)
-                        evt.preventDefault()
-                      }}
-                      variant="destructive"
-                      type="submit"
-                      disabled={submitting}
-                      sx={{ width: '100%', display: 'block', mt: 3 }}
-                    >
-                      {deletion.text}
-                    </Button>
-                  ) : null}
                   <Button
                     large
                     id="submit-form"
@@ -305,14 +279,44 @@ export const ResearchUpdateForm = observer((props: IProps) => {
                     type="submit"
                     disabled={submitting}
                     sx={{
-                      mt: 3,
-                      mb: ['40px', '40px', 0],
-                      width: '100%',
+                      alignSelf: 'stretch',
                       justifyContent: 'center',
                     }}
                   >
-                    <span>{publishButtonText}</span>
+                    {publishButtonText}
                   </Button>
+
+                  <Button
+                    data-cy="draft"
+                    onClick={() => {
+                      trySubmitForm(true)
+                    }}
+                    variant="secondary"
+                    type="submit"
+                    sx={{
+                      alignSelf: 'stretch',
+                      justifyContent: 'center',
+                    }}
+                    disabled={submitting}
+                  >
+                    {draftButtonText}
+                  </Button>
+
+                  {isEdit ? (
+                    <Button
+                      data-cy="delete"
+                      onClick={(evt) => {
+                        setShowDeleteModal(true)
+                        evt.preventDefault()
+                      }}
+                      variant="destructive"
+                      type="submit"
+                      disabled={submitting}
+                      sx={{ alignSelf: 'stretch', justifyContent: 'center' }}
+                    >
+                      {deletion.text}
+                    </Button>
+                  ) : null}
 
                   <ResearchErrors
                     errors={errors}
@@ -322,7 +326,7 @@ export const ResearchUpdateForm = observer((props: IProps) => {
 
                   {store.activeResearchItem ? (
                     <ResearchEditorOverview
-                      sx={{ mt: 4 }}
+                      sx={{ mt: 2 }}
                       updates={getResearchUpdates(
                         store.activeResearchItem.updates || [],
                         store.activeResearchItem._id,
@@ -334,7 +338,7 @@ export const ResearchUpdateForm = observer((props: IProps) => {
                       showBackToResearchButton={true}
                     />
                   ) : null}
-                </Box>
+                </Flex>
               </Flex>
               <ConfirmModal
                 isOpen={showDeleteModal}

--- a/src/pages/Research/Content/ResearchArticle.tsx
+++ b/src/pages/Research/Content/ResearchArticle.tsx
@@ -213,7 +213,14 @@ const ResearchArticle = observer(() => {
           ).length || 0
         }
       />
-      <Box sx={{ marginTop: 8, marginBottom: 4 }}>
+      <Flex
+        sx={{
+          flexDirection: 'column',
+          marginTop: 8,
+          marginBottom: 4,
+          gap: [4, 6],
+        }}
+      >
         {item &&
           getPublicUpdates(item, researchStore.activeUser).map(
             (update, index) => (
@@ -227,7 +234,7 @@ const ResearchArticle = observer(() => {
               />
             ),
           )}
-      </Box>
+      </Flex>
 
       <UserEngagementWrapper>
         <Box

--- a/src/pages/Research/Content/ResearchUpdate.tsx
+++ b/src/pages/Research/Content/ResearchUpdate.tsx
@@ -6,6 +6,7 @@ import {
   DownloadStaticFile,
   ImageGallery,
   LinkifyText,
+  Tooltip,
   Username,
   VideoPlayer,
 } from 'oa-components'
@@ -41,6 +42,7 @@ const ResearchUpdate = (props: IProps) => {
     files,
     fileLink,
     images,
+    status,
     title,
     videoUrl,
   } = update
@@ -62,164 +64,190 @@ const ResearchUpdate = (props: IProps) => {
   }
 
   const displayNumber = updateIndex + 1
+  const isDraft = status == 'draft'
 
   return (
     <Flex
-      data-testid={`ResearchUpdate: ${_id}`}
-      data-cy={`ResearchUpdate: ${_id}`}
-      id={`update_${_id}`}
       sx={{
-        flexDirection: ['column', 'column', 'row'],
-        gap: [3, 6],
-        marginBottom: [6, 8],
+        flexDirection: 'column',
+        border: isDraft ? '2px dashed grey' : '',
+        borderRadius: 2,
+        padding: isDraft ? 2 : 0,
+        gap: 2,
       }}
     >
+      {isDraft && (
+        <>
+          <Button
+            data-cy="DraftUpdateLabel"
+            data-tip="Only visible to you (and other collaborators)"
+            sx={{ alignSelf: 'flex-start', backgroundColor: 'softblue' }}
+            variant="subtle"
+            small
+          >
+            Draft Update
+          </Button>
+          <Tooltip />
+        </>
+      )}
+
       <Flex
+        data-testid={`ResearchUpdate: ${_id}`}
+        data-cy={`ResearchUpdate: ${_id}`}
+        id={`update_${_id}`}
         sx={{
-          alignItems: 'center',
-          flexDirection: ['row', 'row', 'column'],
+          flexDirection: ['column', 'column', 'row'],
           gap: [2, 4],
         }}
       >
-        <Card sx={{ padding: [3, 4] }}>
-          <Heading sx={{ textAlign: 'center' }}>{displayNumber}</Heading>
-        </Card>
+        <Flex
+          sx={{
+            alignItems: 'center',
+            flexDirection: ['row', 'row', 'column'],
+            gap: [2, 4],
+          }}
+        >
+          <Card sx={{ padding: [3, 4] }}>
+            <Heading sx={{ textAlign: 'center' }}>{displayNumber}</Heading>
+          </Card>
 
-        {research && (
-          <ResearchLinkToUpdate research={research} update={update} />
-        )}
-      </Flex>
+          {research && (
+            <ResearchLinkToUpdate research={research} update={update} />
+          )}
+        </Flex>
 
-      <Flex
-        sx={{
-          width: '100%',
-          flexDirection: 'column',
-          flex: 9,
-          overflow: 'hidden',
-        }}
-      >
-        <Card>
-          <Flex sx={{ flexDirection: 'column' }} py={4} px={4}>
-            <Flex sx={{ flexDirection: ['column', 'row', 'row'] }}>
-              <Box sx={{ width: ['100%', '75%', '75%'] }}>
-                {contributors.length > 0 ? (
-                  <Box sx={{ mb: 2 }} data-testid="collaborator/creator">
-                    <Username user={contributors[0]} />
-                  </Box>
-                ) : null}
+        <Flex
+          sx={{
+            width: '100%',
+            flexDirection: 'column',
+            flex: 9,
+            overflow: 'hidden',
+          }}
+        >
+          <Card>
+            <Flex sx={{ flexDirection: 'column' }} py={4} px={4}>
+              <Flex sx={{ flexDirection: ['column', 'row', 'row'] }}>
+                <Box sx={{ width: ['100%', '75%', '75%'] }}>
+                  {contributors.length > 0 ? (
+                    <Box sx={{ mb: 2 }} data-testid="collaborator/creator">
+                      <Username user={contributors[0]} />
+                    </Box>
+                  ) : null}
 
-                <Heading as="h2" sx={{ mb: 2 }}>
-                  {title}
-                </Heading>
-              </Box>
+                  <Heading as="h2" sx={{ mb: 2 }}>
+                    {title}
+                  </Heading>
+                </Box>
 
-              <Flex
-                sx={{
-                  flexDirection: ['row', 'column', 'column'],
-                  width: ['100%', '25%', '25%'],
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-end',
-                }}
-              >
-                <Flex sx={{ flexDirection: ['column'] }}>
-                  <Text
-                    variant="auxiliary"
-                    sx={{
-                      textAlign: ['left', 'right', 'right'],
-                    }}
-                  >
-                    {'created ' + formattedCreateDatestamp}
-                  </Text>
-
-                  {formattedCreateDatestamp !== formattedModifiedDatestamp && (
+                <Flex
+                  sx={{
+                    flexDirection: ['row', 'column', 'column'],
+                    width: ['100%', '25%', '25%'],
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-end',
+                  }}
+                >
+                  <Flex sx={{ flexDirection: ['column'] }}>
                     <Text
                       variant="auxiliary"
                       sx={{
                         textAlign: ['left', 'right', 'right'],
                       }}
                     >
-                      {'edited ' + formattedModifiedDatestamp}
+                      {'created ' + formattedCreateDatestamp}
                     </Text>
+
+                    {formattedCreateDatestamp !==
+                      formattedModifiedDatestamp && (
+                      <Text
+                        variant="auxiliary"
+                        sx={{
+                          textAlign: ['left', 'right', 'right'],
+                        }}
+                      >
+                        {'edited ' + formattedModifiedDatestamp}
+                      </Text>
+                    )}
+                  </Flex>
+                  {/* Show edit button for the creator of the research OR a super-admin */}
+                  {isEditable && (
+                    <Link to={'/research/' + slug + '/edit-update/' + _id}>
+                      <Button
+                        type="button"
+                        variant="primary"
+                        data-cy="edit-update"
+                        ml="auto"
+                        mt={[0, 2, 2]}
+                      >
+                        Edit
+                      </Button>
+                    </Link>
                   )}
                 </Flex>
-                {/* Show edit button for the creator of the research OR a super-admin */}
-                {isEditable && (
-                  <Link to={'/research/' + slug + '/edit-update/' + _id}>
-                    <Button
-                      type="button"
-                      variant="primary"
-                      data-cy="edit-update"
-                      ml="auto"
-                      mt={[0, 2, 2]}
-                    >
-                      Edit
-                    </Button>
-                  </Link>
-                )}
               </Flex>
+              <Box>
+                <Text
+                  mt={3}
+                  variant="paragraph"
+                  color={'grey'}
+                  sx={{ whiteSpace: 'pre-line' }}
+                >
+                  <LinkifyText>{description}</LinkifyText>
+                </Text>
+              </Box>
             </Flex>
-            <Box>
-              <Text
-                mt={3}
-                variant="paragraph"
-                color={'grey'}
-                sx={{ whiteSpace: 'pre-line' }}
-              >
-                <LinkifyText>{description}</LinkifyText>
-              </Text>
-            </Box>
-          </Flex>
-          <Box sx={{ width: '100%' }}>
-            {videoUrl ? (
-              <VideoPlayer videoUrl={videoUrl} />
-            ) : (
-              <ImageGallery
-                images={formatImagesForGallery(images) as any}
-                allowPortrait={true}
-              />
-            )}
-          </Box>
-          {((files && files.length > 0) || fileLink) && (
-            <Flex
-              className="file-container"
-              mt={3}
-              sx={{ flexDirection: 'column', px: 4 }}
-            >
-              {fileLink && (
-                <DownloadFileFromLink
-                  handleClick={handleDownloadClick}
-                  link={fileLink}
-                  redirectToSignIn={
-                    !loggedInUser ? redirectToSignIn : undefined
-                  }
+            <Box sx={{ width: '100%' }}>
+              {videoUrl ? (
+                <VideoPlayer videoUrl={videoUrl} />
+              ) : (
+                <ImageGallery
+                  images={formatImagesForGallery(images) as any}
+                  allowPortrait={true}
                 />
               )}
-              {files &&
-                files
-                  .filter(Boolean)
-                  .map(
-                    (file, index) =>
-                      file && (
-                        <DownloadStaticFile
-                          allowDownload
-                          file={file}
-                          key={file ? file.name : `file-${index}`}
-                          handleClick={handleDownloadClick}
-                          redirectToSignIn={
-                            !loggedInUser ? redirectToSignIn : undefined
-                          }
-                        />
-                      ),
-                  )}
-              <DownloadCounter total={downloadCount} />
-            </Flex>
-          )}
-          <ResearchUpdateDiscussion
-            update={update}
-            research={research}
-            showComments={showComments}
-          />
-        </Card>
+            </Box>
+            {((files && files.length > 0) || fileLink) && (
+              <Flex
+                className="file-container"
+                mt={3}
+                sx={{ flexDirection: 'column', px: 4 }}
+              >
+                {fileLink && (
+                  <DownloadFileFromLink
+                    handleClick={handleDownloadClick}
+                    link={fileLink}
+                    redirectToSignIn={
+                      !loggedInUser ? redirectToSignIn : undefined
+                    }
+                  />
+                )}
+                {files &&
+                  files
+                    .filter(Boolean)
+                    .map(
+                      (file, index) =>
+                        file && (
+                          <DownloadStaticFile
+                            allowDownload
+                            file={file}
+                            key={file ? file.name : `file-${index}`}
+                            handleClick={handleDownloadClick}
+                            redirectToSignIn={
+                              !loggedInUser ? redirectToSignIn : undefined
+                            }
+                          />
+                        ),
+                    )}
+                <DownloadCounter total={downloadCount} />
+              </Flex>
+            )}
+            <ResearchUpdateDiscussion
+              update={update}
+              research={research}
+              showComments={showComments}
+            />
+          </Card>
+        </Flex>
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the current behavior?
It wasn't clear sometimes to research creators that there updates had been saved as drafts.

## What is the new behavior?

1. Clearly shows an update is draft on display page.
2. Re-order the buttons that that it's a little harder to accidently set an update back to draft.

<img width="1218" alt="Screenshot 2024-09-03 at 13 54 34" src="https://github.com/user-attachments/assets/cbe86d78-a85f-4def-bce7-2b28902fe648">
<img width="832" alt="Screenshot 2024-09-03 at 14 25 47" src="https://github.com/user-attachments/assets/a0e718a1-9ed6-4b7a-acd7-ea5e39b78b06">
