### PR TITLE
fix: temp reduction in map spec coverage

### DIFF
--- a/packages/cypress/src/integration/map.spec.ts
+++ b/packages/cypress/src/integration/map.spec.ts
@@ -27,7 +27,8 @@ describe('[Map]', () => {
     cy.step('New map shows the cards')
     cy.get('[data-cy="welome-header"]').should('be.visible')
     cy.get('[data-cy="CardList-desktop"]').should('be.visible')
-    cy.get('[data-cy="list-results"]').contains('52 results in view')
+    // Should be 'x results in view' - reduction in coverage until temp API removed
+    cy.get('[data-cy="list-results"]').contains('results in view')
 
     cy.step('Map filters can be used')
     cy.get('[data-cy=FilterList]')
@@ -35,9 +36,11 @@ describe('[Map]', () => {
       .children()
       .should('have.length', profileTypesCount)
     cy.get('[data-cy=MapListFilter]').first().click()
-    cy.get('[data-cy="list-results"]').contains('6 results in view')
+    // Reduction in coverage until temp API removed
+    // cy.get('[data-cy="list-results"]').contains('6 results in view')
     cy.get('[data-cy=MapListFilter-active]').first().click()
-    cy.get('[data-cy="list-results"]').contains('52 results in view')
+    // Reduction in coverage until temp API removed
+    // cy.get('[data-cy="list-results"]').contains('52 results in view')
 
     cy.step('As the user moves in the list updates')
     for (let i = 0; i < 9; i++) {


### PR DESCRIPTION
The cypress map test currently relies on an external (to this repo) api with a version of our dev data on. So as new/existing engineers get involved the number of map pins goes up and the test starts failing. The API is being replaced shortly (and will be part of this repo) so I'm temporarily removing the result total related expectations until that happens.