### PR TITLE
Fix Typo: Correct "visiable" to "visible" in Cypress Integration Tests

### DIFF
--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -124,7 +124,7 @@ describe('[News.Write]', () => {
       // cy.visit(`/news/${initialExpectedSlug}`)
       // cy.contains(updatedTitle)
 
-      cy.step('All updated fields visiable on list')
+      cy.step('All updated fields visible on list')
       cy.visit('/news')
       cy.contains(updatedSummary)
       cy.contains(updatedTitle)

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -126,7 +126,7 @@ describe('[Question]', () => {
       // cy.visit(`/questions/${initialExpectedSlug}`)
       // cy.contains(updatedTitle)
 
-      cy.step('All updated fields visiable on list')
+      cy.step('All updated fields visible on list')
       cy.visit('/questions')
       cy.contains(updatedTitle)
       cy.contains(category)


### PR DESCRIPTION


**Description:**  
This pull request fixes a typo in the Cypress integration test files for both news and questions. The word "visiable" has been corrected to "visible" in the step descriptions to improve clarity and maintain consistency throughout the test suite. No functional changes were made; this is a documentation/description update only.