### PR TITLE
build: add app name to fly preview workflow

### DIFF
--- a/.github/workflows/fly-pr-preview.yml
+++ b/.github/workflows/fly-pr-preview.yml
@@ -48,4 +48,5 @@ jobs:
         uses: superfly/fly-pr-review-apps@1.2.1
         with:
           config: fly-preview.toml
+          name: community-platform-pr-${{ github.event.number }}
           secrets: VITE_SITE_VARIANT=preview VITE_PROJECT_VERSION=${GITHUB_SHA}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Fly preview workflow fails because GitHub organisation isn't lowercase 🙄 

## What is the new behavior?

Set non default app name that is all lower case

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
