### PR TITLE
build: remove preview label if pr closed + destroy fly.io preview app if label removed

### DIFF
--- a/.github/workflows/fly-pr-preview.yml
+++ b/.github/workflows/fly-pr-preview.yml
@@ -43,7 +43,22 @@ jobs:
           # pull the repo from the pull request source, not the default local repo
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Remove label if closed
+        if: github.event.pull_request.closed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: github.event.number,
+              name: 'Review allow-preview ✅',
+            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy PR app to Fly.io
+        if: github.event.pull_request.closed == false
         id: deploy
         uses: superfly/fly-pr-review-apps@1.3.0
         with:

--- a/.github/workflows/preview-label-removed.yml
+++ b/.github/workflows/preview-label-removed.yml
@@ -1,0 +1,23 @@
+name: Destroy fly preview app when label removed
+
+on:
+  pull_request_target:
+    types:
+      - unlabeled
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  label_removed:
+    if: github.event.label.name == 'Review allow-preview ✅'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    concurrency:
+      group: pr-${{ github.event.number }}
+    steps:
+      - name: Destroy fly.io preview app
+        id: destroy
+        uses: iSCJT/fly-destroy-app@1.0.0
+        with:
+          name: community-platform-pr-${{ github.event.number }}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently closing or merging a pr will destroy the fly.io preview app, however the label remains in place and as a result when the pr is included in a release the updates trigger another preview deploy.

## What is the new behavior?

Introduces 2 improvements:

1. when a pr is closed the label is automatically removed preventing any further updates triggering an inadvertent deploy.
2. when the preview label is removed a workflow is triggered to destroy the fly.io app

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
