### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/reset-staging-site.yml
+++ b/.github/workflows/reset-staging-site.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Set up Cloud SDK


### PR DESCRIPTION
Bumps setup-node to v4 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/actions/setup-node/releases/tag/v4.0.0