### PR TITLE
added returnURL and used session storage for opening the pop up modal

### DIFF
--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { DonationRequestModal } from '../DonationRequestModal/DonationRequestModal'
 import { DownloadButton } from '../DownloadButton/DownloadButton'
@@ -14,6 +14,7 @@ export interface IProps {
   fileDownloadCount: number
   fileLink?: string
   files?: (IUploadedFileMeta | File | null)[]
+  openModel?: boolean
 }
 
 export const DownloadWithDonationAsk = (props: IProps) => {
@@ -25,8 +26,9 @@ export const DownloadWithDonationAsk = (props: IProps) => {
     fileDownloadCount,
     fileLink,
     files,
+    openModel = false,
   } = props
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(openModel)
   const [link, setLink] = useState<string>('')
 
   const toggleIsModalOpen = () => setIsModalOpen(!isModalOpen)
@@ -35,6 +37,13 @@ export const DownloadWithDonationAsk = (props: IProps) => {
     handleClick()
     toggleIsModalOpen()
   }
+
+  // Add effect to set initial link when modal opens automatically
+  useEffect(() => {
+    if (openModel && fileLink) {
+      setLink(fileLink)
+    }
+  }, [openModel])
 
   const filteredFiles: IUploadedFileMeta[] | undefined = files?.filter(
     (file): file is IUploadedFileMeta => file !== null && 'downloadUrl' in file,

--- a/src/common/DownloadWrapper.tsx
+++ b/src/common/DownloadWrapper.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { DownloadButton, DownloadWithDonationAsk } from 'oa-components'
 
@@ -15,11 +16,28 @@ interface IProps {
 export const DownloadWrapper = (props: IProps) => {
   const { handleClick, fileLink, files, fileDownloadCount } = props
   const hasFiles = files && files.length > 0
+  const [openModel, setOpenModel] = useState<boolean>(false)
 
   const navigate = useNavigate()
 
   if (!fileLink && !hasFiles) {
     return null
+  }
+
+  useEffect(() => {
+    if (sessionStorage.getItem('loginRedirect') && (fileLink || hasFiles)) {
+      sessionStorage.removeItem('loginRedirect')
+      if (files && files?.length === 1) {
+        setOpenModel(true)
+      }
+    }
+  }, [fileLink, hasFiles])
+
+  const handleLoggedOutDownloadClick = () => {
+    sessionStorage.setItem('loginRedirect', 'true')
+    navigate(
+      `/sign-in?returnUrl=${encodeURIComponent(`${location?.pathname}`)}`,
+    )
   }
 
   const body = import.meta.env.VITE_DONATIONS_BODY
@@ -37,13 +55,14 @@ export const DownloadWrapper = (props: IProps) => {
           imageURL={imageURL}
           files={files}
           fileDownloadCount={fileDownloadCount}
+          openModel={openModel}
         />
       }
       loggedOut={
         <DownloadButton
           isLoggedIn={false}
           fileDownloadCount={fileDownloadCount}
-          onClick={() => navigate('/sign-in')}
+          onClick={handleLoggedOutDownloadClick}
         />
       }
     />


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [x] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
If a logged-out user tries to download, the user is navigated to the login page but after logging in the user is not redirected back to the download page.

## What is the new behavior?

After the user logs in, the user is redirected to the download page, for Library the DownloadAskForDontation pop is opened when it's a single for multiple files the pop-up is not opened.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4132

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
