### PR TITLE
feat: drop links as a required user field

### DIFF
--- a/packages/cypress/src/support/commandsUi.ts
+++ b/packages/cypress/src/support/commandsUi.ts
@@ -88,14 +88,8 @@ Cypress.Commands.add('saveSettingsForm', () => {
 
 Cypress.Commands.add('setSettingAddContactLink', (link: ILink) => {
   cy.step('Set Contact Link')
-
-  if (link.index > 0) {
-    // click the button to add another set of input fields
-    cy.get('[data-cy=add-link]').click()
-  }
-  // specifies the contact type, such as website or discord
+  cy.get('[data-cy=add-link]').click()
   cy.selectTag(link.label, `[data-cy=select-link-${link.index}]`)
-  // input the corresponding value
   cy.get(`[data-cy=input-link-${link.index}]`)
     .clear()
     .type(link.url)

--- a/shared/models/user.ts
+++ b/shared/models/user.ts
@@ -147,7 +147,7 @@ export interface IUser {
   // images will be in different formats if they are pending upload vs pulled from db
   coverImages: IUploadedFileMeta[]
   userImage?: IUploadedFileMeta
-  links: IExternalLink[]
+  links?: IExternalLink[]
   userRoles?: UserRole[]
   about?: string | null
   country?: string | null

--- a/src/pages/UserSettings/SettingsPageUserProfile.tsx
+++ b/src/pages/UserSettings/SettingsPageUserProfile.tsx
@@ -10,7 +10,6 @@ import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { logger } from 'src/logger'
 import { isContactable, isMessagingBlocked } from 'src/utils/helpers'
 import { Flex } from 'theme-ui'
-import { v4 as uuid } from 'uuid'
 
 import { FocusSection } from './content/sections/Focus.section'
 import { PublicContactSection } from './content/sections/PublicContact.section'
@@ -45,6 +44,8 @@ export const SettingsPageUserProfile = () => {
       cover ? true : false,
     )
 
+    toUpdate.links = toUpdate.links || []
+
     try {
       logger.debug({ profile: toUpdate }, 'SettingsPage.saveProfile')
       await userStore.updateUserProfile(toUpdate, 'settings-save-profile')
@@ -77,10 +78,6 @@ export const SettingsPageUserProfile = () => {
       errors.coverImages = []
       errors.coverImages[ARRAY_ERROR] = 'Must have at least one cover image'
     }
-    if (!v.links[0]) {
-      errors.links = []
-      errors.links[ARRAY_ERROR] = 'Must have at least one valid link'
-    }
     return errors
   }
 
@@ -88,15 +85,11 @@ export const SettingsPageUserProfile = () => {
     .fill(null)
     .map((v, i) => (user.coverImages[i] ? user.coverImages[i] : v))
 
-  const links = (user && user.links?.length > 0 ? user.links : [{} as any]).map(
-    (i) => ({ ...i, key: uuid() }),
-  )
-
   const initialValues = {
     profileType: user.profileType || ProfileTypeList.MEMBER,
     displayName: user.displayName || null,
     userName: user.userName,
-    links,
+    links: user.links || [],
     location: user.location || null,
     about: user.about || null,
     isContactableByPublic: isContactable(user.isContactableByPublic),
@@ -128,6 +121,7 @@ export const SettingsPageUserProfile = () => {
         if (isLoading) return <Loader sx={{ alignSelf: 'center' }} />
 
         const isMember = values.profileType === ProfileTypeList.MEMBER
+        console.log(values.links)
 
         return (
           <Flex sx={{ flexDirection: 'column', gap: 4 }}>

--- a/src/pages/UserSettings/content/fields/ProfileLink.field.tsx
+++ b/src/pages/UserSettings/content/fields/ProfileLink.field.tsx
@@ -127,7 +127,6 @@ export const ProfileLinkField = (props: IProps) => {
         component={FieldInput}
         placeholder={fields.links.placeholder}
         format={(v) => formatLink(v, state.linkType)}
-        formatOnBlur={true}
       />
       {isDeleteEnabled ? <DeleteButton /> : null}
       {

--- a/src/pages/UserSettings/content/sections/UserInfos.section.tsx
+++ b/src/pages/UserSettings/content/sections/UserInfos.section.tsx
@@ -25,7 +25,7 @@ import { FlexSectionContainer } from '../elements'
 import { ProfileLinkField } from '../fields/ProfileLink.field'
 import { ProfileTags } from './ProfileTags.section'
 
-import type { IUser } from 'oa-shared'
+import type { IExternalLink, IUser } from 'oa-shared'
 
 interface IProps {
   formValues: Partial<IUser>
@@ -154,27 +154,27 @@ export const UserInfosSection = ({ formValues }: IProps) => {
             gap: [4, 4, 2],
           }}
         >
-          <Text>{`${fields.links.title} *`}</Text>
-          <FieldArray name="links" initialValue={links}>
+          <Text>{fields.links.title}</Text>
+          <FieldArray name="links" initialValue={links as IExternalLink[]}>
             {({ fields }) => (
               <>
                 {fields
                   ? fields.map((name, i: number) => (
                       <ProfileLinkField
-                        key={fields.value[i].key}
+                        key={i}
                         name={name}
                         onDelete={() => {
                           fields.remove(i)
                         }}
                         index={i}
-                        isDeleteEnabled={i > 0 || (fields as any).length > 1}
+                        isDeleteEnabled={true}
                       />
                     ))
                   : null}
                 <Button
                   type="button"
                   data-cy="add-link"
-                  variant="quiet"
+                  variant="secondary"
                   onClick={() => {
                     fields.push({} as any)
                   }}

--- a/src/pages/UserSettings/labels.ts
+++ b/src/pages/UserSettings/labels.ts
@@ -16,7 +16,7 @@ export const buttons = {
   },
   guidelines: 'Check out our guidelines',
   link: {
-    add: 'Add another link',
+    add: 'Add link',
     type: 'type',
   },
   map: 'Add a map pin',

--- a/src/services/userService.server.ts
+++ b/src/services/userService.server.ts
@@ -86,7 +86,6 @@ const createFirebaseProfile = async (authUser: User) => {
   const user: IUser & { _id: string } = {
     _id: username,
     coverImages: [],
-    links: [],
     verified: false,
     _authID: '',
     displayName: username,

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -291,7 +291,6 @@ export class UserStore extends ModuleStore {
     }
     const user: IUser = {
       coverImages: [],
-      links: [],
       verified: false,
       _authID: '',
       displayName: userName,

--- a/src/utils/isProfileComplete.test.ts
+++ b/src/utils/isProfileComplete.test.ts
@@ -43,18 +43,6 @@ describe('isProfileComplete', () => {
 
         expect(isProfileComplete(user)).toBe(false)
       })
-      it('no links', () => {
-        const missingLinks = {
-          about: 'A member',
-          displayName: 'Jeffo',
-          links: [],
-          profileType: ProfileTypeList.MEMBER,
-          userImage: factoryImage,
-        }
-        const user = FactoryUser(missingLinks)
-
-        expect(isProfileComplete(user)).toBe(false)
-      })
       it('no userImage', () => {
         const missingUserImage = {
           about: 'A member',
@@ -105,18 +93,6 @@ describe('isProfileComplete', () => {
           coverImages: [factoryImage],
         }
         const user = FactoryUser(missingDisplayName)
-
-        expect(isProfileComplete(user)).toBe(false)
-      })
-      it('no links', () => {
-        const missingLinks = {
-          about: 'An important space',
-          displayName: 'Jeffo',
-          links: [],
-          profileType: ProfileTypeList.WORKSPACE,
-          coverImages: [factoryImage],
-        }
-        const user = FactoryUser(missingLinks)
 
         expect(isProfileComplete(user)).toBe(false)
       })

--- a/src/utils/isProfileComplete.ts
+++ b/src/utils/isProfileComplete.ts
@@ -7,9 +7,9 @@ const nonMemberProfileTypes = Object.values(ProfileTypeList).filter(
 )
 
 export const isProfileComplete = (user: IUserDB): boolean => {
-  const { about, coverImages, displayName, links, userImage } = user
+  const { about, coverImages, displayName, userImage } = user
 
-  const isBasicInfoFilled = !!(about && displayName && links?.length !== 0)
+  const isBasicInfoFilled = !!(about && displayName)
 
   const isMember = user.profileType === ProfileTypeList.MEMBER
   const isSpace = !!nonMemberProfileTypes.find(


### PR DESCRIPTION
## PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the new behavior?

* Links no longer a required field when a user fills in their profile.
* Empty/no links no longer a variable when showing the incomplete profile banner.

