### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.github/ISSUE_TEMPLATE/build-new-component.md
+++ b/.github/ISSUE_TEMPLATE/build-new-component.md
@@ -10,7 +10,7 @@ assignees: ''
 
 ### Description
 
-Write a quick descritpion of what is the component for, and as mainy details you consider useful to the person that will have to build it.
+Write a quick description of what is the component for, and as mainy details you consider useful to the person that will have to build it.
 
 ### Page related
 

--- a/packages/documentation/docs/Backend Development/integrations.md
+++ b/packages/documentation/docs/Backend Development/integrations.md
@@ -44,4 +44,4 @@ The implementation is at [`functions/src/config/config.ts`](https://github.com/O
 
 ## Development
 
-Contact a maintainer in order to access the config variables needed to test these integrations locally. Or, set up your own test account on the integration platform and and generate keys to play with! Just remember not to remove any sensitive info before pushing to Github 🤫
+Contact a maintainer in order to access the config variables needed to test these integrations locally. Or, set up your own test account on the integration platform and generate keys to play with! Just remember not to remove any sensitive info before pushing to Github 🤫

--- a/packages/documentation/docs/Install.md
+++ b/packages/documentation/docs/Install.md
@@ -8,8 +8,8 @@ Requirements
 1. [Authentication](https://firebase.google.com/docs/auth?authuser=0) with the Sign-in providers **Email/Password** enabled.
 1. [Cloud Firestore](https://firebase.google.com/docs/firestore/quickstart)
 1. [Realtime Database](https://firebase.google.com/docs/database?authuser=0&hl=en)
-1. Firebase CLI tools](https://firebase.google.com/docs/cli) locally
-1. Create an application](https://console.cloud.google.com/appengine/start/create)
+1. [Firebase CLI tools](https://firebase.google.com/docs/cli) locally
+1. [Create an application](https://console.cloud.google.com/appengine/start/create)
 1. Your project must be on the Blaze pay as you go pricing plan
 1. Configure `cors.json` on the storage bucket](https://cloud.google.com/storage/docs/configuring-cors) to support your deployed origin. See: functions/src/config/cors.md
 

--- a/types/readme.md
+++ b/types/readme.md
@@ -1,4 +1,4 @@
-When installing 3rd party packages typescript will expect a corresponding typing file
+When installing 3rd party packages TypeScript will expect a corresponding typing file
 You can try to see if one is available via
 
 ```


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "descritpion" to "description".
Corrected "platform and and generate" to "platform and generate".
The phrase "Firebase CLI tools]" — the opening square bracket before "Firebase CLI tools" was missing, corrected.
The phrase "Create an application]" — again, the opening square bracket before "Create an application" was missing, corrected.
Corrected "typescript" to "TypeScript".

Please review the changes and let me know if any additional changes are needed.