### PR TITLE
fix: alert profile icon positioning

### DIFF
--- a/src/common/Alerts/AlertProfileVerification.tsx
+++ b/src/common/Alerts/AlertProfileVerification.tsx
@@ -20,7 +20,7 @@ export const AlertProfileVerification = () => {
   const isVerificationSuccessful = verificationState === 'sent'
   const isVerificationPending = verificationState === 'pending'
   const alertLabel = isVerificationPending
-    ? 'Click here to receive an email to confirm your account.'
+    ? 'Click here to receive an email to confirm your account'
     : "Sorry, we couldn't send an email. Please try again later."
   const successLabelMessage =
     'Verification email sent. Please check your inbox and spam folder. '
@@ -55,12 +55,12 @@ export const AlertProfileVerification = () => {
         )}
 
         {!isVerificationSuccessful && (
-          <Text>
+          <>
             {isVerificationPending && (
               <Icon glyph="email" mr={1} verticalAlign={'text-top'} />
             )}
-            {alertLabel}
-          </Text>
+            <Text>{alertLabel}</Text>
+          </>
         )}
       </Banner>
     </Flex>


### PR DESCRIPTION
## What is the current behavior?
<img width="1085" alt="Screenshot 2024-10-09 at 13 52 22" src="https://github.com/user-attachments/assets/08a8de55-34f2-48c7-8a0e-fd5e06af6912">

## What is the new behavior?

<img width="1085" alt="Screenshot 2024-10-09 at 13 51 59" src="https://github.com/user-attachments/assets/98172e86-9c01-4548-9c1a-cad7835187c1">