### PR TITLE
fix: adding eslint rule for no exclusive tests

### DIFF
--- a/packages/cypress/.eslintrc.json
+++ b/packages/cypress/.eslintrc.json
@@ -7,6 +7,7 @@
     "cypress/no-force": "warn",
     "cypress/no-async-tests": "warn",
     "cypress/no-pause": "warn",
-    "mocha/no-skipped-tests": "error"
+    "mocha/no-skipped-tests": "error",
+    "mocha/no-exclusive-tests": "error"
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

You can merge in Jest tests that are exclusive (IE using `describe.only`). 

## What is the new behavior?

An ESLint error will be thrown if any exclusive test is added. I chose to go with error because I can't think of a super good reason why this should ever be allowed.

<img width="1309" alt="Screenshot 2024-10-22 at 1 37 35 PM" src="https://github.com/user-attachments/assets/3c1e9587-c5d2-4efe-af4f-1c168e25438e">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #3873

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
