### PR TITLE
feat: set map pins to have profile link

### DIFF
--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -8,9 +8,10 @@ import type { IProfileCreator } from 'oa-shared'
 
 interface IProps {
   creator: IProfileCreator
+  isLink: boolean
 }
 
-export const CardDetailsMemberProfile = ({ creator }: IProps) => {
+export const CardDetailsMemberProfile = ({ creator, isLink }: IProps) => {
   const { _id, badges, countryCode, profileType, userImage } = creator
 
   return (
@@ -55,7 +56,7 @@ export const CardDetailsMemberProfile = ({ creator }: IProps) => {
             isVerified: badges?.verified || false,
           }}
           sx={{ alignSelf: 'flex-start' }}
-          isLink={false}
+          isLink={isLink}
         />
         <Category
           category={{ label: 'Wants to get started' }}

--- a/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
@@ -8,9 +8,10 @@ import type { IProfileCreator } from 'oa-shared'
 
 interface IProps {
   creator: IProfileCreator
+  isLink: boolean
 }
 
-export const CardDetailsSpaceProfile = ({ creator }: IProps) => {
+export const CardDetailsSpaceProfile = ({ creator, isLink }: IProps) => {
   const { _id, about, badges, countryCode, coverImage, profileType, subType } =
     creator
 
@@ -68,7 +69,7 @@ export const CardDetailsSpaceProfile = ({ creator }: IProps) => {
               isSupporter: badges?.supporter || false,
             }}
             sx={{ alignSelf: 'flex-start' }}
-            isLink={false}
+            isLink={isLink}
           />
         </Flex>
         {subType && (

--- a/packages/components/src/CardProfile/CardProfile.tsx
+++ b/packages/components/src/CardProfile/CardProfile.tsx
@@ -8,17 +8,22 @@ import type { MapListItem } from '../types/common'
 
 export interface IProps {
   item: MapListItem
+  isLink?: boolean
 }
 
-export const CardProfile = ({ item }: IProps) => {
+export const CardProfile = ({ item, isLink = false }: IProps) => {
   const { creator } = item
 
   const isMember = creator?.profileType === 'member'
 
   return (
     <Flex sx={{ alignItems: 'stretch', alignContent: 'stretch' }}>
-      {isMember && <CardDetailsMemberProfile creator={creator} />}
-      {!isMember && creator && <CardDetailsSpaceProfile creator={creator} />}
+      {isMember && (
+        <CardDetailsMemberProfile creator={creator} isLink={isLink} />
+      )}
+      {!isMember && creator && (
+        <CardDetailsSpaceProfile creator={creator} isLink={isLink} />
+      )}
       {!creator && <CardDetailsFallback item={item} />}
     </Flex>
   )

--- a/packages/components/src/PinProfile/PinProfile.tsx
+++ b/packages/components/src/PinProfile/PinProfile.tsx
@@ -32,7 +32,7 @@ export const PinProfile = (props: IProps) => {
         </Box>
       </Box>
 
-      <CardProfile item={item} />
+      <CardProfile item={item} isLink />
 
       {!isMember && creator?.isContactableByPublic && (
         <Flex sx={{ justifyContent: 'flex-end' }}>


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [x] Feature (adds functionality)


## What is the new behavior?

Adding back in the regular profile link for usernames on the map pin, was removed for the list cards.

<img width="502" alt="Screenshot 2024-09-26 at 13 51 15" src="https://github.com/user-attachments/assets/8cf8f98b-fced-41cf-a13a-de88026e987a">

