### PR TITLE
feat: email footer service message or preferences

### DIFF
--- a/supabase/functions/send-email/_templates/layout.tsx
+++ b/supabase/functions/send-email/_templates/layout.tsx
@@ -85,15 +85,15 @@ export const Layout = (props: LayoutArgs) => {
           />
           <Section style={card}>{children}</Section>
           <Footer>
-            You must receive important community messages. <br />
+            {!isNotificationEmail && <>This is a service email.</>}
             {isNotificationEmail && (
               <>
                 <Link href={preferencesUpdatePath} style={link}>
                   Unsubscribe or update your email preferences.
                 </Link>
-                <br />
               </>
             )}
+            <br />
             Something is not right? Send us{' '}
             <Link
               href={`${settings.siteUrl}/feedback/#page=email`}


### PR DESCRIPTION
For notification emails:
<img width="673" height="169" alt="Screenshot 2025-07-22 at 14 50 19" src="https://github.com/user-attachments/assets/7cc0744f-48cc-4125-9b28-a025401d306e" />

Service emails say: "This is a service email" instead.