### PR TITLE
feat: update notifications for non-drafts

### DIFF
--- a/packages/cypress/src/support/commands.ts
+++ b/packages/cypress/src/support/commands.ts
@@ -19,6 +19,7 @@ declare global {
       clearServiceWorkers(): Promise<void>
       deleteIDB(name: string): Promise<boolean>
       expectNewNotification(ExpectedNewNotification): Chainable<void>
+      expectNoNewNotification(): Chainable<void>
       interceptAddressSearchFetch(addressResponse): Chainable<void>
       interceptAddressReverseFetch(addressResponse): Chainable<void>
       queryDocuments(
@@ -142,3 +143,10 @@ Cypress.Commands.add(
     cy.url().should('include', path)
   },
 )
+
+Cypress.Commands.add('expectNoNewNotification', () => {
+  localStorage.setItem('devSiteRole', UserRole.BETA_TESTER)
+  cy.wait(3000)
+
+  cy.get('[data-cy=notifications-no-new-messages]').first()
+})

--- a/shared/models/research.ts
+++ b/shared/models/research.ts
@@ -178,6 +178,7 @@ export class ResearchUpdate implements IDoc, IDownloadable {
   researchId: number
   title: string
   videoUrl: string | null
+  research?: DBResearchItem
 
   constructor(obj: ResearchUpdate) {
     Object.assign(this, obj)

--- a/src/routes/api.research.$id.updates.$updateId.ts
+++ b/src/routes/api.research.$id.updates.$updateId.ts
@@ -1,6 +1,6 @@
 import { ResearchUpdate } from 'oa-shared'
 import { createSupabaseServerClient } from 'src/repository/supabase.server'
-import { notificationsService } from 'src/services/notificationsService.server'
+import { notificationsCoordinationServiceServer } from 'src/services/notificationsCoordinationService.server'
 import { profileServiceServer } from 'src/services/profileService.server'
 import { researchServiceServer } from 'src/services/researchService.server'
 import { storageServiceServer } from 'src/services/storageService.server'
@@ -8,7 +8,7 @@ import { SUPPORTED_IMAGE_TYPES } from 'src/utils/storage'
 
 import type { ActionFunctionArgs } from '@remix-run/node'
 import type { SupabaseClient, User } from '@supabase/supabase-js'
-import type { DBMedia, DBProfile, DBResearchUpdate, MediaFile } from 'oa-shared'
+import type { DBMedia, DBResearchUpdate, MediaFile } from 'oa-shared'
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
   try {
@@ -68,7 +68,8 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       .select()
       .eq('id', updateId)
       .single()
-    const update = researchUpdateResult.data as DBResearchUpdate
+
+    const oldResearchUpdate = researchUpdateResult.data as DBResearchUpdate
 
     const uploadedImages = formData.getAll('images') as File[]
     const uploadedFiles = formData.getAll('files') as File[]
@@ -84,7 +85,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       )
     }
 
-    const uploadPath = `research/${researchId}/updates/${update.id}`
+    const uploadPath = `research/${researchId}/updates/${oldResearchUpdate.id}`
     const images = await updateOrReplaceImage(
       imagesToKeepIds as string[],
       uploadedImages,
@@ -101,7 +102,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       client,
     )
 
-    const updateResult = await client
+    const researchUpdateAfterUpdating = await client
       .from('research_updates')
       .update({
         title: data.title,
@@ -112,24 +113,30 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
         video_url: data.videoUrl,
         files: files.map((x) => ({ id: x.id, name: x.name, size: x.size })),
       })
-      .eq('id', update.id)
-      .select('*,research:research(slug)')
+      .eq('id', oldResearchUpdate.id)
+      .select('*,research:research(id,slug,is_draft)')
       .single()
 
-    if (updateResult.error || !updateResult.data) {
-      throw updateResult.error
+    if (
+      researchUpdateAfterUpdating.error ||
+      !researchUpdateAfterUpdating.data
+    ) {
+      throw researchUpdateAfterUpdating.error
     }
 
-    if (update.is_draft && !updateResult.data.is_draft) {
-      notificationsService.sendResearchUpdateNotification(
-        client,
-        updateResult.data.research,
-        updateResult.data,
-        profile as DBProfile,
-      )
-    }
+    const researchUpdate = ResearchUpdate.fromDB(
+      researchUpdateAfterUpdating.data,
+      [],
+    )
+    researchUpdate.research = researchUpdateAfterUpdating.data.research
 
-    const researchUpdate = ResearchUpdate.fromDB(updateResult.data, [])
+    notificationsCoordinationServiceServer.researchUpdate(
+      researchUpdate,
+      profile,
+      client,
+      request,
+      oldResearchUpdate,
+    )
 
     return Response.json({ researchUpdate }, { headers, status: 201 })
   } catch (error) {

--- a/src/services/notificationSupabaseService.server.ts
+++ b/src/services/notificationSupabaseService.server.ts
@@ -3,10 +3,11 @@ import { notificationEmailService } from './notificationEmailService.server'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type {
   DBComment,
+  DBProfile,
   DBResearchItem,
-  DBResearchUpdate,
   NewNotificationData,
   NotificationActionType,
+  ResearchUpdate,
   SubscribableContentTypes,
 } from 'oa-shared'
 
@@ -142,13 +143,10 @@ const createNotificationsNewComment = async (
 
 const createNotificationsResearchUpdate = async (
   research: DBResearchItem,
-  researchUpdate: DBResearchUpdate,
+  researchUpdate: ResearchUpdate,
+  profile: DBProfile,
   client: SupabaseClient,
 ) => {
-  if (!researchUpdate.created_by) {
-    return
-  }
-
   try {
     const contentType: SubscribableContentTypes = 'research'
 
@@ -166,8 +164,8 @@ const createNotificationsResearchUpdate = async (
         sourceContentType: 'research',
         sourceContentId: research.id,
         parentContentId: researchUpdate.id,
-        triggeredById: researchUpdate.created_by!,
         contentType: 'researchUpdate',
+        triggeredById: profile.id,
       }
 
       createNotification(client, notification, subscriberId!)

--- a/src/services/notificationsCoordinationService.server.ts
+++ b/src/services/notificationsCoordinationService.server.ts
@@ -1,0 +1,44 @@
+import { discordServiceServer } from './discordService.server'
+import { notificationsService } from './notificationsService.server'
+import { notificationsSupabaseServiceServer } from './notificationSupabaseService.server'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { DBProfile, DBResearchUpdate, ResearchUpdate } from 'oa-shared'
+
+function researchUpdate(
+  update: ResearchUpdate,
+  profile: DBProfile | null,
+  client: SupabaseClient,
+  request: Request,
+  oldUpdate?: DBResearchUpdate,
+) {
+  const beforeCheck = oldUpdate ? !!oldUpdate.is_draft : true
+  const research = update.research
+  const siteUrl = new URL(request.url).origin.replace('http:', 'https:')
+
+  if (!research || !profile || research?.is_draft) {
+    return
+  }
+
+  if (beforeCheck && update.isDraft === false && !!update.research) {
+    notificationsService.sendResearchUpdateNotification(
+      client,
+      research,
+      update,
+      profile as DBProfile,
+    )
+    notificationsSupabaseServiceServer.createNotificationsResearchUpdate(
+      research,
+      update,
+      profile as DBProfile,
+      client,
+    )
+    discordServiceServer.postWebhookRequest(
+      `🧪 ${profile.username} posted a new research update: ${update.title}\nCheck it out here: <${siteUrl}/research/${research.slug}#update_${update.id}>`,
+    )
+  }
+}
+
+export const notificationsCoordinationServiceServer = {
+  researchUpdate,
+}

--- a/src/services/notificationsService.server.ts
+++ b/src/services/notificationsService.server.ts
@@ -11,10 +11,10 @@ import type {
   DBProfile,
   DBQuestion,
   DBResearchItem,
-  DBResearchUpdate,
   INotification,
   IUserDB,
   NotificationType,
+  ResearchUpdate,
 } from 'oa-shared'
 
 const sendCommentNotification = async (
@@ -56,21 +56,23 @@ const sendCommentNotification = async (
 const sendResearchUpdateNotification = async (
   client: SupabaseClient,
   research: DBResearchItem,
-  researchUpdate: DBResearchUpdate,
+  researchUpdate: ResearchUpdate,
   triggeredBy: DBProfile,
 ) => {
   // The join creates an incorrect type, so going to any
   const { data }: { data: any[] | null } = await client
     .from('subscribers')
     .select('id, user:profiles(username)')
-    .eq('content_id', researchUpdate.research_id)
+    .eq('content_id', research.id)
     .eq('content_type', 'research')
 
-  const profileIds = data?.map((subscriber) => subscriber.user.username).flat()
+  const profileUsernames = data
+    ?.map((subscriber) => subscriber.user.username)
+    .flat()
 
-  const recipientsToNotify = new Set<string>(profileIds)
-  if (researchUpdate.created_by) {
-    recipientsToNotify.add(researchUpdate.created_by.toString())
+  const recipientsToNotify = new Set<string>(profileUsernames)
+  if (researchUpdate.author) {
+    recipientsToNotify.add(researchUpdate.author.username.toString())
   }
 
   const url = `/research/${research.slug}/#update_${researchUpdate.id}`

--- a/src/test/factories/ResearchItem.ts
+++ b/src/test/factories/ResearchItem.ts
@@ -1,6 +1,12 @@
 import { faker } from '@faker-js/faker'
 
-import type { ResearchFormData, ResearchItem, ResearchUpdate } from 'oa-shared'
+import type {
+  DBResearchItem,
+  DBResearchUpdate,
+  ResearchFormData,
+  ResearchItem,
+  ResearchUpdate,
+} from 'oa-shared'
 
 export const FactoryResearchItemUpdate = (
   researchItemUpdateOverloads: Partial<ResearchUpdate> = {},
@@ -20,7 +26,29 @@ export const FactoryResearchItemUpdate = (
   title: faker.lorem.words(),
   videoUrl: null,
   isDraft: false,
+  research: undefined,
   ...researchItemUpdateOverloads,
+})
+
+export const FactoryDBResearchItemUpdate = (
+  researchDBItemUpdateOverloads: Partial<DBResearchUpdate> = {},
+): DBResearchUpdate => ({
+  created_by: faker.number.int(100),
+  comment_count: 0,
+  created_at: faker.date.past(),
+  deleted: false,
+  description: faker.lorem.sentences(2),
+  id: faker.number.int(),
+  images: [],
+  files: [],
+  file_download_count: faker.number.int(),
+  file_link: '',
+  modified_at: faker.date.past(),
+  research_id: faker.number.int(100),
+  title: faker.lorem.words(),
+  video_url: null,
+  is_draft: false,
+  ...researchDBItemUpdateOverloads,
 })
 
 export const FactoryResearchItem = (
@@ -55,6 +83,33 @@ export const FactoryResearchItem = (
   updateCount: 0,
   status: 'in-progress',
   usefulCount: 2,
+  ...researchItemOverloads,
+})
+
+export const FactoryDBResearchItem = (
+  researchItemOverloads: Partial<DBResearchItem> = {},
+): DBResearchItem => ({
+  id: faker.number.int(),
+  is_draft: false,
+  created_by: faker.number.int(),
+  modified_at: faker.date.past(),
+  created_at: faker.date.past(),
+  deleted: faker.datatype.boolean(),
+  description: faker.lorem.paragraphs(),
+  title: faker.lorem.words(),
+  slug: faker.lorem.slug(),
+  previous_slugs: [],
+  collaborators: [],
+  updates: [FactoryDBResearchItemUpdate()],
+  tags: [],
+  total_views: faker.number.int(),
+  subscriber_count: faker.number.int(),
+  comment_count: 0,
+  category: null,
+  image: null,
+  update_count: 0,
+  status: 'in-progress',
+  useful_count: 2,
   ...researchItemOverloads,
 })
 

--- a/src/test/factories/profile.ts
+++ b/src/test/factories/profile.ts
@@ -1,0 +1,17 @@
+import { faker } from '@faker-js/faker'
+
+import type { DBProfile } from 'oa-shared'
+
+export const FactoryDBProfile = (
+  dbProfileOverloads: Partial<DBProfile> = {},
+): DBProfile => ({
+  id: faker.number.int(),
+  username: faker.internet.userName(),
+  display_name: faker.internet.userName(),
+  is_verified: faker.datatype.boolean(),
+  is_supporter: faker.datatype.boolean(),
+  photo_url: faker.image.avatar(),
+  country: '',
+  roles: [],
+  ...dbProfileOverloads,
+})

--- a/src/test/services/notificationsCoordinationService.server.ts
+++ b/src/test/services/notificationsCoordinationService.server.ts
@@ -1,0 +1,177 @@
+import { discordServiceServer } from 'src/services/discordService.server'
+import { notificationsCoordinationServiceServer } from 'src/services/notificationsCoordinationService.server'
+import { notificationsService } from 'src/services/notificationsService.server'
+import { notificationsSupabaseServiceServer } from 'src/services/notificationSupabaseService.server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FactoryDBProfile } from '../factories/profile'
+import {
+  FactoryDBResearchItem,
+  FactoryDBResearchItemUpdate,
+  FactoryResearchItemUpdate,
+} from '../factories/ResearchItem'
+
+vi.mock('src/services/notificationsService.server')
+vi.mock('src/services/notificationSupabaseService.server')
+vi.mock('src/services/discordService.server')
+
+describe('notificationsCoordinationServiceServer', () => {
+  describe('researchUpdate', () => {
+    const mockProfile = FactoryDBProfile()
+    const mockClient = {} as any
+    const mockRequest = new Request('http://example.com')
+    const mockResearch = FactoryDBResearchItem({
+      is_draft: false,
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    describe('when research update has draft research', () => {
+      it('does not send any notifications when researchUpdate.research.is_draft is true', () => {
+        const researchUpdate = FactoryResearchItemUpdate({
+          isDraft: false,
+          research: { ...mockResearch, is_draft: true },
+        })
+
+        notificationsCoordinationServiceServer.researchUpdate(
+          researchUpdate,
+          mockProfile,
+          mockClient,
+          mockRequest,
+        )
+
+        expect(
+          notificationsService.sendResearchUpdateNotification,
+        ).not.toHaveBeenCalled()
+        expect(
+          notificationsSupabaseServiceServer.createNotificationsResearchUpdate,
+        ).not.toHaveBeenCalled()
+        expect(discordServiceServer.postWebhookRequest).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when research update itself is draft', () => {
+      it('does not send any notifications when researchUpdate.isDraft is true', () => {
+        const researchUpdate = FactoryResearchItemUpdate({
+          isDraft: true,
+          research: mockResearch,
+        })
+
+        notificationsCoordinationServiceServer.researchUpdate(
+          researchUpdate,
+          mockProfile,
+          mockClient,
+          mockRequest,
+        )
+
+        expect(
+          notificationsService.sendResearchUpdateNotification,
+        ).not.toHaveBeenCalled()
+        expect(
+          notificationsSupabaseServiceServer.createNotificationsResearchUpdate,
+        ).not.toHaveBeenCalled()
+        expect(discordServiceServer.postWebhookRequest).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when transitioning from non-draft to non-draft', () => {
+      it('does not send any notifications when researchUpdate.isDraft is false and oldResearchUpdate.is_draft is false', () => {
+        const researchUpdate = FactoryResearchItemUpdate({
+          isDraft: false,
+          research: mockResearch,
+        })
+        const oldResearchUpdate = FactoryDBResearchItemUpdate({
+          is_draft: false,
+        })
+
+        notificationsCoordinationServiceServer.researchUpdate(
+          researchUpdate,
+          mockProfile,
+          mockClient,
+          mockRequest,
+          oldResearchUpdate,
+        )
+
+        expect(
+          notificationsService.sendResearchUpdateNotification,
+        ).not.toHaveBeenCalled()
+        expect(
+          notificationsSupabaseServiceServer.createNotificationsResearchUpdate,
+        ).not.toHaveBeenCalled()
+        expect(discordServiceServer.postWebhookRequest).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when transitioning from draft to published', () => {
+      it('sends all notifications when researchUpdate.isDraft is false and oldResearchUpdate.is_draft is true', () => {
+        const researchUpdate = FactoryResearchItemUpdate({
+          isDraft: false,
+          research: mockResearch,
+        })
+        const oldResearchUpdate = FactoryDBResearchItemUpdate({
+          is_draft: true,
+        })
+
+        notificationsCoordinationServiceServer.researchUpdate(
+          researchUpdate,
+          mockProfile,
+          mockClient,
+          mockRequest,
+          oldResearchUpdate,
+        )
+
+        expect(
+          notificationsService.sendResearchUpdateNotification,
+        ).toHaveBeenCalledWith(
+          mockClient,
+          mockResearch,
+          researchUpdate,
+          mockProfile,
+        )
+        expect(
+          notificationsSupabaseServiceServer.createNotificationsResearchUpdate,
+        ).toHaveBeenCalledWith(
+          mockResearch,
+          researchUpdate,
+          mockProfile,
+          mockClient,
+        )
+        expect(discordServiceServer.postWebhookRequest).toHaveBeenCalled()
+      })
+
+      it('sends all notifications when researchUpdate.isDraft is false and oldResearchUpdate is not provided', () => {
+        const researchUpdate = FactoryResearchItemUpdate({
+          isDraft: false,
+          research: mockResearch,
+        })
+
+        notificationsCoordinationServiceServer.researchUpdate(
+          researchUpdate,
+          mockProfile,
+          mockClient,
+          mockRequest,
+        )
+
+        expect(
+          notificationsService.sendResearchUpdateNotification,
+        ).toHaveBeenCalledWith(
+          mockClient,
+          mockResearch,
+          researchUpdate,
+          mockProfile,
+        )
+        expect(
+          notificationsSupabaseServiceServer.createNotificationsResearchUpdate,
+        ).toHaveBeenCalledWith(
+          mockResearch,
+          researchUpdate,
+          mockProfile,
+          mockClient,
+        )
+        expect(discordServiceServer.postWebhookRequest).toHaveBeenCalled()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [x] Feature (adds functionality)

## What is the new behavior?

Previously, notifications wouldn't be sent for research updates that were initially saved as drafts, they are now - with improved unit tests.