### PR TITLE
fix: tooltip going beyond screen limit

### DIFF
--- a/packages/components/src/InformationTooltip/InformationTooltip.tsx
+++ b/packages/components/src/InformationTooltip/InformationTooltip.tsx
@@ -13,13 +13,14 @@ export const InformationTooltip = (props: IProps) => {
 
   return (
     <>
-      <Icon
-        {...props}
-        data-tooltip-id={id}
-        data-tooltip-content={props.tooltip}
-      />
+      <Icon {...props} data-tooltip-id={id} />
 
-      <Tooltip id={id} />
+      <Tooltip id={id}>
+        <p
+          dangerouslySetInnerHTML={{ __html: props.tooltip }}
+          style={{ textAlign: 'center', margin: 0 }}
+        />
+      </Tooltip>
     </>
   )
 }

--- a/packages/components/src/Tooltip/Tooltip.tsx
+++ b/packages/components/src/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ const StyledTooltip = styled(ReactTooltip)`
   opacity: 1 !important;
   z-index: 9999 !important;
   line-height: 1.5rem;
+  text-align: center;
 `
 
 type TooltipProps = {

--- a/src/pages/UserSettings/SupabaseNotificationsForm.tsx
+++ b/src/pages/UserSettings/SupabaseNotificationsForm.tsx
@@ -87,7 +87,7 @@ export const SupabaseNotificationsForm = (props: IProps) => {
         <InformationTooltip
           glyph="information"
           size={22}
-          tooltip="Afriad we've got to send these to you, so you can't opt-out"
+          tooltip="Afriad we've got to send these to you,<br/>so you can't opt-out. "
         />
       ),
       description:


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## What is the current behavior?
<img width="562" height="1218" alt="IMG_2260" src="https://github.com/user-attachments/assets/0c3721e1-2b3f-44ea-8f7c-45bf949f58df" />


## What is the new behavior?

<img width="450" height="235" alt="Screenshot 2025-07-23 at 16 18 33" src="https://github.com/user-attachments/assets/9b97e476-8be8-4787-98ef-8bd6d48eb724" />
<img width="491" height="235" alt="Screenshot 2025-07-23 at 16 18 53" src="https://github.com/user-attachments/assets/c420ed1d-ddcc-4f94-84e4-047d67086d11" />
