### PR TITLE
tests: cy howto read flaky

### DIFF
--- a/packages/cypress/src/integration/howto/read.spec.ts
+++ b/packages/cypress/src/integration/howto/read.spec.ts
@@ -50,13 +50,14 @@ describe('[How To]', () => {
 
     beforeEach(() => {
       cy.visit('/how-to')
-      // Hack to get the tags store to finish populating before the expectations
-      cy.wait(1000)
     })
 
     describe('[By Everyone]', () => {
       it('[See all info]', () => {
         const howto = howtos[0]
+        // Hack to avoid flaky test as the tags are not being loaded on time
+        cy.queryDocuments('howtos', '_id', '==', howto._id)
+
         cy.visit(specificHowtoUrl)
         cy.step('Edit button is not available')
         cy.get('[data-cy=edit]').should('not.exist')


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the scenario **[Read a How-to][By Everyone][See all info]** has flaky steps when trying to assert the data on the how-to. The cause is a rerender from a cypress that loses track.

Example:

`assert expected <div.howto-description-container.css-703r4> to contain product`

[cypress cloud with the issue](https://cloud.cypress.io/projects/4s5zgo/runs/6249/test-results/25283bbf-c706-4201-96ac-f3bd951796d4/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A3456-130__command-logs&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1727121987362.1)

## What is the new behavior?

To avoid the page being rerendered I used the [aliases](https://docs.cypress.io/guides/core-concepts/retry-ability#Correctly-ending-chains-after-an-action)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No