### PR TITLE
fix: create stacking context for markdown editor

### DIFF
--- a/packages/components/src/FieldMarkdown/style.css
+++ b/packages/components/src/FieldMarkdown/style.css
@@ -1,6 +1,8 @@
 .mdxeditor {
   border-radius: 8px;
   border: 2px solid #f0f0f3;
+  position: relative;
+  z-index: 0;
 
   &.mdxeditor-error {
     border: 2px solid red;
@@ -9,5 +11,5 @@
 
 /* hacky way to hide the markdown diff part of https://mdxeditor.dev/editor/docs/diff-source */
 [aria-label='Diff mode'] {
-  display: none
+  display: none;
 }


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

In the /news/create path, when tag select is open, is hidden by the rich text editor, As described in #4356

## What is the new behavior?

New stacking context is created in the FieldMarkdown component, preventing from hiding the selection menu. Also, keeping the sitcky functionality for the tools of the editor.

<img width="812" height="226" alt="image" src="https://github.com/user-attachments/assets/64284eed-5976-4703-b577-58611b57ff64" />
<img width="793" height="812" alt="image" src="https://github.com/user-attachments/assets/27798758-7507-4c5f-875b-64d25dbf867f" />


## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4356 

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
