### PR TITLE
fix: discussion duplication

### DIFF
--- a/src/stores/Discussions/discussion.store.test.ts
+++ b/src/stores/Discussions/discussion.store.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../common/module.store')
-import { faker } from '@faker-js/faker'
 import {
   FactoryDiscussion,
   FactoryDiscussionComment,
@@ -67,23 +66,6 @@ const factory = (
 
 describe('discussion.store', () => {
   describe('fetchOrCreateDiscussionBySource', () => {
-    it('fetches a discussion by sourceId', async () => {
-      const fakeSourceId = faker.internet.password()
-      const fakePrimaryContentId = faker.internet.password()
-      const { store, getWhereFn } = factory([
-        FactoryDiscussion({ sourceId: fakeSourceId }),
-      ])
-
-      await store.fetchOrCreateDiscussionBySource(
-        fakeSourceId,
-        'question',
-        fakePrimaryContentId,
-      )
-
-      expect(getWhereFn).toHaveBeenCalledTimes(1)
-      expect(getWhereFn).toHaveBeenCalledWith('sourceId', '==', fakeSourceId)
-    })
-
     it('creates a discussion if one does not exist', async () => {
       const { store, getWhereFn, setFn } = factory()
 

--- a/src/stores/Discussions/discussions.store.tsx
+++ b/src/stores/Discussions/discussions.store.tsx
@@ -36,15 +36,17 @@ export class DiscussionStore extends ModuleStore {
     sourceType: IDiscussion['sourceType'],
     primaryContentId: IDiscussion['primaryContentId'],
   ): Promise<IDiscussionDB | null> {
-    const foundDiscussion =
-      toJS(
-        await this.db
-          .collection<IDiscussion>(DISCUSSIONS_COLLECTION)
-          .getWhere('sourceId', '==', sourceId),
-      )[0] || null
+    const discussions = toJS(
+      await this.db
+        .collection<IDiscussion>(DISCUSSIONS_COLLECTION)
+        .getWhere('sourceId', '==', sourceId, 1),
+    )
+
+    const foundDiscussion = discussions
+      ? discussions.find((x) => x.comments.length > 0) || discussions.at(0)
+      : null
 
     if (foundDiscussion) {
-      await this._validatePrimaryContentId(foundDiscussion, primaryContentId)
       return this._formatDiscussion(foundDiscussion)
     }
 


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?
Discussions are being duplicated which causes comments to not show. There should only be 1 discussion per sourceId.

## What is the new behavior?

Ensure that even with duplicated discussions, it shows the correct one.
Change that might prevent this duplication in the first place.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #