### PR TITLE
fix: do not show deployment approval unless it's the default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,6 +511,7 @@ workflows:
             - release-context
           requires:
             - "Approve Production deployment"
+          <<: *filter_only_default_branch
       - deploy:
           name: 'Deploy: community.fixing.fashion'
           requires:


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [x] CI related changes

## What is the current behavior?
"Approve Production deployment" step is showing even when it's not the master branch.

## What is the new behavior?
fixes that :)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
