### PR TITLE
build: add fly preview workflow

### DIFF
--- a/.github/workflows/fly-pr-preview.yml
+++ b/.github/workflows/fly-pr-preview.yml
@@ -1,0 +1,50 @@
+name: Fly PR Preview
+on:
+  # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
+  pull_request_target:
+    # Trigger when labels are changed or more commits added to a PR that contains labels
+    types: [labeled, synchronize]
+    # Only create a preview if changes have been made to the main src code or backend functions
+    paths:
+      - 'src/**'
+      - 'functions/**'
+      - 'packages/components/**'
+      - '.github/workflows/pr-preview.yml'
+      - 'package.json'
+      - 'yarn.lock'
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  # Set these to your Fly.io organization and preferred region.
+  FLY_REGION: cdg
+  FLY_ORG: one-army
+
+jobs:
+  preview_app:
+    if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    # Only run one deployment at a time per PR.
+    concurrency:
+      group: pr-${{ github.event.number }}
+
+    # Deploying apps with this "review" environment allows the URL for the app to be displayed in the PR UI.
+    # Feel free to change the name of this environment.
+    environment:
+      name: preview
+      # The script in the `deploy` sets the URL output for each review app.
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Get code
+        uses: actions/checkout@v4
+        with:
+          # pull the repo from the pull request source, not the default local repo
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Deploy PR app to Fly.io
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.2.1
+        with:
+          secrets: VITE_SITE_VARIANT=preview VITE_PROJECT_VERSION=${GITHUB_SHA}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Old pr preview workflow no longer works since moving to fly.io

## What is the new behavior?

Implements pr preview workflow using fly.io

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
