### PR TITLE
bug: setting as draft a published research does not reset the total comment count

### DIFF
--- a/src/stores/Research/research.store.tsx
+++ b/src/stores/Research/research.store.tsx
@@ -262,7 +262,6 @@ export class ResearchStore extends ModuleStore {
             : values.creatorCountry
               ? values.creatorCountry
               : '',
-        totalCommentCount: 0,
       }
       logger.debug('populating database', researchItem)
       // set the database document


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
Re publishing or updating a research reset its total comments count to 0

## What is the new behavior?
The total comments count is not reset on Publish/Draft

Note: this PR does not fix the researches already affected by the bug. The correct count value will be displayed when a new comment or update is posted

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Git Issues

Closes #3905

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
