### PR TITLE
feat: trigger preview workflow on pull request closure

### DIFF
--- a/.github/workflows/fly-pr-preview.yml
+++ b/.github/workflows/fly-pr-preview.yml
@@ -3,7 +3,7 @@ on:
   # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
   pull_request_target:
     # Trigger when labels are changed or more commits added to a PR that contains labels
-    types: [labeled, synchronize]
+    types: [closed, labeled, synchronize]
     # Only create a preview if changes have been made to the main src code or backend functions
     paths:
       - 'src/**'


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [x] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Preview workflow only triggered on addition of preview label.

## What is the new behavior?

Triggers on close of pull request to tidy up fly deployment.

_Describe the new behaviour_
_If useful, provide screenshot or capture to highlight main changes_

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
