### PR TITLE
test: change domain for test emails

### DIFF
--- a/packages/cypress/src/integration/SignUp.spec.ts
+++ b/packages/cypress/src/integration/SignUp.spec.ts
@@ -77,7 +77,7 @@ describe('[User sign-up]', () => {
       const { email, username, password } = user
       cy.signUpNewUser(user)
 
-      const newEmail = `${username}-super_cool@test.com`
+      const newEmail = `delivered+${username}-super_cool@resend.dev`
       const newPassword = '<dfbss73DF'
 
       cy.step('Go to settings page')

--- a/packages/cypress/src/support/seedAccounts.ts
+++ b/packages/cypress/src/support/seedAccounts.ts
@@ -79,7 +79,7 @@ export const deleteAccounts = async () => {
 
   for (const user of result.data.users) {
     // only delete mock users and test users
-    if (mockUsers.has(user.email) || user.email.endsWith('@test.com')) {
+    if (mockUsers.has(user.email) || user.email.endsWith('@resend.dev')) {
       await adminClient.auth.admin.deleteUser(user.id)
     }
   }

--- a/packages/cypress/src/utils/TestUtils.ts
+++ b/packages/cypress/src/utils/TestUtils.ts
@@ -45,7 +45,7 @@ export const generateNewUserDetails = (): IUserSignUpDetails => {
   const username = `CI_${generateAlphaNumeric(9)}`.toLocaleLowerCase()
   return {
     username,
-    email: `${username}@test.com`.toLocaleLowerCase(),
+    email: `delivered+${username}@resend.dev`.toLocaleLowerCase(),
     password: 'test1234',
   }
 }


### PR DESCRIPTION
Resend is now sending out all the test emails from the cypress tests and we don't want to be changed for them! 

So changing all the future test accounts to use the [email address that have for testing](https://resend.com/changelog/sending-test-emails)