### PR TITLE
feat: descriptive follow reply actions

### DIFF
--- a/packages/components/src/ActionSet/ActionSet.tsx
+++ b/packages/components/src/ActionSet/ActionSet.tsx
@@ -44,9 +44,9 @@ export const ActionSet = ({ children, itemType }: IProps) => {
             position: 'absolute',
             right: 0,
             zIndex: 1,
-            padding: 2,
-            gap: 2,
-            minWidth: '190px',
+            padding: 1,
+            gap: 1,
+            minWidth: '200px',
           }}
         >
           <Flex

--- a/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
@@ -102,8 +102,8 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
                   iconFollow="discussionFollow"
                   iconUnfollow="discussionUnfollow"
                   itemId={comment.id}
-                  labelFollow="Follow replies"
-                  labelUnfollow="Unfollow replies"
+                  labelFollow="Not following replies"
+                  labelUnfollow="Following replies"
                   sx={{ fontSize: 1 }}
                   variant="subtle"
                 />
@@ -121,11 +121,11 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
               <FollowButtonAction
                 contentType="comments"
                 itemId={comment.id}
-                labelFollow="Follow replies"
-                labelUnfollow="Unfollow replies"
+                labelFollow="Not following replies"
+                labelUnfollow="Following replies"
                 showIconOnly
-                tooltipFollow="Follow new replies"
-                tooltipUnfollow="Unfollow new replies"
+                tooltipFollow="Not following replies"
+                tooltipUnfollow="Following replies"
                 variant="subtle"
                 hideSubscribeIcon
               />


### PR DESCRIPTION
## What is the current behavior?
<img width="442" height="576" alt="Screenshot 2025-07-22 at 15 53 37" src="https://github.com/user-attachments/assets/dc78754a-b7e4-4763-89c1-0be9e9edf6b0" />

## What is the new behavior?

<img width="442" height="576" alt="Screenshot 2025-07-22 at 15 53 30" src="https://github.com/user-attachments/assets/7e4b100b-5a8b-433b-a95d-da0147bc13df" />
