### PR TITLE
fix: Breadcrumbs are unnecessarily trunca...

### DIFF
--- a/packages/components/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.tsx
@@ -17,12 +17,19 @@ export const Breadcrumbs = ({ steps }: BreadcrumbsProps) => {
         marginBottom: 2,
         padding: 0,
         alignItems: 'center',
+        width: '100%',
       }}
     >
       {steps.map((step, index) => {
         const isLast = index === steps.length - 1
         return (
-          <Flex key={index} sx={{ alignItems: 'center' }}>
+          <Flex
+            key={index}
+            sx={{
+              alignItems: 'center',
+              ...(isLast && { flex: '1', minWidth: 0 }),
+            }}
+          >
             <BreadcrumbItem text={step.text} link={step.link} isLast={isLast} />
             {!isLast && (
               <Icon

--- a/packages/components/src/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/components/src/Breadcrumbs/BreadcrumbsItem.tsx
@@ -30,7 +30,15 @@ const BreadcrumbButton = ({ text, link }: BreadcrumbButtonProps) => {
 
 export const BreadcrumbItem = ({ text, link, isLast }: BreadcrumbItemProps) => (
   <Box
-    style={{ display: 'inline-flex', marginRight: '3px' }}
+    style={{
+      display: 'inline-flex',
+      marginRight: '3px',
+      ...(isLast && {
+        flex: '1',
+        minWidth: 0,
+        maxWidth: '100%',
+      }),
+    }}
     data-testid="breadcrumbsItem"
     data-cy="breadcrumbsItem"
   >
@@ -45,7 +53,7 @@ export const BreadcrumbItem = ({ text, link, isLast }: BreadcrumbItemProps) => (
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
-          width: [100, '100%'],
+          width: '100%',
         }}
       >
         {text}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix #4121 

## What is the current behavior?

Text is currently being truncated for breadcrumb links.

## What is the new behavior?

Adds a more responsive breadcrumb. This should handle long titles in for any browser width in breadcrumbs.

AFTER: 
![image](https://github.com/user-attachments/assets/cd3e2c70-36b6-4aa6-8b3f-601a8b67b2b1)

![image](https://github.com/user-attachments/assets/7f3b4e4b-8a22-47f3-8baf-7f92113ab793)

