### PR TITLE
fix: hide profile map button when map mod off

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,9 @@ WS_URLS=localhost:24678,ws://localhost:24678
 # All valid options for VITE_THEME: project-kamp, fixing-fashion or precious-plastic
 VITE_THEME=precious-plastic
 
+# A key variable to set which modules/top level features to have on, full list: howto,map,research,academy,user,question,news
+VITE_SUPPORTED_MODULES=howto,map,research,academy,user,question,news
+
 # Academies that exist https://onearmy.github.io/academy/, https://project-kamp-academy.netlify.app/, https://fixing-fashion-academy.netlify.app/
 VITE_ACADEMY_RESOURCE=https://onearmy.github.io/academy/
 VITE_DONATIONS_BODY=All of the content here is free. Your donation supports this library of open source recycling knowledge. Making it possible for everyone in the world to use it and start recycling.

--- a/packages/components/src/UserStatistics/UserStatistics.tsx
+++ b/packages/components/src/UserStatistics/UserStatistics.tsx
@@ -20,6 +20,7 @@ export interface UserStatisticsProps {
   usefulCount: number
   researchCount: number
   totalViews: number
+  hasLocation?: boolean
   sx?: ThemeUIStyleObject | undefined
 }
 
@@ -27,7 +28,7 @@ export const UserStatistics = (props: UserStatisticsProps) => {
   const hasLocation =
     props.country !== undefined && props.userName !== undefined
 
-  if (isEmpty(props) && !hasLocation) {
+  if (isEmpty({ hasLocation, ...props })) {
     return null
   }
 
@@ -138,8 +139,10 @@ export const UserStatistics = (props: UserStatisticsProps) => {
 }
 
 const isEmpty = (props: UserStatisticsProps) =>
+  !props.hasLocation &&
   !props.isVerified &&
   !props.isSupporter &&
-  !props.usefulCount &&
   !props.libraryCount &&
-  !props.totalViews
+  !props.researchCount &&
+  !props.totalViews &&
+  !props.usefulCount

--- a/src/pages/User/content/ProfileDetails.tsx
+++ b/src/pages/User/content/ProfileDetails.tsx
@@ -1,7 +1,10 @@
+import { useContext } from 'react'
 import { UserStatistics } from 'oa-components'
 import { UserRole } from 'oa-shared'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { ProfileTags } from 'src/common/ProfileTags'
+import { isModuleSupported, MODULE } from 'src/modules'
+import { EnvironmentContext } from 'src/pages/common/EnvironmentContext'
 import { Box, Divider, Flex, Paragraph } from 'theme-ui'
 
 import type { IUser } from 'oa-shared'
@@ -14,6 +17,14 @@ interface IProps {
 
 export const ProfileDetails = ({ docs, user }: IProps) => {
   const { about, location, tags, userName } = user
+
+  const env = useContext(EnvironmentContext)
+  const isMapModule = isModuleSupported(
+    env?.VITE_SUPPORTED_MODULES || '',
+    MODULE.MAP,
+  )
+
+  const country = isMapModule ? location?.country : undefined
 
   return (
     <Box style={{ height: '100%' }}>
@@ -50,7 +61,7 @@ export const ProfileDetails = ({ docs, user }: IProps) => {
             fallback={
               <UserStatistics
                 userName={userName}
-                country={location?.country}
+                country={country}
                 isVerified={user.verified}
                 isSupporter={!!user.badges?.supporter}
                 libraryCount={docs?.library.length || 0}
@@ -62,7 +73,7 @@ export const ProfileDetails = ({ docs, user }: IProps) => {
           >
             <UserStatistics
               userName={userName}
-              country={location?.country}
+              country={country}
               isVerified={user.verified}
               isSupporter={!!user.badges?.supporter}
               libraryCount={docs?.library.length || 0}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

Just realised the location map button on profiles shows even if the map is off:

<img width="793" alt="Screenshot 2025-05-05 at 13 53 47" src="https://github.com/user-attachments/assets/25a4d512-61c5-498c-a9a2-0b14bd727d15" />

## What is the new behavior?

No map mod. No location button.
