### PR TITLE
fix: remove revert to draft state

### DIFF
--- a/src/pages/Howto/Content/Common/HowtoButtonDraft.tsx
+++ b/src/pages/Howto/Content/Common/HowtoButtonDraft.tsx
@@ -1,10 +1,10 @@
 import { Button } from 'oa-components'
-import { IModerationStatus } from 'oa-shared'
 import { Flex, Text } from 'theme-ui'
 
 import { buttons } from '../../labels'
 
 import type { FormApi } from 'final-form'
+import type { IModerationStatus } from 'oa-shared'
 
 interface IProps {
   form: FormApi
@@ -14,10 +14,8 @@ interface IProps {
 }
 
 export const HowtoButtonDraft = (props: IProps) => {
-  const { form, formId, moderation, submitting } = props
-  const { create, description, update } = buttons.draft
-
-  const text = moderation !== IModerationStatus.DRAFT ? create : update
+  const { form, formId, submitting } = props
+  const { create, description } = buttons.draft
 
   return (
     <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
@@ -31,7 +29,7 @@ export const HowtoButtonDraft = (props: IProps) => {
         sx={{ width: '100%', display: 'block' }}
         form={formId}
       >
-        <span>{text}</span>
+        <span>{create}</span>
       </Button>
       <Text sx={{ fontSize: 1, textAlign: 'center' }}>{description}</Text>
     </Flex>

--- a/src/pages/Howto/labels.ts
+++ b/src/pages/Howto/labels.ts
@@ -19,7 +19,6 @@ export const headings = {
 export const buttons = {
   draft: {
     create: 'Save draft',
-    update: 'Revert to draft',
     description: 'A draft can be saved any time',
   },
   files: 'Re-upload files (this will delete the existing ones)',

--- a/src/pages/Research/Content/Common/Research.form.tsx
+++ b/src/pages/Research/Content/Common/Research.form.tsx
@@ -58,7 +58,7 @@ const ResearchFormLabel = ({ children, ...props }) => (
 
 const ResearchForm = observer((props: IProps) => {
   const { formValues, parentType } = props
-  const { create, update } = buttons.draft
+  const { create } = buttons.draft
 
   formValues.researchStatus = formValues.researchStatus || 'In progress'
 
@@ -106,8 +106,6 @@ const ResearchForm = observer((props: IProps) => {
     await store.uploadResearch(formValues)
   }
 
-  const draftButtonText =
-    formValues.moderation !== IModerationStatus.DRAFT ? create : update
   const pageTitle = headings.overview[parentType]
 
   return (
@@ -323,7 +321,7 @@ const ResearchForm = observer((props: IProps) => {
                     disabled={submitting}
                     sx={{ width: '100%', display: 'block' }}
                   >
-                    <span>{draftButtonText}</span>
+                    <span>{create}</span>
                   </Button>
 
                   <Button


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

We currently show "Revert to draft" as the button CTA for How-tos and Research posts that are still in Draft mode.

## What is the new behavior?

We remove the "Revert to draft" CTA entirely. All draft posts will always just have a "Save as draft" CTA, which makes sense.

https://github.com/user-attachments/assets/2ca986ee-5d9e-497a-8201-f93e6217675c

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #3910

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
