### PR TITLE
fix: ui issues confusing incomplete profiles

### DIFF
--- a/packages/cypress/src/integration/notifications.spec.ts
+++ b/packages/cypress/src/integration/notifications.spec.ts
@@ -4,7 +4,7 @@ describe('[Notifications]', () => {
   it('email preferences can be set', () => {
     localStorage.setItem('devSiteRole', UserRole.BETA_TESTER)
 
-    cy.signUpNewUser()
+    cy.signUpCompletedUser()
     cy.visit('/settings')
 
     cy.step('All ticked be default')
@@ -41,7 +41,6 @@ describe('[Notifications]', () => {
       .contains('Stop receiving messages')
       .click()
 
-    cy.get('[data-cy=info-description').clear().type('Quick preferences test')
     cy.get('[data-cy=isContactableByPublic-true]').click({ force: true })
     cy.saveSettingsForm()
 

--- a/packages/cypress/src/integration/profile.spec.ts
+++ b/packages/cypress/src/integration/profile.spec.ts
@@ -100,6 +100,8 @@ describe('[Profile]', () => {
       cy.step('Can opt-out of being contacted')
       cy.logout()
       cy.signIn(contactee.email, contactee.password)
+      cy.completeUserProfile(contactee.username)
+
       cy.visit('/settings')
       cy.get('[data-cy=PublicContactSection]').should('be.visible')
       cy.get('[data-cy=info-description')

--- a/packages/cypress/src/integration/settings.spec.ts
+++ b/packages/cypress/src/integration/settings.spec.ts
@@ -66,6 +66,7 @@ describe('[Settings]', () => {
       cy.clickMenuItem(UserMenuItem.Profile)
 
       cy.step('Incomplete profile banner visible')
+      cy.get('[data-cy=emptyProfileMessage]').should('be.visible')
       cy.get('[data-cy=incompleteProfileBanner]').click()
 
       cy.step('Cannot add map pin')
@@ -138,6 +139,7 @@ describe('[Settings]', () => {
 
       cy.step('Updated settings display on profile')
       cy.visit(`u/${user.username}`)
+      cy.get('[data-cy=emptyProfileMessage]').should('not.exist')
       cy.contains(user.username)
       cy.contains(displayName)
       cy.contains(description)
@@ -285,6 +287,7 @@ describe('[Settings]', () => {
         country,
         description,
       })
+      cy.setSettingImage('avatar', 'userImage')
       cy.selectTag(tag, '[data-cy=tag-select]')
       cy.setSettingAddContactLink({
         index: 0,
@@ -457,6 +460,7 @@ describe('[Settings]', () => {
         country,
         description,
       })
+      cy.setSettingImage('avatar', 'userImage')
       cy.selectTag(tag, '[data-cy=tag-select]')
       cy.setSettingAddContactLink({
         index: 0,

--- a/packages/cypress/src/support/commandsUi.ts
+++ b/packages/cypress/src/support/commandsUi.ts
@@ -98,6 +98,7 @@ Cypress.Commands.add('addToMarkdownField', (text: string) => {
 
 Cypress.Commands.add('saveSettingsForm', () => {
   cy.get('[data-cy=save]').click()
+  cy.wait(500)
   cy.get('[data-cy=errors-container]').should('not.exist')
   cy.get('[data-cy=save]').should('not.be.disabled')
 })
@@ -302,11 +303,9 @@ Cypress.Commands.add('signUpNewUser', (user?) => {
 })
 
 Cypress.Commands.add('completeUserProfile', (username) => {
-  const userImage = 'avatar'
-
   cy.log('Complete user profile')
   cy.visit('/settings')
-  cy.setSettingImage(userImage, 'userImage')
+  cy.setSettingImage('avatar', 'userImage')
   cy.wait(1500)
   cy.setSettingBasicUserInfo({
     description: `${username} profile description.`,

--- a/src/pages/User/content/UserProfile.tsx
+++ b/src/pages/User/content/UserProfile.tsx
@@ -12,6 +12,7 @@ import { ProfileTypeList, UserRole } from 'oa-shared'
 import { AuthWrapper } from 'src/common/AuthWrapper'
 import { isPreciousPlastic } from 'src/config/config'
 import { isUserContactable } from 'src/utils/helpers'
+import { isProfileComplete } from 'src/utils/isProfileComplete'
 import { Alert, Box, Card, Flex } from 'theme-ui'
 
 import { Impact } from '../impact/Impact'
@@ -22,7 +23,7 @@ import { ProfileHeader } from './ProfileHeader'
 import { ProfileImage } from './ProfileImage'
 import UserCreatedDocuments from './UserCreatedDocuments'
 
-import type { IUser } from 'oa-shared'
+import type { IUser, IUserDB } from 'oa-shared'
 import type { UserCreatedDocs } from '../types'
 
 interface IProps {
@@ -46,7 +47,8 @@ export const UserProfile = ({ docs, isViewingOwnProfile, user }: IProps) => {
   const hasProfile =
     about || (tags && Object.keys(tags).length !== 0) || hasContributed
 
-  const showEmptyProfileAlert = isViewingOwnProfile
+  const showEmptyProfileAlert =
+    isViewingOwnProfile && !isProfileComplete(user as IUserDB)
 
   const defaultValue =
     useLocationHook?.hash?.slice(1) || (hasProfile ? 'profile' : 'contact')

--- a/src/pages/UserSettings/content/sections/UserImages.section.tsx
+++ b/src/pages/UserSettings/content/sections/UserImages.section.tsx
@@ -2,6 +2,7 @@ import { Field } from 'react-final-form'
 import { FieldArray } from 'react-final-form-arrays'
 import { ImageInputField } from 'src/common/Form/ImageInput.field'
 import { fields, headings } from 'src/pages/UserSettings/labels'
+import { required } from 'src/utils/validators'
 import { Box, Flex, Heading, Text } from 'theme-ui'
 
 import type { IUploadedFileMeta, IUser } from 'oa-shared'
@@ -13,11 +14,12 @@ interface IProps {
 
 export const UserImagesSection = ({ isMemberProfile, values }: IProps) => {
   const { coverImages, userImage } = values
+  const isRequired = { validate: required }
 
   return (
     <Flex sx={{ flexDirection: 'column', gap: 3 }}>
       <Heading as="h2">
-        {isMemberProfile ? fields.userImage.title : headings.images}
+        {isMemberProfile ? fields.userImage.title : headings.images} {' *'}
       </Heading>
 
       <Flex sx={{ flexDirection: 'column', alignContent: 'stretch', gap: 1 }}>
@@ -46,6 +48,7 @@ export const UserImagesSection = ({ isMemberProfile, values }: IProps) => {
               width: '120px',
               height: '120px',
             }}
+            {...(isMemberProfile && isRequired)}
           />
         </Box>
       </Flex>


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the new behavior?

1. Fix: Hide 'empty profile' box on profiles when profile not empty.
2. Fix: Make avatar a required field for members.

<img width="1103" alt="Screenshot 2025-06-09 at 11 13 54" src="https://github.com/user-attachments/assets/c308c5c8-81cf-4841-bde0-8510c1739602" />
<img width="1103" alt="Screenshot 2025-06-09 at 11 13 58" src="https://github.com/user-attachments/assets/8d2f6378-2de6-4f78-8e76-defb58c12e52" />


