### PR TITLE
Bug: Moving the DownloadCounter to the parent component + stories changed

### DIFF
--- a/packages/components/src/DownloadButton/DownloadButton.stories.tsx
+++ b/packages/components/src/DownloadButton/DownloadButton.stories.tsx
@@ -8,7 +8,7 @@ export default {
 } as Meta<typeof DownloadButton>
 
 export const Default: StoryFn<typeof DownloadButton> = () => (
-  <DownloadButton onClick={() => {}} fileDownloadCount={7} />
+  <DownloadButton onClick={() => {}} />
 )
 
 export const CustomDetails: StoryFn<typeof DownloadButton> = () => (
@@ -16,6 +16,5 @@ export const CustomDetails: StoryFn<typeof DownloadButton> = () => (
     onClick={() => {}}
     glyph="download-cloud"
     label="Hello there"
-    fileDownloadCount={726}
   />
 )

--- a/packages/components/src/DownloadButton/DownloadButton.tsx
+++ b/packages/components/src/DownloadButton/DownloadButton.tsx
@@ -1,6 +1,5 @@
 import { Flex, Text } from 'theme-ui'
 
-import { DownloadCounter } from '../DownloadCounter/DownloadCounter'
 import { Icon } from '../Icon/Icon'
 import { Tooltip } from '../Tooltip/Tooltip'
 
@@ -8,14 +7,14 @@ import type { IGlyphs } from '../Icon/types'
 
 export interface IProps {
   onClick: () => void
-  fileDownloadCount?: number
+
   isLoggedIn?: boolean
   label?: string
   glyph?: keyof IGlyphs
 }
 
 export const DownloadButton = (props: IProps) => {
-  const { fileDownloadCount, glyph, isLoggedIn, label, onClick } = props
+  const { glyph, isLoggedIn, label, onClick } = props
   return (
     <>
       <Flex
@@ -49,8 +48,6 @@ export const DownloadButton = (props: IProps) => {
         </Text>
       </Flex>
       <Tooltip id="download-files" />
-
-      <DownloadCounter total={fileDownloadCount} />
     </>
   )
 }

--- a/packages/components/src/DownloadStaticFile/DownloadStaticFile.tsx
+++ b/packages/components/src/DownloadStaticFile/DownloadStaticFile.tsx
@@ -69,14 +69,8 @@ const FileDetails = (props: IPropFileDetails) => {
 }
 
 export const DownloadStaticFile = (props: IProps) => {
-  const {
-    file,
-    fileDownloadCount,
-    allowDownload,
-    handleClick,
-    redirectToSignIn,
-    isLoggedIn,
-  } = props
+  const { file, allowDownload, handleClick, redirectToSignIn, isLoggedIn } =
+    props
   const size = bytesToSize(file.size || 0)
 
   if (!file) {
@@ -99,7 +93,6 @@ export const DownloadStaticFile = (props: IProps) => {
       )}
 
       <DownloadButton
-        fileDownloadCount={fileDownloadCount}
         glyph="download-cloud"
         isLoggedIn={isLoggedIn}
         label={`${file.name} (${size})`}

--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.stories.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DownloadWithDonationAsk } from './DownloadWithDonationAsk'
 
 import type { Meta, StoryFn } from '@storybook/react-vite'
@@ -17,9 +18,34 @@ const downloadProps = {
   handleClick: async () => {
     alert('Clicked')
   },
-  files: [],
+  files: [
+    {
+      url: 'https://example.com/file1.pdf',
+      name: 'Long name file, needs to wrap to the next line (File 1)',
+      id: 'file1',
+      size: 20000000,
+    },
+    {
+      url: 'https://example.com/file2.pdf',
+      name: 'File 2',
+      id: 'file2',
+      size: 3000,
+    },
+  ],
 }
 
-export const Default: StoryFn<typeof DownloadWithDonationAsk> = () => (
-  <DownloadWithDonationAsk {...downloadProps} />
-)
+export const WithFileLink: StoryFn<typeof DownloadWithDonationAsk> = () => {
+  const { files, ...props } = downloadProps
+  return <DownloadWithDonationAsk {...props} />
+}
+
+export const WithOneFile: StoryFn<typeof DownloadWithDonationAsk> = () => {
+  const { fileLink, ...rest } = downloadProps
+  const props = { ...rest, files: [rest.files[0]] }
+  return <DownloadWithDonationAsk {...props} />
+}
+
+export const WithFiles: StoryFn<typeof DownloadWithDonationAsk> = () => {
+  const { fileLink, ...props } = downloadProps
+  return <DownloadWithDonationAsk {...props} />
+}

--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.test.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.test.tsx
@@ -82,7 +82,7 @@ describe('DownloadWithDonationAsk', () => {
   })
 
   it('renders the download counter with the correct total', () => {
-    const fileDownloadCount = 1234567 
+    const fileDownloadCount = 1234567
 
     const { container } = render(
       <DownloadWithDonationAsk

--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.test.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.test.tsx
@@ -80,4 +80,21 @@ describe('DownloadWithDonationAsk', () => {
     expect(getAllByTestId('DonationRequest')[0]).toBeInTheDocument()
     expect(handleClick).not.toHaveBeenCalled()
   })
+
+  it('renders the download counter with the correct total', () => {
+    const fileDownloadCount = 1234567 
+
+    const { container } = render(
+      <DownloadWithDonationAsk
+        {...downloadProps}
+        fileDownloadCount={fileDownloadCount}
+        fileLink={undefined}
+        files={[]}
+      />,
+    )
+    const counter = container.querySelector('[data-cy="file-download-counter"]')
+    expect(counter).toBeInTheDocument()
+
+    expect(counter).toHaveTextContent('1,234,567 downloads')
+  })
 })

--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
@@ -79,8 +79,8 @@ export const DownloadWithDonationAsk = (props: IProps) => {
             ))}
           </Flex>
         )}
+        <DownloadCounter total={props.fileDownloadCount} />
       </>
-      <DownloadCounter total={props.fileDownloadCount} />
     </>
   )
 }

--- a/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
+++ b/packages/components/src/DownloadWithDonationAsk/DownloadWithDonationAsk.tsx
@@ -3,6 +3,7 @@ import { Flex } from 'theme-ui'
 
 import { DonationRequestModal } from '../DonationRequestModal/DonationRequestModal'
 import { DownloadButton } from '../DownloadButton/DownloadButton'
+import { DownloadCounter } from '../DownloadCounter/DownloadCounter'
 import { DownloadStaticFile } from '../DownloadStaticFile/DownloadStaticFile'
 
 import type { MediaFile } from 'oa-shared'
@@ -56,7 +57,6 @@ export const DownloadWithDonationAsk = (props: IProps) => {
         {fileLink && (
           <DownloadButton
             isLoggedIn
-            fileDownloadCount={props.fileDownloadCount}
             onClick={() => {
               setLink(fileLink)
               toggleIsModalOpen()
@@ -80,6 +80,7 @@ export const DownloadWithDonationAsk = (props: IProps) => {
           </Flex>
         )}
       </>
+      <DownloadCounter total={props.fileDownloadCount} />
     </>
   )
 }

--- a/src/common/DownloadWrapper.test.tsx
+++ b/src/common/DownloadWrapper.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom/vitest'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DownloadWrapper } from './DownloadWrapper'
+
+const mockedUsedNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockedUsedNavigate,
+}))
+
+vi.mock('./UserAction', () => ({
+  UserAction: ({ loggedOut }: { loggedOut: React.ReactNode }) => (
+    <>{loggedOut}</>
+  ),
+}))
+
+vi.mock('src/common/hooks/useCommonStores', () => ({
+  __esModule: true,
+  useCommonStores: vi.fn(),
+}))
+
+describe('DownloadWrapper', () => {
+  it('renders DownloadButton with isLoggedIn=false and shows DownloadCounter', () => {
+    render(
+      <DownloadWrapper
+        fileDownloadCount={42}
+        fileLink="https://example.com/file.pdf"
+        files={[]}
+      />,
+    )
+
+    expect(screen.getByText('Download files')).toBeInTheDocument()
+    expect(screen.getByText('42 downloads')).toBeInTheDocument()
+  })
+})

--- a/src/common/DownloadWrapper.tsx
+++ b/src/common/DownloadWrapper.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { DownloadButton, DownloadWithDonationAsk } from 'oa-components'
+import {
+  DownloadButton,
+  DownloadCounter,
+  DownloadWithDonationAsk,
+} from 'oa-components'
 
 import { UserAction } from './UserAction'
 
@@ -59,10 +63,13 @@ export const DownloadWrapper = (props: IProps) => {
         />
       }
       loggedOut={
-        <DownloadButton
-          isLoggedIn={false}
-          onClick={handleLoggedOutDownloadClick}
-        />
+        <>
+          <DownloadButton
+            isLoggedIn={false}
+            onClick={handleLoggedOutDownloadClick}
+          />
+          <DownloadCounter total={fileDownloadCount} />
+        </>
       }
     />
   )

--- a/src/common/DownloadWrapper.tsx
+++ b/src/common/DownloadWrapper.tsx
@@ -61,7 +61,6 @@ export const DownloadWrapper = (props: IProps) => {
       loggedOut={
         <DownloadButton
           isLoggedIn={false}
-          fileDownloadCount={fileDownloadCount}
           onClick={handleLoggedOutDownloadClick}
         />
       }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features) 

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)

## What is the current behavior?

The download count is total, but displayed in each file/link

<img width="1174" height="1110" alt="464725421-60aa115b-289e-44b6-ae76-46a67a858699" src="https://github.com/user-attachments/assets/2b92d422-cdf7-4b5f-9f31-ceee622682c0" />


## What is the new behavior?
Now it displays a total count at the bottom of the File/Link list

<img width="385" height="142" alt="Screenshot 2025-07-15 at 15 25 57" src="https://github.com/user-attachments/assets/995111ee-b951-4f66-b5ae-10bee34141e4" />
<img width="391" height="178" alt="Screenshot 2025-07-15 at 15 25 52" src="https://github.com/user-attachments/assets/10e131ce-2e62-4de4-ab4c-06f740e838b2" />
<img width="353" height="179" alt="Screenshot 2025-07-15 at 15 25 48" src="https://github.com/user-attachments/assets/5f089995-4f94-4d53-8d03-f5ce4a864021" />


## Git Issues

Closes #4332

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
