### PR TITLE
feat: Add loading state to ImageGallery (#3462)

### DIFF
--- a/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.stories.tsx
+++ b/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.stories.tsx
@@ -1,0 +1,127 @@
+import { ImageGalleryThumbnail } from './ImageGalleryThumbnail'
+
+import type { Meta, StoryFn } from '@storybook/react'
+import type { ImageGalleryThumbnailProps } from './ImageGalleryThumbnail'
+
+export default {
+  title: 'Layout/ImageGallery/ImageGalleryThumbnail',
+  component: ImageGalleryThumbnail,
+} as Meta<typeof ImageGalleryThumbnail>
+
+export const Default: StoryFn<typeof ImageGalleryThumbnail> = (
+  props: ImageGalleryThumbnailProps,
+) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={0}
+      allowPortrait={false}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://picsum.photos/id/29/150/150"
+    />
+  )
+}
+
+export const AllowPortrait: StoryFn<typeof ImageGalleryThumbnail> = (
+  props: ImageGalleryThumbnailProps,
+) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={0}
+      allowPortrait={true}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://picsum.photos/id/29/150/150"
+    />
+  )
+}
+
+export const DisallowPortrait: StoryFn<typeof ImageGalleryThumbnail> = (
+  props: ImageGalleryThumbnailProps,
+) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={0}
+      allowPortrait={false}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://picsum.photos/id/29/150/150"
+    />
+  )
+}
+
+export const ImageIsActive: StoryFn<typeof ImageGalleryThumbnail> = (
+  props: ImageGalleryThumbnailProps,
+) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={0}
+      allowPortrait={false}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://picsum.photos/id/29/150/150"
+    />
+  )
+}
+
+export const ImageIsNotActive: StoryFn<typeof ImageGalleryThumbnail> = (
+  props: ImageGalleryThumbnailProps,
+) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={1}
+      allowPortrait={false}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://picsum.photos/id/29/150/150"
+    />
+  )
+}
+
+export const ThumbnailUrlInvalidAltText: StoryFn<
+  typeof ImageGalleryThumbnail
+> = (props: ImageGalleryThumbnailProps) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={1}
+      allowPortrait={false}
+      alt="alt"
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://fastly.picsum.photos/404"
+    />
+  )
+}
+
+export const ThumbnailUrlInvalidNameText: StoryFn<
+  typeof ImageGalleryThumbnail
+> = (props: ImageGalleryThumbnailProps) => {
+  return (
+    <ImageGalleryThumbnail
+      {...props}
+      activeImageIndex={1}
+      allowPortrait={false}
+      name="name"
+      index={0}
+      setActiveIndex={() => {}}
+      thumbnailUrl="https://fastly.picsum.photos/404"
+    />
+  )
+}

--- a/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.test.tsx
+++ b/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom/vitest'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '../test/utils'
+import { ImageGalleryThumbnail } from './ImageGalleryThumbnail'
+
+describe('ImageGalleryThumbnail', () => {
+  it('calls Callback, when image clicked', () => {
+    const mockFn = vi.fn()
+    const { getByTestId } = render(
+      <ImageGalleryThumbnail
+        activeImageIndex={0}
+        allowPortrait={false}
+        alt="alt"
+        name="name"
+        index={0}
+        setActiveIndex={mockFn}
+        thumbnailUrl="https://picsum.photos/id/29/150/150"
+      />,
+    )
+    getByTestId('thumbnail').click()
+    expect(mockFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.tsx
+++ b/packages/components/src/ImageGalleryThumbnail/ImageGalleryThumbnail.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import styled from '@emotion/styled'
+import { Box, Image as ThemeImage } from 'theme-ui'
+
+import { Loader } from '../Loader/Loader'
+
+import type { CardProps } from 'theme-ui'
+
+import 'photoswipe/style.css'
+
+export interface ImageGalleryThumbnailProps {
+  setActiveIndex: (index: number) => void
+  allowPortrait: boolean
+  activeImageIndex: number
+  thumbnailUrl: string
+  index: number
+  alt?: string
+  name?: string
+}
+
+export const ThumbCard = styled<CardProps & React.ComponentProps<any>>(Box)`
+  cursor: pointer;
+  padding: 5px;
+  overflow: hidden;
+  transition: 0.2s ease-in-out;
+  &:hover {
+    transform: translateY(-5px);
+  }
+`
+
+export const ImageGalleryThumbnail = (props: ImageGalleryThumbnailProps) => {
+  const [thumbnailLoaded, setThumbnailLoaded] = useState<boolean>(false)
+
+  return (
+    <>
+      {!thumbnailLoaded && (
+        <Loader sx={{ mb: 3, mt: 4, width: 100, height: 67 }} />
+      )}
+      <ThumbCard
+        data-cy="thumbnail"
+        data-testid="thumbnail"
+        mb={3}
+        mt={4}
+        opacity={props.index === props.activeImageIndex ? 1.0 : 0.5}
+        onClick={() => props.setActiveIndex(props.index)}
+      >
+        <ThemeImage
+          loading="lazy"
+          src={props.thumbnailUrl}
+          alt={props.alt ?? props.name}
+          onLoad={() => setThumbnailLoaded(true)}
+          onError={() => setThumbnailLoaded(true)}
+          sx={{
+            width: thumbnailLoaded ? 100 : 0,
+            height: 67,
+            objectFit: props.allowPortrait ? 'contain' : 'cover',
+            borderRadius: 1,
+            border: '1px solid offWhite',
+          }}
+          crossOrigin=""
+        />
+      </ThumbCard>
+    </>
+  )
+}

--- a/packages/components/src/MapFilterList/MapFilterList.tsx
+++ b/packages/components/src/MapFilterList/MapFilterList.tsx
@@ -40,7 +40,9 @@ export const MapFilterList = (props: IProps) => {
   const isActive = (checkingFilter: string) =>
     !!activeFilters.find((filter) => filter.label === checkingFilter)
 
-  const buttonLabel = `${pinCount} result${pinCount === 1 ? '' : 's'} in current view`
+  const buttonLabel = `${pinCount} result${
+    pinCount === 1 ? '' : 's'
+  } in current view`
 
   return (
     <Flex

--- a/packages/components/src/MemberTypeVerticalList/MemberTypeVerticalList.client.tsx
+++ b/packages/components/src/MemberTypeVerticalList/MemberTypeVerticalList.client.tsx
@@ -35,7 +35,9 @@ export const MemberTypeVerticalList = (props: IProps) => {
         )
         return (
           <CardButton
-            data-cy={`MemberTypeVerticalList-Item${isSelected ? '-active' : ''}`}
+            data-cy={`MemberTypeVerticalList-Item${
+              isSelected ? '-active' : ''
+            }`}
             data-testid="MemberTypeVerticalList-Item"
             title={item._id}
             key={index}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Feature (adds functionality)

## What is the current behavior?

Images loading in are displayed while they are uncompleted. 

## What is the new behavior?

When Images load in, there is now the Applications Load Spinner.

## Does this PR introduce a breaking change?

No

## Git Issues

Closes #3462

## Additional Information

I've decided to move the Loadingspinner logic for the thumbnails into their own component, for a couple of reasons:

1. Keep the ImageGallery state as small as possible (to prevent rerenders)
2. Prevent rerender data loss, when images load at the exact same time (which is the main Reason)
3. Make the ImageGallery tighter

`packages/components/src/MapFilterList/MapFilterList.tsx` and `packages/components/src/MemberTypeVerticalList/MemberTypeVerticalList.client.tsx` I've only noticed now. I'm guessing they got in while linting/formatting (`yarn format && yarn lint`).