### PR TITLE
fix: hide comment thread subscribe icon

### DIFF
--- a/src/common/FollowButtonAction.tsx
+++ b/src/common/FollowButtonAction.tsx
@@ -18,11 +18,12 @@ interface IProps extends OptionalFollowButtonProps {
   contentType: SubscribableContentTypes
   item: Comment | News | Question | ResearchUpdate
   setSubscribersCount?: Dispatch<SetStateAction<number>>
+  hideSubscribeIcon?: boolean
   tooltipContent?: string
 }
 
 export const FollowButtonAction = (props: IProps) => {
-  const { contentType, item, setSubscribersCount } = props
+  const { contentType, hideSubscribeIcon, item, setSubscribersCount } = props
   const [subscribed, setSubscribed] = useState<boolean>(false)
 
   const { userStore } = useCommonStores().stores
@@ -70,6 +71,10 @@ export const FollowButtonAction = (props: IProps) => {
       action,
       label: `${item.id}`,
     })
+  }
+
+  if (!subscribed && hideSubscribeIcon) {
+    return
   }
 
   return (

--- a/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
@@ -111,6 +111,7 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
                 tooltipFollow="Follow new replies"
                 tooltipUnfollow="Unfollow new replies"
                 variant="subtle"
+                hideSubscribeIcon
               />
             </AuthWrapper>
           }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)


## What is the new behavior?

<img width="590" alt="Screenshot 2025-06-25 at 15 36 55" src="https://github.com/user-attachments/assets/4db38b87-d859-43f2-9ef5-f5a6e184de0f" />

