### PR TITLE
fix: always display download button

### DIFF
--- a/packages/components/src/DonationRequest/DonationRequest.tsx
+++ b/packages/components/src/DonationRequest/DonationRequest.tsx
@@ -33,7 +33,7 @@ export const DonationRequest = (props: IProps) => {
     <>
       <Card
         sx={{
-          overflowY: 'scroll',
+          overflowY: 'auto',
           scrollbarWidth: 'thin',
           borderRadius: '4px 4px 0 0',
         }}

--- a/packages/components/src/DonationRequest/DonationRequest.tsx
+++ b/packages/components/src/DonationRequest/DonationRequest.tsx
@@ -30,64 +30,65 @@ export const DonationRequest = (props: IProps) => {
   }
 
   return (
-    <Card
-      sx={{
-        overflowY: 'scroll',
-        scrollbarWidth: 'none',
-        msOverflowStyle: 'none',
-      }}
-      data-cy="DonationRequest"
-      data-testid="DonationRequest"
-    >
-      <script
-        src="https://donorbox.org/widget.js"
-        data-paypalexpress="false"
-      ></script>
-
-      <Flex
+    <>
+      <Card
         sx={{
-          flexDirection: ['column', 'row'],
+          overflowY: 'scroll',
+          scrollbarWidth: 'thin',
+          borderRadius: '4px 4px 0 0',
         }}
+        data-cy="DonationRequest"
+        data-testid="DonationRequest"
       >
-        <Flex sx={{ flexDirection: 'column', flex: 1 }}>
-          {imageURL && (
-            <Flex sx={{ display: ['none', 'inline'] }}>
-              <AspectImage
-                loading="lazy"
-                ratio={16 / 9}
-                src={imageURL}
-                alt={REQUEST_TITLE}
-                data-testid="donationRequestImage"
-              />
-            </Flex>
-          )}
-
-          <Text sx={{ padding: [2, 4, 6] }}>
-            <Text as="h1">{REQUEST_TITLE}</Text>
-            <p>{body}</p>
-            <p>{REQUEST_THANKYOU}</p>
-          </Text>
-        </Flex>
+        <script
+          src="https://donorbox.org/widget.js"
+          data-paypalexpress="false"
+        ></script>
 
         <Flex
           sx={{
-            borderLeft: [0, '2px solid'],
-            minHeight: '650px',
-            width: ['100%', '350px', '400px'],
+            flexDirection: ['column', 'row'],
           }}
         >
-          <iframe
-            {...iframeArgs}
-            loading="lazy"
-            style={{ border: '0', overflow: 'scroll', width: '100%' }}
-          ></iframe>
-        </Flex>
-      </Flex>
+          <Flex sx={{ flexDirection: 'column', flex: 1 }}>
+            {imageURL && (
+              <Flex sx={{ display: ['none', 'inline'] }}>
+                <AspectImage
+                  loading="lazy"
+                  ratio={16 / 9}
+                  src={imageURL}
+                  alt={REQUEST_TITLE}
+                  data-testid="donationRequestImage"
+                />
+              </Flex>
+            )}
 
+            <Text sx={{ padding: [2, 4, 6] }}>
+              <Text as="h1">{REQUEST_TITLE}</Text>
+              <p>{body}</p>
+              <p>{REQUEST_THANKYOU}</p>
+            </Text>
+          </Flex>
+
+          <Flex
+            sx={{
+              borderLeft: [0, '2px solid'],
+              minHeight: '542px',
+              width: ['100%', '350px', '400px'],
+            }}
+          >
+            <iframe
+              {...iframeArgs}
+              loading="lazy"
+              style={{ border: '0', overflow: 'scroll', width: '100%' }}
+            ></iframe>
+          </Flex>
+        </Flex>
+      </Card>
       <Flex
         sx={{
           backgroundColor: 'offWhite',
-          borderTop: '2px solid',
+          borderRadius: '0 0 4px 4px',
           flexDirection: ['column', 'row'],
           padding: 2,
           gap: 2,
@@ -104,6 +105,6 @@ export const DonationRequest = (props: IProps) => {
           <Button>{BUTTON_LABEL}</Button>
         </ExternalLink>
       </Flex>
-    </Card>
+    </>
   )
 }

--- a/packages/components/src/DonationRequestModal/DonationRequestModal.tsx
+++ b/packages/components/src/DonationRequestModal/DonationRequestModal.tsx
@@ -17,6 +17,7 @@ export const DonationRequestModal = (props: IProps) => {
 
   const sx = {
     width: ['500px', '750px', '1050px'],
+    minWidth: '350px',
     border: '0 !important',
     background: 'none !important',
   }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?
Users with lower screen resolutions or smaller laptops are experiencing difficulties locating the download button. 

## What is the new behavior?
Download button is always displayed at the bottom of the screen, regardless of the content length.
Also added a thin scrollbar and increased the modal width for mobile.

![image](https://github.com/user-attachments/assets/2e610f0d-2b1b-416f-8234-dae664c72634)
![image](https://github.com/user-attachments/assets/341d6070-4a89-4c49-a2b6-70ad46e2b46b)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #3847
