### PR TITLE
fix: question comment counts reseting on pagination

### DIFF
--- a/src/pages/Question/QuestionListing.tsx
+++ b/src/pages/Question/QuestionListing.tsx
@@ -85,7 +85,12 @@ export const QuestionListing = () => {
 
       if (count.size > 0) {
         setQuestions((questions) =>
-          questions.map((x) => ({ ...x, commentCount: count.get(x._id) || 0 })),
+          questions.map((x) => {
+            const commentCount =
+              (count.has(x._id) ? count.get(x._id) : x.commentCount) || 0
+
+            return { ...x, commentCount }
+          }),
         )
       }
     } catch (error) {


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?
Loading more comment counts was resetting the previous page comment counts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Git Issues

Closes #
