### PR TITLE
build: add local fly preview destroy app action

### DIFF
--- a/.github/actions/destroy-fly-preview-app/Dockerfile
+++ b/.github/actions/destroy-fly-preview-app/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+RUN apk add --no-cache curl jq
+
+RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/destroy-fly-preview-app/action.yml
+++ b/.github/actions/destroy-fly-preview-app/action.yml
@@ -1,0 +1,12 @@
+name: "Destroy fly.io app"
+description: "Destroy fly.io app if matching app name found"
+author: iSCJT
+branding:
+  icon: "delete"
+  color: "red"
+runs:
+  using: "docker"
+  image: "Dockerfile"
+inputs:
+  name:
+    description: Fly app name

--- a/.github/actions/destroy-fly-preview-app/entrypoint.sh
+++ b/.github/actions/destroy-fly-preview-app/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -l
+
+set -ex
+
+# Change underscores to hyphens.
+app="${INPUT_NAME//_/-}"
+
+
+if ! flyctl status --app "$app"; then
+  echo "App name not found"
+  exit 1
+fi
+
+flyctl apps destroy "$app" -y || true
+exit 0

--- a/.github/workflows/preview-label-removed.yml
+++ b/.github/workflows/preview-label-removed.yml
@@ -16,8 +16,11 @@ jobs:
     concurrency:
       group: pr-${{ github.event.number }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
       - name: Destroy fly.io preview app
         id: destroy
-        uses: iSCJT/fly-destroy-app@v1
+        uses: ./.github/actions/destroy-fly-preview-app
         with:
           name: community-platform-pr-${{ github.event.number }}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?

Adds local action to destroy fly preview apps

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
