### PR TITLE
fix: redirect previous slugs to latest content

### DIFF
--- a/packages/cypress/src/integration/library/write.spec.ts
+++ b/packages/cypress/src/integration/library/write.spec.ts
@@ -289,6 +289,10 @@ describe('[Library]', () => {
           .should('contain', step.text)
       })
 
+      cy.step('Can access the project with the previous slug')
+      cy.visit(firstSlug)
+      cy.contains(title)
+
       // Won't show on profile yet as project needs admin approval
       // cy.step('Published project should appear on users profile')
       // cy.visit('/u/' + creator.displayName)

--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -118,11 +118,9 @@ describe('[News.Write]', () => {
       cy.contains(initialNewsBodyTwo)
       cy.contains(initialNewsBodyThree)
 
-      // Bug: Missing previous slug functionality
-      //
-      // cy.step('Can access the news with the previous slug')
-      // cy.visit(`/news/${initialExpectedSlug}`)
-      // cy.contains(updatedTitle)
+      cy.step('Can access the news with the previous slug')
+      cy.visit(`/news/${initialExpectedSlug}`)
+      cy.contains(updatedTitle)
 
       cy.step('All updated fields visible on list')
       cy.visit('/news')

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -120,11 +120,9 @@ describe('[Question]', () => {
         .should('include', `/questions/${updatedExpectedSlug}`)
       cy.contains(updatedTitle)
 
-      // Bug: Missing previous slug functionality
-      //
-      // cy.step('Can access the question with the previous slug')
-      // cy.visit(`/questions/${initialExpectedSlug}`)
-      // cy.contains(updatedTitle)
+      cy.step('Can access the question with the previous slug')
+      cy.visit(`/questions/${initialExpectedSlug}`)
+      cy.contains(updatedTitle)
 
       cy.step('All updated fields visible on list')
       cy.visit('/questions')

--- a/packages/cypress/src/integration/research/write.spec.ts
+++ b/packages/cypress/src/integration/research/write.spec.ts
@@ -29,6 +29,10 @@ describe('[Research]', () => {
 
   describe('[Create research article]', () => {
     it('[By Authenticated]', () => {
+      const initialRandomId = generateAlphaNumeric(4).toLowerCase()
+      const initialTitle = initialRandomId + ' Initial Title'
+      const initialExpectedSlug = initialRandomId + '-initial-title'
+
       const expected = generateArticle()
 
       const updateTitle = faker.lorem.words(5)
@@ -62,7 +66,7 @@ describe('[Research]', () => {
       cy.contains(`Should be more than ${RESEARCH_TITLE_MIN_LENGTH} characters`)
 
       cy.step('Enter research article details')
-      cy.get('[data-cy=intro-title').clear().type(expected.title).blur()
+      cy.get('[data-cy=intro-title').clear().type(initialTitle).blur()
 
       cy.step('Cannot be published without description')
 
@@ -77,8 +81,9 @@ describe('[Research]', () => {
       cy.get('[data-testid=research-stat]').should('not.exist')
       cy.get('[data-cy=ContribTab]').should('not.exist')
 
-      cy.visit(`/research/${expected.slug}`)
+      cy.visit(`/research/${initialExpectedSlug}`)
       cy.get('[data-cy=edit]').click()
+      cy.get('[data-cy=intro-title').clear().type(expected.title).blur()
 
       cy.step('New collaborators can be assigned to research')
       cy.selectTag(subscriber.userName, '[data-cy=UserNameSelect]')
@@ -93,6 +98,10 @@ describe('[Research]', () => {
       cy.contains(expected.title)
       cy.contains(expected.description)
       cy.contains(admin.userName)
+
+      cy.step('Can access the research with the previous slug')
+      cy.visit(`/research/${initialExpectedSlug}`)
+      cy.contains(expected.title)
 
       cy.step('Published Research should appear on users profile')
       cy.visit('/u/' + admin.displayName)

--- a/src/services/newsService.server.ts
+++ b/src/services/newsService.server.ts
@@ -1,7 +1,12 @@
 import { storageServiceServer } from './storageService.server'
 
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { DBMedia } from 'oa-shared'
+import type { DBMedia, DBNews } from 'oa-shared'
+
+async function getById(id: number, client: SupabaseClient) {
+  const result = await client.from('news').select().eq('id', id).single()
+  return result.data as DBNews
+}
 
 const getBySlug = (client: SupabaseClient, slug: string) => {
   return client
@@ -46,6 +51,7 @@ const getHeroImage = async (
 }
 
 export const newsServiceServer = {
+  getById,
   getBySlug,
   getHeroImage,
 }

--- a/src/services/questionService.server.ts
+++ b/src/services/questionService.server.ts
@@ -1,5 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Question } from 'oa-shared'
+import type { DBQuestion, Question } from 'oa-shared'
+
+const getById = async (id: number, client: SupabaseClient) => {
+  const result = await client.from('questions').select().eq('id', id).single()
+  return result.data as DBQuestion
+}
 
 const getBySlug = (client: SupabaseClient, slug: string) => {
   return client
@@ -52,6 +57,7 @@ const getQuestionsByUser = async (
 }
 
 export const questionServiceServer = {
+  getById,
   getBySlug,
   getQuestionsByUser,
 }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

Content (questions, research, news, library) are not storing their previous slugs

When navigating to a contents previous url (using a previous slug), the url gives you a 404 (instead of directing you to the content).

When checking for duplicate slugs on content creation, we are not accounting for previous slugs.


## What is the new behavior?

We now persist all the previous slugs of all content.

When navigating to content using its previous slug it will show you the updated version of that content.
Example: the url is for a previous slug name "testing113", and it is showing the latest version of the question with slug "testing115"
![screenshot-2025-06-24_15:45:53](https://github.com/user-attachments/assets/d23be436-bddb-4598-b00d-6a23b8efa82a)

When creating new content or updating existing content, it will now block you if the content's new slug matches a previous slug of another content of the same type. This will not block content from using one of it's own previous slugs.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4166 