### PR TITLE
fix: follow/usefulstats buttons colors

### DIFF
--- a/packages/components/src/FollowButton/FollowButton.tsx
+++ b/packages/components/src/FollowButton/FollowButton.tsx
@@ -26,15 +26,14 @@ export const FollowButton = (props: IProps) => {
         data-cy={isLoggedIn ? 'follow-button' : 'follow-redirect'}
         data-tooltip-id={uuid}
         data-tooltip-content={isLoggedIn ? '' : 'Login to follow'}
-        icon="thunderbolt"
         variant="outline"
-        iconColor={hasUserSubscribed ? 'subscribed' : 'notSubscribed'}
         sx={{
           fontSize: 2,
           py: 0,
           ...sx,
         }}
         onClick={() => (isLoggedIn ? onFollowClick() : navigate('/sign-in'))}
+        icon={hasUserSubscribed ? 'thunderbolt-grey' : 'thunderbolt'}
       >
         {hasUserSubscribed ? 'Following' : 'Follow'}
       </Button>

--- a/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
+++ b/packages/components/src/UsefulStatsButton/UsefulStatsButton.tsx
@@ -52,7 +52,7 @@ export const UsefulStatsButton = (props: IProps) => {
           },
           ...props.sx,
         }}
-        icon={props.hasUserVotedUseful ? 'star' : 'star-active'}
+        icon={props.hasUserVotedUseful ? 'star-active' : 'star'}
       >
         <Text
           pr={2}


### PR DESCRIPTION
## PR Checklist

- [X] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

Clicking on "Mark as useful" is reversed, and clicking on Follow does not change the icon color:
![image](https://github.com/user-attachments/assets/34d69887-a480-4706-80b2-c5813a6b0c3b)
![image](https://github.com/user-attachments/assets/d3f2029a-b7e5-488a-9e37-a4ff1bcc9696)

## What is the new behavior?

This PR fixes the follow and useful stats button colors, by showing a greyed out color when it was not clicked and colorful color when clicked.

[useful-follow.webm](https://github.com/user-attachments/assets/116b9a1e-e8ed-4bfc-9777-1eef86f8970f)

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [X] No

## Git Issues

Closes #4014

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
