### PR TITLE
fix: old data for verified at top user level

### DIFF
--- a/src/pages/User/content/ProfileDetails.tsx
+++ b/src/pages/User/content/ProfileDetails.tsx
@@ -62,7 +62,7 @@ export const ProfileDetails = ({ docs, user }: IProps) => {
               <UserStatistics
                 userName={userName}
                 country={country}
-                isVerified={user.verified}
+                isVerified={!!user.badges?.verified}
                 isSupporter={!!user.badges?.supporter}
                 libraryCount={docs?.projects.length || 0}
                 usefulCount={user.totalUseful || 0}
@@ -74,7 +74,7 @@ export const ProfileDetails = ({ docs, user }: IProps) => {
             <UserStatistics
               userName={userName}
               country={country}
-              isVerified={user.verified}
+              isVerified={!!user.badges?.verified}
               isSupporter={!!user.badges?.supporter}
               libraryCount={docs?.projects.length || 0}
               usefulCount={user.totalUseful || 0}


### PR DESCRIPTION
## What is the current behavior?

There's `user.badges.verified` and `user.verified` - which should be the same

