### PR TITLE
feat: block actions from incomplete profiles

### DIFF
--- a/packages/cypress/src/integration/library/write.spec.ts
+++ b/packages/cypress/src/integration/library/write.spec.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { DifficultyLevel, IModerationStatus } from 'oa-shared'
 
 import { MOCK_DATA } from '../../data'
+import { generateNewUserDetails } from '../../utils/TestUtils'
 
 describe('[Library]', () => {
   beforeEach(() => {
@@ -180,7 +181,6 @@ describe('[Library]', () => {
 
       cy.get('[data-cy="sign-up"]')
       cy.signIn(creator.email, creator.password)
-      cy.get('[data-cy=loader]').should('not.exist')
       cy.get('[data-cy="MemberBadge-member"]').should('be.visible')
       cy.visit('/library')
 
@@ -334,6 +334,23 @@ describe('[Library]', () => {
       cy.get('[data-cy=intro-title]').clear().blur({ force: true })
       cy.get('[data-cy=page-link][href*="/library"]').click()
       cy.url().should('match', /\/library?/)
+    })
+
+    it('[Incomplete Users]', () => {
+      const user = generateNewUserDetails()
+      cy.signUpNewUser(user)
+
+      cy.step("Can't add a library project with an incomplete profile")
+      cy.visit('/library')
+      cy.get('[data-cy=create-project]').should('not.exist')
+      cy.get('[data-cy=complete-profile-project]').should('be.visible')
+
+      cy.completeUserProfile(user.username)
+
+      cy.step('Can add a library project now profile is complete')
+      cy.visit('/library')
+      cy.get('[data-cy=create-project]').should('be.visible')
+      cy.get('[data-cy=complete-profile-project]').should('not.exist')
     })
   })
 })

--- a/packages/cypress/src/integration/library/write.spec.ts
+++ b/packages/cypress/src/integration/library/write.spec.ts
@@ -314,8 +314,27 @@ describe('[Library]', () => {
 
     it('[By Anonymous]', () => {
       cy.step('Ask users to login before creating a project')
+      cy.visit('/library')
+      cy.get('[data-cy=create-project]').should('not.exist')
+      cy.get('[data-cy=sign-up]').should('be.visible')
+
       cy.visit('/library/create')
-      cy.get('div').contains('Please login to access this page')
+      cy.get('[data-cy=logged-out-message]').should('be.visible')
+      cy.get('[data-cy=intro-title]').should('not.exist')
+    })
+
+    it('[By Incomplete Profile User]', () => {
+      const user = generateNewUserDetails()
+      cy.signUpNewUser(user)
+
+      cy.step("Can't add to library")
+      cy.visit('/library')
+      cy.get('[data-cy=create-project]').should('not.exist')
+      cy.get('[data-cy=complete-profile-project]').should('be.visible')
+
+      cy.visit('/library/create')
+      cy.get('[data-cy=incomplete-profile-message]').should('be.visible')
+      cy.get('[data-cy=intro-title]').should('not.exist')
     })
 
     it('[Warning on leaving page]', () => {

--- a/packages/cypress/src/integration/questions/discussions.spec.ts
+++ b/packages/cypress/src/integration/questions/discussions.spec.ts
@@ -25,9 +25,16 @@ describe('[Questions.Discussions]', () => {
 
     cy.signUpNewUser(visitor)
 
-    cy.step('Can add comment')
+    cy.step("Can't add comment with an incomplete profile")
+    cy.visit(questionPath)
+    cy.get('[data-cy=comments-form]').should('not.exist')
+    cy.get('[data-cy=comments-incomplete-profile-prompt]').should('be.visible')
+
+    cy.step('Can add comment when profile is complete')
+    cy.completeUserProfile(visitor.username)
     cy.visit(questionPath)
     cy.contains('Start the discussion')
+    cy.get('[data-cy=comments-incomplete-profile-prompt]').should('not.exist')
     cy.addComment(newComment)
     cy.contains('1 Comment')
 
@@ -37,7 +44,7 @@ describe('[Questions.Discussions]', () => {
     cy.step('Another user can add reply')
     const secondCommentor = generateNewUserDetails()
     cy.logout()
-    cy.signUpNewUser(secondCommentor)
+    cy.signUpCompletedUser(secondCommentor)
     cy.visit(questionPath)
     cy.addReply(newReply)
     cy.wait(1000)

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -58,10 +58,11 @@ describe('[Question]', () => {
       cy.get('[data-cy=field-description]').type(initialQuestionDescription, {
         delay: 0,
       })
-
       cy.step('Add category')
       cy.selectTag(category, '[data-cy=category-select]')
 
+      // Bug: Tags missing in test suite setup
+      //
       // cy.step('Add tags')
       // cy.selectTag(tag1, '[data-cy="tag-select"]')
       // cy.selectTag(tag2, '[data-cy="tag-select"]')
@@ -112,16 +113,16 @@ describe('[Question]', () => {
         .should('include', `/questions/${updatedExpectedSlug}`)
       cy.contains(updatedTitle)
 
-      cy.step('Can access the question with the previous slug')
-      cy.visit(`/questions/${initialExpectedSlug}`)
-      cy.contains(updatedTitle)
-
-      // Commented out until test indexes issue solved
+      // Bug: Missing previous slug functionality
       //
-      // cy.step('All updated fields visiable on list')
-      // cy.visit('/questions')
+      // cy.step('Can access the question with the previous slug')
+      // cy.visit(`/questions/${initialExpectedSlug}`)
       // cy.contains(updatedTitle)
-      // cy.contains(category)
+
+      cy.step('All updated fields visiable on list')
+      cy.visit('/questions')
+      cy.contains(updatedTitle)
+      cy.contains(category)
     })
   })
 })

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -124,5 +124,16 @@ describe('[Question]', () => {
       cy.contains(updatedTitle)
       cy.contains(category)
     })
+
+    it('[By Anonymous]', () => {
+      cy.step('Ask users to login before creating a question')
+      cy.visit('/questions')
+      cy.get('[data-cy=create-question]').should('not.exist')
+      cy.get('[data-cy=sign-up]').should('be.visible')
+
+      cy.visit('/questions/create')
+      cy.pause()
+      cy.get('[data-cy=logged-out-message]').should('be.visible')
+    })
   })
 })

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -1,117 +1,127 @@
-// import { seedCategories, seedTags } from '../../support/seedQuestions'
-// import { generateAlphaNumeric } from '../../utils/TestUtils'
+import {
+  generateAlphaNumeric,
+  generateNewUserDetails,
+} from '../../utils/TestUtils'
 
-// describe('[Question]', () => {
-//   before(() => {
-//     cy.then(async () => {
-//       await Promise.all([seedTags(), seedCategories()])
-//     })
-//   })
+describe('[Question]', () => {
+  describe('[Create a question]', () => {
+    const initialRandomId = generateAlphaNumeric(8).toLowerCase()
+    const initialTitle = initialRandomId + ' Health cost of plastic?'
+    const initialExpectedSlug = initialRandomId + '-health-cost-of-plastic'
+    const initialQuestionDescription =
+      "Hello! I'm wondering how people feel about the health concerns about working with melting plastic and being in environments with microplastics. I have been working with recycling plastic (hdpe) for two years now, shredding and injection molding and haven't had any bad consequences yet. But with the low knowledge around micro plastics and its effects on the human body, and many concerns and hypotheses I have been a bit concerned lately.So I would like to ask the people in this community how you are feeling about it, and if you have experienced any issues with the microplastics or gases yet, if so how long have you been working with it? And what extra steps do you take to be protected from it? I use a gas mask with dust filters"
+    const category = 'Moulds'
+    // const tag1 = 'product'
+    // const tag2 = 'workshop'
+    const updatedRandomId = generateAlphaNumeric(8).toLowerCase()
+    const updatedTitle = updatedRandomId + ' Real health cost of plastic?'
+    const updatedExpectedSlug = updatedRandomId + '-real-health-cost-of-plastic'
+    const updatedQuestionDescription = `${initialQuestionDescription} and super awesome goggles`
 
-//   describe('[Create a question]', () => {
-//     const initialRandomId = generateAlphaNumeric(8).toLowerCase()
-//     const initialTitle = initialRandomId + ' Health cost of plastic?'
-//     const initialExpectedSlug = initialRandomId + '-health-cost-of-plastic'
-//     const initialQuestionDescription =
-//       "Hello! I'm wondering how people feel about the health concerns about working with melting plastic and being in environments with microplastics. I have been working with recycling plastic (hdpe) for two years now, shredding and injection molding and haven't had any bad consequences yet. But with the low knowledge around micro plastics and its effects on the human body, and many concerns and hypotheses I have been a bit concerned lately.So I would like to ask the people in this community how you are feeling about it, and if you have experienced any issues with the microplastics or gases yet, if so how long have you been working with it? And what extra steps do you take to be protected from it? I use a gas mask with dust filters"
-//     const category = 'Moulds'
-//     const tag1 = 'product'
-//     const tag2 = 'workshop'
-//     const updatedRandomId = generateAlphaNumeric(8).toLowerCase()
-//     const updatedTitle = updatedRandomId + ' Real health cost of plastic?'
-//     const updatedExpectedSlug = updatedRandomId + '-real-health-cost-of-plastic'
-//     const updatedQuestionDescription = `${initialQuestionDescription} and super awesome goggles`
+    it('[By Authenticated]', () => {
+      cy.visit('/questions')
+      const user = generateNewUserDetails()
+      cy.signUpNewUser(user)
 
-//     it('[By Authenticated]', () => {
-//      cy.visit('/questions')
-//      cy.get('[data-cy="sign-up"]')
-//       cy.signUpNewUser()
+      cy.step("Can't add question with an incomplete profile")
+      cy.visit('/questions')
+      cy.get('[data-cy=create-question]').should('not.exist')
+      cy.get('[data-cy=complete-profile-question]').should('be.visible')
+      cy.visit('/questions/create')
+      cy.get('[data-cy=incomplete-profile-message]').should('be.visible')
+      cy.get('[data-cy=question-create-title]').should('not.exist')
 
-//       cy.step('Go to create page')
-//       cy.visit('/questions/create')
-//       cy.get('[data-cy=question-create-title]', { timeout: 20000 })
+      cy.completeUserProfile(user.username)
 
-//       cy.step('Add title field')
-//       cy.get('[data-cy=field-title]')
-//         .clear()
-//         .type(initialTitle)
-//         .blur({ force: true })
+      cy.step('Can add a library project now profile is complete')
+      cy.visit('/questions')
+      cy.get('[data-cy=complete-profile-question]').should('not.exist')
+      cy.get('[data-cy=create-question]').click()
 
-//       cy.step('Add title description')
-//       cy.get('[data-cy=field-description]').type(initialQuestionDescription, {
-//         delay: 0,
-//       })
+      cy.get('[data-cy=question-create-title]', { timeout: 20000 })
 
-//       cy.step('Add images')
-//       cy.get('[data-cy=image-upload-0]')
-//         .find(':file')
-//         .attachFile('images/howto-step-pic1.jpg')
-//       cy.get('[data-cy=image-upload-1]')
-//         .find(':file')
-//         .attachFile('images/howto-step-pic2.jpg')
+      // cy.step('Add images')
+      // cy.get('[data-cy=image-upload-0]')
+      //   .find(':file')
+      //   .attachFile('images/howto-step-pic1.jpg')
+      // cy.get('[data-cy=image-upload-1]')
+      //   .find(':file')
+      //   .attachFile('images/howto-step-pic2.jpg')
 
-//       cy.step('Add category')
-//       cy.selectTag(category, '[data-cy=category-select]')
+      cy.step('Add title field')
+      cy.get('[data-cy=field-title]')
+        .clear()
+        .type(initialTitle)
+        .blur({ force: true })
 
-//       cy.step('Add tags')
-//       cy.selectTag(tag1, '[data-cy="tag-select"]')
-//       cy.selectTag(tag2, '[data-cy="tag-select"]')
+      cy.step('Add title description')
+      cy.get('[data-cy=field-description]').type(initialQuestionDescription, {
+        delay: 0,
+      })
 
-//       cy.step('Submit question')
-//       cy.get('[data-cy=submit]')
-//         .click()
-//         .url()
-//         .should('include', `/questions/${initialExpectedSlug}`)
+      cy.step('Add category')
+      cy.selectTag(category, '[data-cy=category-select]')
 
-//       cy.step('All question fields visible')
-//       cy.contains(initialTitle)
-//       cy.contains(initialQuestionDescription)
-//       cy.contains(category)
-//       cy.contains(tag1)
-//       cy.contains(tag2)
+      // cy.step('Add tags')
+      // cy.selectTag(tag1, '[data-cy="tag-select"]')
+      // cy.selectTag(tag2, '[data-cy="tag-select"]')
 
-//       cy.step('Edit question')
-//       cy.get('[data-cy=edit]')
-//         .click()
-//         .url()
-//         .should('include', `/questions/${initialExpectedSlug}/edit`)
+      cy.step('Submit question')
+      cy.get('[data-cy=submit]')
+        .click()
+        .url()
+        .should('include', `/questions/${initialExpectedSlug}`)
 
-//       cy.step('Add title description')
-//       cy.get('[data-cy=field-description]')
-//         .clear()
-//         .type(updatedQuestionDescription, { delay: 0 })
+      cy.step('All question fields visible')
+      cy.contains(initialTitle)
+      cy.contains(initialQuestionDescription)
+      cy.contains(category)
+      // cy.contains(tag1)
+      // cy.contains(tag2)
+      // contains images
 
-//       cy.step('Update images by removing one')
-//       cy.get('[data-cy=image-upload-0]')
-//         .get('[data-cy=delete-image]:first')
-//         .click({ force: true })
+      cy.step('Edit question')
+      cy.get('[data-cy=edit]')
+        .click()
+        .url()
+        .should('include', `/questions/${initialExpectedSlug}/edit`)
 
-//       cy.step('Updated question details shown')
-//       cy.get('[data-cy=submit]')
-//         .click()
-//         .url()
-//         .should('include', `/questions/${initialExpectedSlug}`)
-//       cy.contains(updatedQuestionDescription)
+      cy.step('Add title description')
+      cy.get('[data-cy=field-description]')
+        .clear()
+        .type(updatedQuestionDescription, { delay: 0 })
 
-//       cy.step('Updating the title changes the slug')
-//       cy.get('[data-cy=edit]').click()
-//       cy.get('[data-cy=field-title]').clear().type(updatedTitle).blur()
-//       cy.get('[data-cy=submit]')
-//         .click()
-//         .url()
-//         .should('include', `/questions/${updatedExpectedSlug}`)
-//       cy.contains(updatedTitle)
+      // cy.step('Update images by removing one')
+      // cy.get('[data-cy=image-upload-0]')
+      //   .get('[data-cy=delete-image]:first')
+      //   .click({ force: true })
 
-//       cy.step('Can access the question with the previous slug')
-//       cy.visit(`/questions/${initialExpectedSlug}`)
-//       cy.contains(updatedTitle)
+      cy.step('Updated question details shown')
+      cy.get('[data-cy=submit]')
+        .click()
+        .url()
+        .should('include', `/questions/${initialExpectedSlug}`)
+      cy.contains(updatedQuestionDescription)
 
-//       // Commented out until test indexes issue solved
-//       //
-//       // cy.step('All updated fields visiable on list')
-//       // cy.visit('/questions')
-//       // cy.contains(updatedTitle)
-//       // cy.contains(category)
-//     })
-//   })
-// })
+      cy.step('Updating the title changes the slug')
+      cy.get('[data-cy=edit]').click()
+      cy.get('[data-cy=field-title]').clear().type(updatedTitle).blur()
+      cy.get('[data-cy=submit]')
+        .click()
+        .url()
+        .should('include', `/questions/${updatedExpectedSlug}`)
+      cy.contains(updatedTitle)
+
+      cy.step('Can access the question with the previous slug')
+      cy.visit(`/questions/${initialExpectedSlug}`)
+      cy.contains(updatedTitle)
+
+      // Commented out until test indexes issue solved
+      //
+      // cy.step('All updated fields visiable on list')
+      // cy.visit('/questions')
+      // cy.contains(updatedTitle)
+      // cy.contains(category)
+    })
+  })
+})

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -4,6 +4,7 @@ import { RESEARCH_TITLE_MIN_LENGTH } from '../../../../../src/pages/Research/con
 import { MOCK_DATA } from '../../data'
 import {
   generateAlphaNumeric,
+  generateNewUserDetails,
   setIsPreciousPlastic,
 } from '../../utils/TestUtils'
 
@@ -59,8 +60,21 @@ describe('[Research]', () => {
       const updateDescription = 'This is the description for the update.'
       const updateVideoUrl = 'http://youtube.com/watch?v=sbcWY7t-JX8'
       const newCollaborator = MOCK_DATA.users.subscriber
+
+      const user = generateNewUserDetails()
+      cy.signUpNewUser(user)
+
+      cy.step("Can't add research with an incomplete profile")
+      cy.visit('/research')
+      cy.get('[data-cy=create-research]').should('not.exist')
+      cy.get('[data-cy=complete-profile-research]').should('be.visible')
+      cy.visit('/research/create')
+      cy.get('[data-cy=incomplete-profile-message]').should('be.visible')
+      cy.get('[data-cy=intro-title]').should('not.exist')
+      cy.completeUserProfile(user.username)
+
       cy.step('Create the research article')
-      cy.signUpCompletedUser()
+      cy.completeUserProfile(user.username)
       setIsPreciousPlastic()
       cy.visit('/research')
       cy.get('[data-cy=loader]').should('not.exist')
@@ -215,8 +229,12 @@ describe('[Research]', () => {
 
     it('[By Anonymous]', () => {
       cy.step('Ask users to login before creating a research item')
+      cy.visit('/research')
+      cy.get('[data-cy=create]').should('not.exist')
+      cy.get('[data-cy=sign-up]').should('be.visible')
+
       cy.visit('/research/create')
-      cy.get('div').contains('role required to access this page')
+      cy.get('[data-cy=logged-out-message]').should('be.visible')
     })
 
     it('[New PK user]', () => {

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -33,6 +33,25 @@ describe('[Research]', () => {
   })
 
   describe('[Create research article]', () => {
+    it('[Warning on leaving page]', () => {
+      cy.signIn(researcherEmail, researcherPassword)
+      cy.visit('/research')
+      cy.step('Access the create research article')
+      cy.get('[data-cy=create]').click()
+      cy.get('[data-cy=intro-title')
+        .clear()
+        .type('Create research article test')
+        .blur({ force: true })
+      cy.get('[data-cy=page-link][href*="/research"]').click()
+      cy.get('[data-cy="Confirm.modal: Cancel"]').click()
+
+      cy.url().should('match', /\/research\/create$/)
+
+      cy.step('Clear title input')
+      cy.get('[data-cy=intro-title').clear().blur({ force: true })
+      cy.url().should('match', /\/research?/)
+    })
+
     it('[By Authenticated]', () => {
       const expected = generateArticle()
 
@@ -41,10 +60,10 @@ describe('[Research]', () => {
       const updateVideoUrl = 'http://youtube.com/watch?v=sbcWY7t-JX8'
       const newCollaborator = MOCK_DATA.users.subscriber
       cy.step('Create the research article')
-      cy.signIn(researcherEmail, researcherPassword)
+      cy.signUpCompletedUser()
+      setIsPreciousPlastic()
       cy.visit('/research')
       cy.get('[data-cy=loader]').should('not.exist')
-      cy.get('a[href="/research/create"]').should('be.visible')
       cy.get('[data-cy=create]').click()
 
       cy.step('Warn if title is identical to an existing one')
@@ -200,97 +219,24 @@ describe('[Research]', () => {
       cy.get('div').contains('role required to access this page')
     })
 
-    it('[Any PP user]', () => {
-      const randomId = generateAlphaNumeric(8).toLowerCase()
-      const title = randomId + ' PP plastic stuff'
-      const expectSlug = randomId + '-pp-plastic-stuff'
-      const description = 'Bespoke research topic'
+    it('[New PK user]', () => {
+      localStorage.setItem('VITE_THEME', 'project-kamp')
+      cy.signUpCompletedUser()
 
-      const updateTitle = 'First wonderful update'
-      const updateDescription =
-        'Update. One. Ready to start with the observations.'
-      const updateVideoUrl = 'https://www.youtube.com/watch?v=U3mrj84p3cM'
-
-      cy.signIn(
-        MOCK_DATA.users.research_reader.email,
-        MOCK_DATA.users.research_reader.password,
-      )
-      setIsPreciousPlastic()
-      cy.step('Can access create form')
+      cy.step("Can't create research")
       cy.visit('/research')
       cy.wait(2000)
-      cy.get('[data-cy=loader]').should('not.exist')
-      cy.get('[data-cy=create]').should('be.visible')
-      cy.get('a[href="/research/create"]').should('be.visible')
-
-      cy.step('Enter research article details')
-      cy.visit('/research/create')
-      cy.get('[data-cy=intro-title').clear().type(title).blur({ force: true })
-
-      cy.get('[data-cy=intro-description]')
-        .wait(0)
-        .focus()
-        .clear()
-        .clear({ force: true })
-        .type(description)
-
-      cy.get('[data-cy=submit]').click()
-      cy.step('Publishes as expected')
-      cy.get('[data-cy=view-research]:enabled', { timeout: 20000 })
-        .click()
-        .url()
-        .should('include', `/research/${expectSlug}`)
-
-      cy.contains(title).should('be.visible')
-      cy.contains(description).should('be.visible')
-
-      cy.step('Can add update')
-      cy.get('[data-cy=addResearchUpdateButton]').click()
-      cy.fillIntroTitle(updateTitle)
-
-      cy.get('[data-cy=intro-description]')
-        .wait(0)
-        .focus()
-        .clear()
-        .type(updateDescription)
-        .blur({ force: true })
-
-      cy.get('[data-cy=videoUrl]')
-        .clear()
-        .type(updateVideoUrl)
-        .blur({ force: true })
-
-      cy.step('Update is published')
-      cy.get('[data-cy=submit]').click()
-
-      cy.step('Open the research update')
-      cy.get('[data-cy=view-research]:enabled', { timeout: 20000 })
-        .click()
-        .url()
-
-      cy.contains(updateTitle).should('be.visible')
-      cy.contains(updateDescription).should('be.visible')
+      cy.get('[data-cy=create]').should('not.exist')
     })
 
-    it('[Warning on leaving page]', () => {
+    it('[PK user with research creator role]', () => {
+      localStorage.setItem('VITE_THEME', 'project-kamp')
       cy.signIn(researcherEmail, researcherPassword)
+
+      cy.step('Can create research')
       cy.visit('/research')
-      cy.step('Access the create research article')
-      cy.get('[data-cy=loader]').should('not.exist')
-      cy.get('a[href="/research/create"]').should('be.visible')
-      cy.get('[data-cy=create]').click()
-      cy.get('[data-cy=intro-title')
-        .clear()
-        .type('Create research article test')
-        .blur({ force: true })
-      cy.get('[data-cy=page-link][href*="/research"]').click()
-      cy.get('[data-cy="Confirm.modal: Cancel"]').click()
-
-      cy.url().should('match', /\/research\/create$/)
-
-      cy.step('Clear title input')
-      cy.get('[data-cy=intro-title').clear().blur({ force: true })
-      cy.url().should('match', /\/research?/)
+      cy.get('[data-cy=create]').should('be.visible')
+      cy.get('[data-cy=complete-profile-research]').should('not.exist')
     })
   })
 

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -63,6 +63,8 @@ describe('[Settings]', () => {
       const user = generateNewUserDetails()
       cy.signUpNewUser(user)
 
+      cy.clickMenuItem(UserMenuItem.Profile)
+
       cy.step('Incomplete profile banner visible')
       cy.get('[data-cy=incompleteProfileBanner]').click()
 
@@ -273,6 +275,7 @@ describe('[Settings]', () => {
 
       const user = generateNewUserDetails()
       cy.signUpNewUser(user)
+
       cy.visit('/settings')
 
       cy.step('Can set the required fields')
@@ -315,7 +318,6 @@ describe('[Settings]', () => {
 
       cy.step('Go to User Settings')
       cy.visit('/settings')
-
       cy.setSettingFocus(profileType)
 
       cy.step("Can't save without required fields being populated")

--- a/packages/cypress/src/support/commandsUi.ts
+++ b/packages/cypress/src/support/commandsUi.ts
@@ -10,7 +10,7 @@ export enum UserMenuItem {
 }
 
 interface IInfo {
-  displayName: string
+  displayName?: string
   country?: string
   description: string
 }
@@ -65,6 +65,8 @@ declare global {
       setSettingPublicContact()
 
       signUpNewUser(user?): Chainable<void>
+      signUpCompletedUser(user?): Chainable<void>
+      completeUserProfile(username: string): Chainable<void>
       confirmUser(username: string): Chainable<void>
 
       toggleUserMenuOn(): Chainable<void>
@@ -100,7 +102,7 @@ Cypress.Commands.add('setSettingBasicUserInfo', (info: IInfo) => {
   const { country, description, displayName } = info
 
   cy.step('Update Info section')
-  cy.get('[data-cy=displayName').clear().type(displayName)
+  displayName && cy.get('[data-cy=displayName').clear().type(displayName)
   cy.get('[data-cy=info-description').clear().type(description)
   country && cy.selectTag(country, '[data-cy=location-dropdown]')
 })
@@ -169,6 +171,7 @@ Cypress.Commands.add('signIn', (email: string, password: string) => {
   cy.get('[data-cy=email]').clear().type(email)
   cy.get('[data-cy=password]').clear().type(password)
   cy.get('[data-cy=submit]').click()
+  cy.get('[data-cy=loader]').should('not.exist')
 })
 
 Cypress.Commands.add('logout', () => {
@@ -260,4 +263,23 @@ Cypress.Commands.add('signUpNewUser', (user?) => {
   cy.fillSignupForm(username, email, password)
   cy.get('[data-cy=submit]').click()
   cy.url().should('include', 'sign-up-message')
+})
+
+Cypress.Commands.add('completeUserProfile', (username) => {
+  const userImage = 'avatar'
+
+  cy.log('Complete user profile')
+  cy.visit('/settings')
+  cy.setSettingImage(userImage, 'userImage')
+  cy.wait(1500)
+  cy.setSettingBasicUserInfo({
+    description: `${username} profile description.`,
+  })
+  cy.saveSettingsForm()
+})
+
+Cypress.Commands.add('signUpCompletedUser', (user?) => {
+  const { username } = user || generateNewUserDetails()
+  cy.signUpNewUser(user)
+  cy.completeUserProfile(username)
 })

--- a/packages/themes/src/common/button.ts
+++ b/packages/themes/src/common/button.ts
@@ -30,6 +30,15 @@ export const getButtons = (colors: ThemeWithName['colors']) => ({
       backgroundColor: colors.accent.base,
     },
   },
+  disabled: {
+    ...BASE_BUTTON,
+    color: colors.black,
+    backgroundColor: colors.accent.base,
+    opacity: 0.5,
+    '&:hover': {
+      backgroundColor: colors.accent.hover,
+    },
+  },
   secondary: {
     ...BASE_BUTTON,
     border: '2px solid ' + colors.black,

--- a/src/common/UserAction.tsx
+++ b/src/common/UserAction.tsx
@@ -1,25 +1,39 @@
-import { useContext } from 'react'
-import { SessionContext } from 'src/pages/common/SessionContext'
+import { observer } from 'mobx-react'
+import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import { isProfileComplete } from 'src/utils/isProfileComplete'
 
 interface IProps {
+  incompleteProfile?: React.ReactNode | null
   loggedIn: React.ReactNode
   loggedOut: React.ReactNode | null
 }
 
-type IUserVerificationConditions = 'loggedIn' | 'loggedOut'
+type IUserVerificationConditions =
+  | 'incompleteProfile'
+  | 'loggedIn'
+  | 'loggedOut'
 
-export const UserAction = (props: IProps) => {
-  const session = useContext(SessionContext)
-  const { loggedIn, loggedOut } = props
+export const UserAction = observer((props: IProps) => {
+  const { incompleteProfile, loggedIn, loggedOut } = props
+  const { userStore } = useCommonStores().stores
 
-  const userCondition: IUserVerificationConditions = session?.id
-    ? 'loggedIn'
-    : 'loggedOut'
+  const activeUser = userStore.activeUser
+  const isLoggedIn = !!activeUser
+  const isUserProfileComplete = isLoggedIn && isProfileComplete(activeUser)
+
+  const options: { [key in IUserVerificationConditions]: boolean } = {
+    incompleteProfile: isLoggedIn && !isUserProfileComplete,
+    loggedIn: isLoggedIn && isUserProfileComplete,
+    loggedOut: !isLoggedIn,
+  }
+  const userCondition = Object.keys(options).find((option) => options[option])
 
   switch (userCondition) {
+    case 'incompleteProfile':
+      return incompleteProfile || loggedIn
     case 'loggedIn':
       return loggedIn
     default:
       return loggedOut
   }
-}
+})

--- a/src/pages/Library/Content/List/LibraryListHeader.tsx
+++ b/src/pages/Library/Content/List/LibraryListHeader.tsx
@@ -6,6 +6,7 @@ import {
   ReturnPathLink,
   SearchField,
   Select,
+  Tooltip,
 } from 'oa-components'
 import { FieldContainer } from 'src/common/Form/FieldContainer'
 import { UserAction } from 'src/common/UserAction'
@@ -143,6 +144,24 @@ export const LibraryListHeader = (props: IProps) => {
 
   const actionComponents = (
     <UserAction
+      incompleteProfile={
+        <>
+          <Link
+            to="/settings"
+            data-tooltip-id="tooltip"
+            data-tooltip-content={listing.incompleteProfile}
+          >
+            <Button
+              type="button"
+              data-cy="complete-profile-project"
+              variant="disabled"
+            >
+              {listing.create}
+            </Button>
+          </Link>
+          <Tooltip id="tooltip" />
+        </>
+      }
       loggedIn={
         <>
           <DraftButton

--- a/src/pages/Library/labels.ts
+++ b/src/pages/Library/labels.ts
@@ -163,6 +163,7 @@ export const steps: ILabels = {
 export const listing = {
   create: 'Add your project',
   join: 'Sign up to add your project',
+  incompleteProfile: 'Complete your profile to add your project',
   empty: 'No projects to show!',
   usefulness: 'How useful it is',
   totalComments: 'Total comments',

--- a/src/pages/Library/labels.ts
+++ b/src/pages/Library/labels.ts
@@ -162,13 +162,15 @@ export const steps: ILabels = {
 
 export const listing = {
   create: 'Add your project',
-  join: 'Sign up to add your project',
-  incompleteProfile: 'Complete your profile to add your project',
   empty: 'No projects to show!',
-  usefulness: 'How useful it is',
-  totalComments: 'Total comments',
   filterCategory: 'Filter by category',
+  incompleteProfile: 'Complete your profile to add your project',
+  join: 'Sign up to add your project',
+  loadMore: 'Load More',
+  loggedOut:
+    'We need that password of yours before learning about your awesome project...',
+  totalComments: 'Total comments',
   search: 'Search the library',
   sort: 'Sort by category',
-  loadMore: 'Load More',
+  usefulness: 'How useful it is',
 }

--- a/src/pages/Question/QuestionListHeader.tsx
+++ b/src/pages/Question/QuestionListHeader.tsx
@@ -6,6 +6,7 @@ import {
   ReturnPathLink,
   SearchField,
   Select,
+  Tooltip,
 } from 'oa-components'
 import { FieldContainer } from 'src/common/Form/FieldContainer'
 import { UserAction } from 'src/common/UserAction'
@@ -83,6 +84,24 @@ export const QuestionListHeader = () => {
 
   const actionComponents = (
     <UserAction
+      incompleteProfile={
+        <>
+          <Link
+            to="/settings"
+            data-tooltip-id="tooltip"
+            data-tooltip-content={listing.incompleteProfile}
+          >
+            <Button
+              type="button"
+              data-cy="complete-profile-question"
+              variant="disabled"
+            >
+              {listing.create}
+            </Button>
+          </Link>
+          <Tooltip id="tooltip" />
+        </>
+      }
       loggedIn={
         <Link to="/questions/create">
           <Button type="button" data-cy="create-question" variant="primary">

--- a/src/pages/Question/labels.ts
+++ b/src/pages/Question/labels.ts
@@ -36,13 +36,14 @@ export const fields: ILabels = {
 
 export const listing = {
   create: 'Ask a question',
-  join: 'Sign up to ask your question',
-  incompleteProfile: 'Complete your profile to ask your question',
-  noQuestions: 'No questions have been asked yet',
-  usefulness: 'How useful it is',
-  totalComments: 'Total comments',
   filterCategory: 'Filter by category',
+  incompleteProfile: 'Complete your profile to ask your question',
+  join: 'Sign up to ask your question',
+  loadMore: 'Load More',
+  loggedOut: 'Gotta log in please for that sweet sweet question asking...',
+  noQuestions: 'No questions have been asked yet',
   search: 'Search for questions',
   sort: 'Sort by',
-  loadMore: 'Load More',
+  totalComments: 'Total comments',
+  usefulness: 'How useful it is',
 }

--- a/src/pages/Question/labels.ts
+++ b/src/pages/Question/labels.ts
@@ -37,6 +37,7 @@ export const fields: ILabels = {
 export const listing = {
   create: 'Ask a question',
   join: 'Sign up to ask your question',
+  incompleteProfile: 'Complete your profile to ask your question',
   noQuestions: 'No questions have been asked yet',
   usefulness: 'How useful it is',
   totalComments: 'Total comments',

--- a/src/pages/Research/Content/CreateResearch/index.tsx
+++ b/src/pages/Research/Content/CreateResearch/index.tsx
@@ -1,25 +1,12 @@
-import React from 'react'
 import { observer } from 'mobx-react'
-import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import ResearchForm from 'src/pages/Research/Content/Common/Research.form'
-import { Flex, Text } from 'theme-ui'
 
 import TEMPLATE from './Template'
 
-import type { IUser } from 'oa-shared'
-
 const CreateResearch = observer(() => {
-  const { userStore } = useCommonStores().stores
-  const currentUser = userStore.user as IUser
   const formValues = { ...TEMPLATE.INITIAL_VALUES }
 
-  return currentUser ? (
-    <ResearchForm formValues={formValues} parentType="create" />
-  ) : (
-    <Flex sx={{ justifyContent: 'center' }} mt="40px">
-      <Text>Please login to access this page</Text>
-    </Flex>
-  )
+  return <ResearchForm formValues={formValues} parentType="create" />
 })
 
 export default CreateResearch

--- a/src/pages/Research/Content/ResearchListHeader.tsx
+++ b/src/pages/Research/Content/ResearchListHeader.tsx
@@ -6,6 +6,7 @@ import {
   ReturnPathLink,
   SearchField,
   Select,
+  Tooltip,
 } from 'oa-components'
 import { ResearchStatus } from 'oa-shared'
 import { AuthWrapper } from 'src/common/AuthWrapper'
@@ -99,13 +100,27 @@ export const ResearchFilterHeader = (props: IProps) => {
 
     setSearchParams(params)
   }
-
+  const roleRequired = isPreciousPlastic() ? undefined : RESEARCH_EDITOR_ROLES
   const actionComponents = (
     <UserAction
+      incompleteProfile={
+        <AuthWrapper roleRequired={roleRequired}>
+          <Link to="/settings">
+            <Button
+              type="button"
+              variant="disabled"
+              data-cy="complete-profile-research"
+              data-tooltip-id="tooltip"
+              data-tooltip-content={listing.incompleteProfile}
+            >
+              {listing.create}
+            </Button>
+          </Link>
+          <Tooltip id="tooltip" />
+        </AuthWrapper>
+      }
       loggedIn={
-        <AuthWrapper
-          roleRequired={isPreciousPlastic() ? undefined : RESEARCH_EDITOR_ROLES}
-        >
+        <AuthWrapper roleRequired={roleRequired}>
           <DraftButton
             showDrafts={showDrafts}
             draftCount={draftCount}

--- a/src/pages/Research/labels.ts
+++ b/src/pages/Research/labels.ts
@@ -89,15 +89,17 @@ export const update: ILabels = {
 }
 
 export const listing = {
-  create: 'Add Research',
-  join: 'Sign up to add your research',
-  incompleteProfile: 'Complete your profile to add your research',
-  noItems: 'No research to show',
-  heading: 'Help out with Research & Development',
-  filterCategory: 'Filter by category',
   author: 'Filter by author',
-  status: 'Filter by status',
+  create: 'Add Research',
+  filterCategory: 'Filter by category',
+  heading: 'Help out with Research & Development',
+  incompleteProfile: 'Complete your profile to add your research',
+  join: 'Sign up to add your research',
+  loadMore: 'Load More',
+  loggedOut:
+    'Oh we really want your research knowledge. Trust us. But a login is needed first.',
+  noItems: 'No research to show',
   search: 'Search for a research',
   sort: 'Sort by',
-  loadMore: 'Load More',
+  status: 'Filter by status',
 }

--- a/src/pages/Research/labels.ts
+++ b/src/pages/Research/labels.ts
@@ -91,6 +91,7 @@ export const update: ILabels = {
 export const listing = {
   create: 'Add Research',
   join: 'Sign up to add your research',
+  incompleteProfile: 'Complete your profile to add your research',
   noItems: 'No research to show',
   heading: 'Help out with Research & Development',
   filterCategory: 'Filter by category',

--- a/src/pages/User/content/ProfileContact.tsx
+++ b/src/pages/User/content/ProfileContact.tsx
@@ -2,6 +2,7 @@ import { ExternalLinkLabel } from 'oa-shared'
 // eslint-disable-next-line import/no-unresolved
 import { ClientOnly } from 'remix-utils/client-only'
 import { UserAction } from 'src/common/UserAction'
+import { isUserContactable } from 'src/utils/helpers'
 import { Flex } from 'theme-ui'
 
 import { UserContactNotLoggedIn } from '../contact'
@@ -25,6 +26,8 @@ export const ProfileContact = ({ user }: IProps) => {
         ),
     ) || []
 
+  const isUserProfileContactable = !isUserContactable(user)
+
   return (
     <Flex sx={{ flexDirection: 'column', gap: 2 }}>
       <ClientOnly fallback={<></>}>
@@ -32,7 +35,11 @@ export const ProfileContact = ({ user }: IProps) => {
           <UserAction
             loggedIn={<UserContactForm user={user} />}
             loggedOut={
-              <UserContactNotLoggedIn displayName={user.displayName} />
+              isUserProfileContactable ? (
+                <UserContactNotLoggedIn displayName={user.displayName} />
+              ) : (
+                <></>
+              )
             }
           />
         )}

--- a/src/pages/UserSettings/SettingsPageUserProfile.tsx
+++ b/src/pages/UserSettings/SettingsPageUserProfile.tsx
@@ -81,9 +81,10 @@ export const SettingsPageUserProfile = () => {
     return errors
   }
 
-  const coverImages = new Array(4)
-    .fill(null)
-    .map((v, i) => (user.coverImages[i] ? user.coverImages[i] : v))
+  const emptyArray = new Array(4).fill(null)
+  const coverImages = user.coverImages
+    ? emptyArray.map((v, i) => (user.coverImages[i] ? user.coverImages[i] : v))
+    : emptyArray
 
   const initialValues = {
     profileType: user.profileType || ProfileTypeList.MEMBER,

--- a/src/pages/UserSettings/SettingsPageUserProfile.tsx
+++ b/src/pages/UserSettings/SettingsPageUserProfile.tsx
@@ -122,7 +122,6 @@ export const SettingsPageUserProfile = () => {
         if (isLoading) return <Loader sx={{ alignSelf: 'center' }} />
 
         const isMember = values.profileType === ProfileTypeList.MEMBER
-        console.log(values.links)
 
         return (
           <Flex sx={{ flexDirection: 'column', gap: 4 }}>

--- a/src/pages/common/CommentsSupabase/CreateCommentSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CreateCommentSupabase.tsx
@@ -80,6 +80,7 @@ export const CreateCommentSupabase = observer((props: Props) => {
             }}
           >
             <UserAction
+              incompleteProfile={<IncompleteProfilePrompt />}
               loggedIn={
                 <Flex sx={{ flexDirection: 'column' }}>
                   <Box
@@ -162,6 +163,25 @@ const LoginPrompt = () => {
           }}
         >
           Login to leave a comment
+        </ReturnPathLink>
+      </Text>
+    </Box>
+  )
+}
+
+const IncompleteProfilePrompt = () => {
+  return (
+    <Box sx={{ padding: [3, 4] }}>
+      <Text data-cy="comments-incomplete-profile-prompt">
+        Hi there!{' '}
+        <ReturnPathLink
+          to="/settings"
+          style={{
+            textDecoration: 'underline',
+            color: 'inherit',
+          }}
+        >
+          Complete your profile leave a comment
         </ReturnPathLink>
       </Text>
     </Box>

--- a/src/routes/_.library.create.tsx
+++ b/src/routes/_.library.create.tsx
@@ -1,15 +1,38 @@
 /* eslint-disable unicorn/filename-case */
+import { UserAction } from 'src/common/UserAction'
 import { AuthRoute } from 'src/pages/common/AuthRoute'
 import CreateLibrary from 'src/pages/Library/CreateLibrary'
+import { listing } from 'src/pages/Library/labels'
+import { Box } from 'theme-ui'
 
 export async function clientLoader() {
   return null
 }
 
 export default function Index() {
+  const { incompleteProfile, loggedOut } = listing
+  const sx = {
+    alignSelf: 'center',
+    paddingTop: 5,
+  }
+
   return (
-    <AuthRoute>
-      <CreateLibrary />
-    </AuthRoute>
+    <UserAction
+      incompleteProfile={
+        <Box data-cy="incomplete-profile-message" sx={sx}>
+          {incompleteProfile}
+        </Box>
+      }
+      loggedIn={
+        <AuthRoute>
+          <CreateLibrary />
+        </AuthRoute>
+      }
+      loggedOut={
+        <Box data-cy="logged-out-message" sx={sx}>
+          {loggedOut}
+        </Box>
+      }
+    />
   )
 }

--- a/src/routes/_.questions.create.tsx
+++ b/src/routes/_.questions.create.tsx
@@ -1,5 +1,8 @@
+import { UserAction } from 'src/common/UserAction'
 import { AuthRoute } from 'src/pages/common/AuthRoute'
+import { listing } from 'src/pages/Question/labels'
 import { QuestionCreate } from 'src/pages/Question/QuestionCreate'
+import { Box } from 'theme-ui'
 
 export async function clientLoader() {
   return null
@@ -7,8 +10,18 @@ export async function clientLoader() {
 
 export default function Index() {
   return (
-    <AuthRoute>
-      <QuestionCreate />
-    </AuthRoute>
+    <UserAction
+      incompleteProfile={
+        <Box data-cy="incomplete-profile-message">
+          Seriously though. {listing.incompleteProfile}
+        </Box>
+      }
+      loggedIn={
+        <AuthRoute>
+          <QuestionCreate />
+        </AuthRoute>
+      }
+      loggedOut={<>Dude. Gotta login please</>}
+    />
   )
 }

--- a/src/routes/_.questions.create.tsx
+++ b/src/routes/_.questions.create.tsx
@@ -9,11 +9,17 @@ export async function clientLoader() {
 }
 
 export default function Index() {
+  const { incompleteProfile, loggedOut } = listing
+  const sx = {
+    alignSelf: 'center',
+    paddingTop: 5,
+  }
+
   return (
     <UserAction
       incompleteProfile={
-        <Box data-cy="incomplete-profile-message">
-          Seriously though. {listing.incompleteProfile}
+        <Box data-cy="incomplete-profile-message" sx={sx}>
+          {incompleteProfile}
         </Box>
       }
       loggedIn={
@@ -21,7 +27,11 @@ export default function Index() {
           <QuestionCreate />
         </AuthRoute>
       }
-      loggedOut={<>Dude. Gotta login please</>}
+      loggedOut={
+        <Box data-cy="logged-out-message" sx={sx}>
+          {loggedOut}
+        </Box>
+      }
     />
   )
 }

--- a/src/routes/_.research.create.tsx
+++ b/src/routes/_.research.create.tsx
@@ -1,18 +1,40 @@
+import { UserAction } from 'src/common/UserAction'
 import { isPreciousPlastic } from 'src/config/config'
 import { AuthRoute } from 'src/pages/common/AuthRoute'
 import { RESEARCH_EDITOR_ROLES } from 'src/pages/Research/constants'
 import CreateResearch from 'src/pages/Research/Content/CreateResearch'
+import { listing } from 'src/pages/Research/labels'
+import { Box } from 'theme-ui'
 
 export async function clientLoader() {
   return null
 }
 
 export default function Index() {
+  const { incompleteProfile, loggedOut } = listing
   const roles = isPreciousPlastic() ? [] : RESEARCH_EDITOR_ROLES
+  const sx = {
+    alignSelf: 'center',
+    paddingTop: 5,
+  }
 
   return (
-    <AuthRoute roleRequired={roles}>
-      <CreateResearch />
-    </AuthRoute>
+    <UserAction
+      incompleteProfile={
+        <Box data-cy="incomplete-profile-message" sx={sx}>
+          {incompleteProfile}
+        </Box>
+      }
+      loggedIn={
+        <AuthRoute roleRequired={roles}>
+          <CreateResearch />
+        </AuthRoute>
+      }
+      loggedOut={
+        <Box data-cy="logged-out-message" sx={sx}>
+          {loggedOut}
+        </Box>
+      }
+    />
   )
 }

--- a/src/stores/User/user.store.ts
+++ b/src/stores/User/user.store.ts
@@ -29,8 +29,6 @@ const { countries } = pkg
 type PartialUser = Partial<IUserDB>
 
 export class UserStore extends ModuleStore {
-  private authUnsubscribe: firebase.default.Unsubscribe
-
   public user: IUserDB | null | undefined = null
   public authUser: User | null = null // TODO: Fix type
   public updateStatus: IUserUpdateStatus = getInitialUpdateStatus()


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the current behavior?

Users can basically do anything.

## What is the new behavior?

Users need to complete their profile before adding projects, research, questions or comments on questions.

Note: can still add comments on projects/research due to how much code is in the component library and I'm accepting that debt as we'll be removing those components (and using the question comment components) soon.

<img width="822" alt="Screenshot 2025-03-11 at 16 49 26" src="https://github.com/user-attachments/assets/26c353d0-5f22-4add-96a8-8f7ab9462b2a" />
<img width="822" alt="Screenshot 2025-03-11 at 16 49 32" src="https://github.com/user-attachments/assets/3085d8de-9ea0-4435-a704-dbc58211c6bd" />
<img width="822" alt="Screenshot 2025-03-11 at 16 49 39" src="https://github.com/user-attachments/assets/4a1024d0-5767-4e93-9d42-b405eaefbab0" />
<img width="1109" alt="Screenshot 2025-03-11 at 16 49 54" src="https://github.com/user-attachments/assets/b5e66b6e-e0d5-4e90-aceb-0b3655e11e39" />
