### PR TITLE
feat: remove sending of secrets from github workflow

### DIFF
--- a/.github/workflows/fly-pr-preview.yml
+++ b/.github/workflows/fly-pr-preview.yml
@@ -45,34 +45,7 @@ jobs:
 
       - name: Deploy PR app to Fly.io
         id: deploy
-        uses: iSCJT/fly-preview-app-with-build-secret@latest
+        uses: superfly/fly-pr-review-apps@1.3.0
         with:
           config: fly-preview.toml
           name: community-platform-pr-${{ github.event.number }}
-          build_secrets: >
-            VITE_SITE_VARIANT=preview
-            VITE_PROJECT_VERSION=${{ github.sha }}
-            VITE_BRANCH=${{ github.head_ref || github.ref_name }}
-            VITE_CDN_URL=""
-            VITE_FIREBASE_API_KEY=""
-            VITE_FIREBASE_AUTH_DOMAIN=""
-            VITE_FIREBASE_DATABASE_URL=""
-            VITE_FIREBASE_MESSAGING_SENDER_ID=""
-            VITE_FIREBASE_PROJECT_ID=""
-            VITE_FIREBASE_STORAGE_BUCKET=""
-            VITE_SENTRY_DSN="${{ secrets.PREVIEW_VITE_SENTRY_DSN }}"
-            VITE_GA_TRACKING_ID="${{ secrets.PREVIEW_VITE_GA_TRACKING_ID }}"
-            VITE_PATREON_CLIENT_ID="${{ secrets.PREVIEW_VITE_PATREON_CLIENT_ID }}"
-            VITE_PLATFORM_THEME="${{ secrets.PREVIEW_VITE_PLATFORM_THEME }}"
-            VITE_SUPPORTED_MODULES="${{ secrets.PREVIEW_VITE_SUPPORTED_MODULES }}"
-            VITE_API_URL="${{ secrets.PREVIEW_VITE_API_URL }}"
-            VITE_ACADEMY_RESOURCE="${{ secrets.PREVIEW_VITE_ACADEMY_RESOURCE }}"
-            VITE_PROFILE_GUIDELINES_URL="${{ secrets.PREVIEW_VITE_PROFILE_GUIDELINES_URL }}"
-            VITE_SITE_NAME="${{ secrets.PREVIEW_VITE_SITE_NAME }}"
-            VITE_THEME="${{ secrets.PREVIEW_VITE_THEME }}"
-            VITE_DONATIONS_BODY="${{ secrets.PREVIEW_VITE_DONATIONS_BODY }}"
-            VITE_DONATIONS_IFRAME_SRC="${{ secrets.PREVIEW_VITE_DONATIONS_IFRAME_SRC }}"
-            VITE_DONATIONS_IMAGE_URL="${{ secrets.PREVIEW_VITE_DONATIONS_IMAGE_URL }}"
-            VITE_HOWTOS_HEADING="${{ secrets.PREVIEW_VITE_HOWTOS_HEADING }}"
-            VITE_COMMUNITY_PROGRAM_URL="${{ secrets.PREVIEW_VITE_COMMUNITY_PROGRAM_URL }}"
-            VITE_QUESTIONS_GUIDELINES_URL="${{ secrets.PREVIEW_VITE_QUESTIONS_GUIDELINES_URL }}"

--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -28,7 +28,8 @@ COPY . .
 # Install packages
 RUN yarn install
 
-RUN echo "VITE_GA_TRACKING_ID=\"G-G4QQ9NSQPC\"" >> .env && \
+RUN echo "VITE_SITE_VARIANT=\"preview\"" >> .env && \
+    echo "VITE_GA_TRACKING_ID=\"G-G4QQ9NSQPC\"" >> .env && \
     echo "VITE_PATREON_CLIENT_ID=\"RLgZo7SKNVn8cOyFlYeGZsNnoCOjvzQiNJFskDfoxltZltjPPGNMPokwJckHNphU\"" >> .env && \
     echo "VITE_PLATFORM_THEME=\"precious-plastic\"" >> .env
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Sending secrets in GitHub workflow

## What is the new behavior?

As using new dockerfile with limited hardcoded env variables no need to send all variables as build secrets

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
