### PR TITLE
fix: profile statistics zero label

### DIFF
--- a/packages/components/src/UserStatistics/UserStatistics.tsx
+++ b/packages/components/src/UserStatistics/UserStatistics.tsx
@@ -18,7 +18,7 @@ export interface UserStatisticsProps {
   howtoCount: number
   usefulCount: number
   researchCount: number
-  totalViews?: number
+  totalViews: number
   sx?: ThemeUIStyleObject | undefined
 }
 
@@ -74,14 +74,14 @@ export const UserStatistics = (props: UserStatisticsProps) => {
           </InternalLink>
         )}
 
-        {props.usefulCount && (
+        {props.usefulCount > 0 && (
           <Flex data-testid="useful-stat">
             <ElWithBeforeIcon icon={starActiveSVG} />
             {`Useful: ${props.usefulCount}`}
           </Flex>
         )}
 
-        {props.howtoCount && (
+        {props.howtoCount > 0 && (
           <InternalLink
             to={'/how-to?q=' + props.userName}
             sx={{ color: 'black' }}
@@ -89,12 +89,12 @@ export const UserStatistics = (props: UserStatisticsProps) => {
           >
             <Flex data-testid="howto-stat">
               <ElWithBeforeIcon icon={HowToCountIcon} />
-              How‑to:&nbsp;{props.howtoCount}
+              {`How-to: ${props.howtoCount}`}
             </Flex>
           </InternalLink>
         )}
 
-        {props.researchCount && (
+        {props.researchCount > 0 && (
           <InternalLink
             to={'/research?q=' + props.userName}
             sx={{ color: 'black' }}
@@ -102,12 +102,12 @@ export const UserStatistics = (props: UserStatisticsProps) => {
           >
             <Flex data-testid="research-stat">
               <ElWithBeforeIcon icon={ResearchIcon} />
-              Research:&nbsp;{props.researchCount}
+              {`Research: ${props.researchCount}`}
             </Flex>
           </InternalLink>
         )}
 
-        {props.totalViews && (
+        {props.totalViews > 0 && (
           <Flex data-testid="profile-views-stat">
             <Icon glyph="view" size={22} />
             <Box ml={1}>{`Views: ${props.totalViews}`}</Box>

--- a/src/pages/User/content/MemberProfile.tsx
+++ b/src/pages/User/content/MemberProfile.tsx
@@ -94,6 +94,7 @@ export const MemberProfile = ({ docs, user }: IProps) => {
                   howtoCount={docs?.howtos.length || 0}
                   researchCount={docs?.research.length || 0}
                   usefulCount={user.totalUseful || 0}
+                  totalViews={0}
                   sx={{ alignSelf: 'stretch' }}
                 />
               }
@@ -107,7 +108,7 @@ export const MemberProfile = ({ docs, user }: IProps) => {
                 researchCount={docs?.research.length || 0}
                 usefulCount={user.totalUseful || 0}
                 sx={{ alignSelf: 'stretch' }}
-                totalViews={user.total_views}
+                totalViews={user.total_views || 0}
               />
             </AuthWrapper>
           </Flex>

--- a/src/pages/User/content/SpaceProfile.tsx
+++ b/src/pages/User/content/SpaceProfile.tsx
@@ -275,6 +275,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                           howtoCount={docs?.howtos.length || 0}
                           usefulCount={user.totalUseful || 0}
                           researchCount={docs?.research.length || 0}
+                          totalViews={0}
                         />
                       }
                     >
@@ -286,7 +287,7 @@ export const SpaceProfile = ({ user, docs }: IProps) => {
                         howtoCount={docs?.howtos.length || 0}
                         usefulCount={user.totalUseful || 0}
                         researchCount={docs?.research.length || 0}
-                        totalViews={user.total_views}
+                        totalViews={user.total_views || 0}
                       />
                     </AuthWrapper>
                   </Box>


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?
Displays zero when shouldn't display anything.
![image](https://github.com/user-attachments/assets/1b6e5bf4-7213-482e-b66a-9ca3461f577b)

## What is the new behavior?
Doesn't display when zero.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #