### PR TITLE
fix: do not display deleted howtos

### DIFF
--- a/src/pages/Howto/howto.service.ts
+++ b/src/pages/Howto/howto.service.ts
@@ -207,7 +207,16 @@ const getBySlug = async (slug: string) => {
     return null
   }
 
-  const howto = snapshot.docs[0].data() as IHowtoDB
+  let howto: IHowtoDB | null = null
+
+  for (const doc of snapshot.docs) {
+    const howtoDoc = doc.data() as IHowtoDB
+
+    if (!howtoDoc._deleted) {
+      howto = howtoDoc
+      break
+    }
+  }
 
   if (!howto) {
     return null


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [x] Bugfix (fixes an issue)

## What is the current behavior?
Displays howto deleted items when navigating to the page by slug.

## What is the new behavior?
Deleted howtos are no longer displayed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #
