### PR TITLE
fix: truncate username when too long

### DIFF
--- a/packages/components/src/Username/Username.tsx
+++ b/packages/components/src/Username/Username.tsx
@@ -59,7 +59,18 @@ export const Username = ({ user, sx, target, isLink = true }: IProps) => {
         )}
       </Flex>
 
-      <Text sx={{ color: 'black' }}>{userName}</Text>
+      <Text
+        sx={{
+          color: 'black',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          maxWidth: '100%',
+        }}
+        title={userName}
+      >
+        {userName}
+      </Text>
       {isVerified && <UserBadge badgeName="verified" />}
       {isSupporter && <UserBadge badgeName="supporter" />}
     </Flex>

--- a/packages/documentation/docs/Testing/overview.md
+++ b/packages/documentation/docs/Testing/overview.md
@@ -25,7 +25,7 @@ yarn test
 ### Components
 
 ```
-yarn test
+yarn test:components
 ```
 
 ### Functions


### PR DESCRIPTION
## PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [X] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

https://github.com/ONEARMY/community-platform/issues/4101

![image](https://github.com/user-attachments/assets/36404139-df4d-4dc8-853e-1821ef4654be)

## What is the new behavior?

This PR truncates the Username when is longer than the limit of the page.
It also adds a Tooltip for users to see the username when it's truncated.

![image](https://github.com/user-attachments/assets/04bfce6a-4602-48bc-ae82-874c069130c0)
![truncate](https://github.com/user-attachments/assets/71765973-ec5b-4693-8a8f-81509804259c)

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [X] No

## Git Issues

Closes #4101

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
