### PR TITLE
Feat/comments/add useful button

### DIFF
--- a/.snaplet/dataModel.json
+++ b/.snaplet/dataModel.json
@@ -196,13 +196,7 @@
           "maxLength": 64
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "audit_log_entries_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "buckets": {
       "id": "storage.buckets",
@@ -350,6 +344,20 @@
           "maxLength": null
         },
         {
+          "id": "storage.buckets.type",
+          "name": "type",
+          "columnName": "type",
+          "type": "buckettype",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "objects",
           "type": "objects",
           "isRequired": false,
@@ -408,16 +416,117 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "buckets_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "bname",
           "fields": ["name"],
           "nullNotDistinct": false
         }
       ]
+    },
+    "buckets_analytics": {
+      "id": "storage.buckets_analytics",
+      "schemaName": "storage",
+      "tableName": "buckets_analytics",
+      "fields": [
+        {
+          "id": "storage.buckets_analytics.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "storage.buckets_analytics.type",
+          "name": "type",
+          "columnName": "type",
+          "type": "buckettype",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.buckets_analytics.format",
+          "name": "format",
+          "columnName": "format",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.buckets_analytics.created_at",
+          "name": "created_at",
+          "columnName": "created_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.buckets_analytics.updated_at",
+          "name": "updated_at",
+          "columnName": "updated_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "name": "iceberg_namespaces",
+          "type": "iceberg_namespaces",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "iceberg_namespacesTobuckets_analytics",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "iceberg_tables",
+          "type": "iceberg_tables",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "iceberg_tablesTobuckets_analytics",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        }
+      ],
+      "uniqueConstraints": []
     },
     "categories": {
       "id": "public.categories",
@@ -1077,13 +1186,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "flow_state_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "hooks": {
       "id": "supabase_functions.hooks",
@@ -1269,6 +1372,258 @@
       ],
       "uniqueConstraints": []
     },
+    "iceberg_namespaces": {
+      "id": "storage.iceberg_namespaces",
+      "schemaName": "storage",
+      "tableName": "iceberg_namespaces",
+      "fields": [
+        {
+          "id": "storage.iceberg_namespaces.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "uuid",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_namespaces.bucket_id",
+          "name": "bucket_id",
+          "columnName": "bucket_id",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_namespaces.name",
+          "name": "name",
+          "columnName": "name",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_namespaces.created_at",
+          "name": "created_at",
+          "columnName": "created_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_namespaces.updated_at",
+          "name": "updated_at",
+          "columnName": "updated_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "name": "buckets_analytics",
+          "type": "buckets_analytics",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "iceberg_namespacesTobuckets_analytics",
+          "relationFromFields": ["bucket_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "iceberg_tables",
+          "type": "iceberg_tables",
+          "isRequired": false,
+          "kind": "object",
+          "relationName": "iceberg_tablesToiceberg_namespaces",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isList": true,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "idx_iceberg_namespaces_bucket_id",
+          "fields": ["bucket_id", "name"],
+          "nullNotDistinct": false
+        }
+      ]
+    },
+    "iceberg_tables": {
+      "id": "storage.iceberg_tables",
+      "schemaName": "storage",
+      "tableName": "iceberg_tables",
+      "fields": [
+        {
+          "id": "storage.iceberg_tables.id",
+          "name": "id",
+          "columnName": "id",
+          "type": "uuid",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": true,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.namespace_id",
+          "name": "namespace_id",
+          "columnName": "namespace_id",
+          "type": "uuid",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.bucket_id",
+          "name": "bucket_id",
+          "columnName": "bucket_id",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.name",
+          "name": "name",
+          "columnName": "name",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.location",
+          "name": "location",
+          "columnName": "location",
+          "type": "text",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.created_at",
+          "name": "created_at",
+          "columnName": "created_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "storage.iceberg_tables.updated_at",
+          "name": "updated_at",
+          "columnName": "updated_at",
+          "type": "timestamptz",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "name": "buckets_analytics",
+          "type": "buckets_analytics",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "iceberg_tablesTobuckets_analytics",
+          "relationFromFields": ["bucket_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        },
+        {
+          "name": "iceberg_namespaces",
+          "type": "iceberg_namespaces",
+          "isRequired": true,
+          "kind": "object",
+          "relationName": "iceberg_tablesToiceberg_namespaces",
+          "relationFromFields": ["namespace_id"],
+          "relationToFields": ["id"],
+          "isList": false,
+          "isId": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": "idx_iceberg_tables_namespace_id",
+          "fields": ["name", "namespace_id"],
+          "nullNotDistinct": false
+        }
+      ]
+    },
     "identities": {
       "id": "auth.identities",
       "schemaName": "auth",
@@ -1417,11 +1772,6 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "identities_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "identities_provider_id_provider_unique",
           "fields": ["provider", "provider_id"],
           "nullNotDistinct": false
@@ -1504,279 +1854,7 @@
           "maxLength": null
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "instances_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
-    },
-    "key": {
-      "id": "pgsodium.key",
-      "schemaName": "pgsodium",
-      "tableName": "key",
-      "fields": [
-        {
-          "id": "pgsodium.key.id",
-          "name": "id",
-          "columnName": "id",
-          "type": "uuid",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": true,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.status",
-          "name": "status",
-          "columnName": "status",
-          "type": "key_status",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.created",
-          "name": "created",
-          "columnName": "created",
-          "type": "timestamptz",
-          "isRequired": true,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.expires",
-          "name": "expires",
-          "columnName": "expires",
-          "type": "timestamptz",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.key_type",
-          "name": "key_type",
-          "columnName": "key_type",
-          "type": "key_type",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.key_id",
-          "name": "key_id",
-          "columnName": "key_id",
-          "type": "int8",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": {
-            "identifier": "\"pgsodium\".\"key_key_id_seq\"",
-            "increment": 1,
-            "start": 1
-          },
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.key_context",
-          "name": "key_context",
-          "columnName": "key_context",
-          "type": "bytea",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.name",
-          "name": "name",
-          "columnName": "name",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.associated_data",
-          "name": "associated_data",
-          "columnName": "associated_data",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": true,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.raw_key",
-          "name": "raw_key",
-          "columnName": "raw_key",
-          "type": "bytea",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.raw_key_nonce",
-          "name": "raw_key_nonce",
-          "columnName": "raw_key_nonce",
-          "type": "bytea",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.parent_key",
-          "name": "parent_key",
-          "columnName": "parent_key",
-          "type": "uuid",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.comment",
-          "name": "comment",
-          "columnName": "comment",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "id": "pgsodium.key.user_data",
-          "name": "user_data",
-          "columnName": "user_data",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
-          "name": "key",
-          "type": "key",
-          "isRequired": false,
-          "kind": "object",
-          "relationName": "keyTokey",
-          "relationFromFields": ["parent_key"],
-          "relationToFields": ["id"],
-          "isList": false,
-          "isId": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false
-        },
-        {
-          "name": "key",
-          "type": "key",
-          "isRequired": false,
-          "kind": "object",
-          "relationName": "keyTokey",
-          "relationFromFields": [],
-          "relationToFields": [],
-          "isList": true,
-          "isId": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false
-        },
-        {
-          "name": "secrets",
-          "type": "secrets",
-          "isRequired": false,
-          "kind": "object",
-          "relationName": "secretsTokey",
-          "relationFromFields": [],
-          "relationToFields": [],
-          "isList": true,
-          "isId": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false
-        }
-      ],
-      "uniqueConstraints": [
-        {
-          "name": "key_key_id_key_context_key_type_idx",
-          "fields": ["key_context", "key_id", "key_type"],
-          "nullNotDistinct": false
-        },
-        {
-          "name": "key_status_idx1",
-          "fields": ["status"],
-          "nullNotDistinct": false
-        },
-        {
-          "name": "pgsodium_key_unique_name",
-          "fields": ["name"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "public_messages": {
       "id": "public.messages",
@@ -2126,11 +2204,6 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "amr_id_pk",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "mfa_amr_claims_session_id_authentication_method_pkey",
           "fields": ["authentication_method", "session_id"],
           "nullNotDistinct": false
@@ -2255,13 +2328,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "mfa_challenges_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "mfa_factors": {
       "id": "auth.mfa_factors",
@@ -2472,11 +2539,6 @@
           "nullNotDistinct": false
         },
         {
-          "name": "mfa_factors_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "mfa_factors_user_friendly_name_unique",
           "fields": ["friendly_name", "user_id"],
           "nullNotDistinct": false
@@ -2554,11 +2616,6 @@
         {
           "name": "migrations_name_key",
           "fields": ["name"],
-          "nullNotDistinct": false
-        },
-        {
-          "name": "migrations_pkey",
-          "fields": ["id"],
           "nullNotDistinct": false
         }
       ]
@@ -3258,6 +3315,20 @@
           "maxLength": null
         },
         {
+          "id": "public.notifications_preferences.is_unsubscribed",
+          "name": "is_unsubscribed",
+          "columnName": "is_unsubscribed",
+          "type": "bool",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "profiles",
           "type": "profiles",
           "isRequired": true,
@@ -3484,11 +3555,6 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "objects_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "bucketid_objname",
           "fields": ["bucket_id", "name"],
           "nullNotDistinct": false
@@ -3624,11 +3690,6 @@
         }
       ],
       "uniqueConstraints": [
-        {
-          "name": "one_time_tokens_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
         {
           "name": "one_time_tokens_user_id_token_type_key",
           "fields": ["token_type", "user_id"],
@@ -3800,13 +3861,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "prefixes_pkey",
-          "fields": ["bucket_id", "level", "name"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "profiles": {
       "id": "public.profiles",
@@ -5438,11 +5493,6 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "refresh_tokens_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "refresh_tokens_token_unique",
           "fields": ["token"],
           "nullNotDistinct": false
@@ -6233,13 +6283,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "s3_multipart_uploads_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "s3_multipart_uploads_parts": {
       "id": "storage.s3_multipart_uploads_parts",
@@ -6415,13 +6459,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "s3_multipart_uploads_parts_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "saml_providers": {
       "id": "auth.saml_providers",
@@ -6574,11 +6612,6 @@
           "name": "saml_providers_entity_id_key",
           "fields": ["entity_id"],
           "nullNotDistinct": false
-        },
-        {
-          "name": "saml_providers_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
         }
       ]
     },
@@ -6728,13 +6761,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "saml_relay_states_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "_realtime_schema_migrations": {
       "id": "_realtime.schema_migrations",
@@ -6792,13 +6819,7 @@
           "maxLength": 255
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "schema_migrations_pkey",
-          "fields": ["version"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "realtime_schema_migrations": {
       "id": "realtime.schema_migrations",
@@ -6963,7 +6984,7 @@
           "isList": false,
           "isGenerated": false,
           "sequence": false,
-          "hasDefaultValue": true,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -7008,20 +7029,6 @@
           "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
-        },
-        {
-          "name": "key",
-          "type": "key",
-          "isRequired": false,
-          "kind": "object",
-          "relationName": "secretsTokey",
-          "relationFromFields": ["key_id"],
-          "relationToFields": ["id"],
-          "isList": false,
-          "isId": false,
-          "isGenerated": false,
-          "sequence": false,
-          "hasDefaultValue": false
         }
       ],
       "uniqueConstraints": [
@@ -7276,13 +7283,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "sessions_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "sso_domains": {
       "id": "auth.sso_domains",
@@ -7374,13 +7375,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "sso_domains_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "sso_providers": {
       "id": "auth.sso_providers",
@@ -7486,13 +7481,7 @@
           "hasDefaultValue": false
         }
       ],
-      "uniqueConstraints": [
-        {
-          "name": "sso_providers_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        }
-      ]
+      "uniqueConstraints": []
     },
     "subscribers": {
       "id": "public.subscribers",
@@ -8186,6 +8175,34 @@
           "hasDefaultValue": true,
           "isId": false,
           "maxLength": null
+        },
+        {
+          "id": "_realtime.tenants.migrations_ran",
+          "name": "migrations_ran",
+          "columnName": "migrations_ran",
+          "type": "int4",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "_realtime.tenants.broadcast_adapter",
+          "name": "broadcast_adapter",
+          "columnName": "broadcast_adapter",
+          "type": "varchar",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": 255
         },
         {
           "name": "extensions",
@@ -8894,16 +8911,6 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "users_phone_key",
-          "fields": ["phone"],
-          "nullNotDistinct": false
-        },
-        {
-          "name": "users_pkey",
-          "fields": ["id"],
-          "nullNotDistinct": false
-        },
-        {
           "name": "confirmation_token_idx",
           "fields": ["confirmation_token"],
           "nullNotDistinct": false
@@ -8931,6 +8938,11 @@
         {
           "name": "users_email_partial_key",
           "fields": ["email"],
+          "nullNotDistinct": false
+        },
+        {
+          "name": "users_phone_key",
+          "fields": ["phone"],
           "nullNotDistinct": false
         }
       ]
@@ -9021,61 +9033,6 @@
         },
         {
           "name": "SUCCESS"
-        }
-      ]
-    },
-    "key_status": {
-      "schemaName": "pgsodium",
-      "values": [
-        {
-          "name": "default"
-        },
-        {
-          "name": "expired"
-        },
-        {
-          "name": "invalid"
-        },
-        {
-          "name": "valid"
-        }
-      ]
-    },
-    "key_type": {
-      "schemaName": "pgsodium",
-      "values": [
-        {
-          "name": "aead-det"
-        },
-        {
-          "name": "aead-ietf"
-        },
-        {
-          "name": "auth"
-        },
-        {
-          "name": "generichash"
-        },
-        {
-          "name": "hmacsha256"
-        },
-        {
-          "name": "hmacsha512"
-        },
-        {
-          "name": "kdf"
-        },
-        {
-          "name": "secretbox"
-        },
-        {
-          "name": "secretstream"
-        },
-        {
-          "name": "shorthash"
-        },
-        {
-          "name": "stream_xchacha20"
         }
       ]
     },
@@ -9210,6 +9167,17 @@
         },
         {
           "name": "neq"
+        }
+      ]
+    },
+    "buckettype": {
+      "schemaName": "storage",
+      "values": [
+        {
+          "name": "ANALYTICS"
+        },
+        {
+          "name": "STANDARD"
         }
       ]
     }

--- a/packages/components/src/CommentDisplay/CommentDisplay.tsx
+++ b/packages/components/src/CommentDisplay/CommentDisplay.tsx
@@ -7,6 +7,7 @@ import { CommentAvatar } from '../CommentAvatar/CommentAvatar'
 import { CommentBody } from '../CommentBody/CommentBody'
 import { DisplayDate } from '../DisplayDate/DisplayDate'
 import { AuthorsContext } from '../providers/AuthorsContext'
+import { UsefulButtonLite } from '../UsefulStatsButton/UsefulButtonLite'
 import { Username } from '../Username/Username'
 
 import type { Comment } from 'oa-shared'
@@ -14,10 +15,17 @@ import type { ReactNode } from 'react'
 
 export interface IProps {
   comment: Comment
-  isEditable: boolean | undefined
   itemType: 'ReplyItem' | 'CommentItem'
+  isLoggedIn: boolean
+  isEditable: boolean | undefined
   setShowDeleteModal: (arg: boolean) => void
   setShowEditModal: (arg: boolean) => void
+  votedUsefulCount: number
+  hasUserVotedUseful: boolean
+  onUsefulClick: (
+    vote: 'add' | 'delete',
+    eventCategory?: string,
+  ) => Promise<void>
   followButton?: ReactNode
   followButtonIcon?: ReactNode
 }
@@ -27,12 +35,16 @@ const DELETED_COMMENT = 'The original comment got deleted'
 export const CommentDisplay = (props: IProps) => {
   const {
     comment,
-    isEditable,
     itemType,
-    setShowDeleteModal,
-    setShowEditModal,
+    isLoggedIn,
+    isEditable,
     followButton,
     followButtonIcon,
+    hasUserVotedUseful,
+    votedUsefulCount,
+    setShowDeleteModal,
+    setShowEditModal,
+    onUsefulClick,
   } = props
 
   const { authors } = useContext(AuthorsContext)
@@ -147,7 +159,20 @@ export const CommentDisplay = (props: IProps) => {
                 </ActionSet>
               </Flex>
             </Flex>
-            <CommentBody body={comment.comment} />
+            <Flex
+              sx={{
+                flexDirection: 'column',
+                gap: 2,
+              }}
+            >
+              <CommentBody body={comment.comment} />
+              <UsefulButtonLite
+                votedUsefulCount={votedUsefulCount}
+                hasUserVotedUseful={hasUserVotedUseful}
+                isLoggedIn={!!isLoggedIn}
+                onUsefulClick={onUsefulClick}
+              />
+            </Flex>
           </Flex>
         </Flex>
       </Flex>

--- a/packages/components/src/UsefulStatsButton/UsefulButtonLite.tsx
+++ b/packages/components/src/UsefulStatsButton/UsefulButtonLite.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from '@remix-run/react'
+import { Flex, Text, useThemeUI } from 'theme-ui'
+
+import { Button } from '../Button/Button'
+import { Icon } from '../Icon/Icon'
+
+import type { ThemeUIStyleObject } from 'theme-ui'
+
+export interface IProps {
+  hasUserVotedUseful?: boolean
+  votedUsefulCount: number | undefined
+  isLoggedIn: boolean
+  onUsefulClick: (
+    vote: 'add' | 'delete',
+    eventCategory?: string,
+  ) => Promise<void>
+  sx?: ThemeUIStyleObject
+}
+
+export const UsefulButtonLite = (props: IProps) => {
+  const { hasUserVotedUseful, votedUsefulCount } = props
+  const { theme } = useThemeUI() as any
+  const navigate = useNavigate()
+  const uuid = useMemo(() => (Math.random() * 16).toString(), [])
+  const [disabled, setDisabled] = useState<boolean>()
+  const usefulAction = hasUserVotedUseful ? 'delete' : 'add'
+  const handleUsefulClick = async () => {
+    setDisabled(true)
+    try {
+      await props.onUsefulClick(usefulAction, 'Comment')
+    } catch (err) {
+      // handle error or ignore
+    }
+    setDisabled(false)
+  }
+
+  return (
+    <Flex sx={{ alignSelf: 'flex-end' }}>
+      <Button
+        type="button"
+        data-tooltip-id={uuid}
+        data-tooltip-content={props.isLoggedIn ? '' : 'Login to add your vote'}
+        data-cy={props.isLoggedIn ? 'vote-useful' : 'vote-useful-redirect'}
+        onClick={() =>
+          props.isLoggedIn
+            ? handleUsefulClick()
+            : navigate(
+                '/sign-in?returnUrl=' + encodeURIComponent(location.pathname),
+              )
+        }
+        disabled={disabled}
+        sx={{
+          fontSize: 1,
+          backgroundColor: hasUserVotedUseful
+            ? theme.colors.offWhite
+            : theme.colors.softgrey,
+          border: 'none',
+          margin: 0,
+          padding: 1,
+          display: 'flex',
+          height: '80%',
+          alignItems: 'center',
+          gap: 1,
+          '&:hover': {
+            backgroundColor: theme.colors.softblue,
+          },
+          ...props.sx,
+        }}
+      >
+        <Flex sx={{ alignItems: 'center' }}>
+          <Text
+            sx={{
+              display: 'inline-block',
+            }}
+          >
+            {votedUsefulCount ?? 0}
+          </Text>
+          <Icon
+            glyph={'star-active'}
+            ml={3}
+            size={'sm'}
+            filter={hasUserVotedUseful ? 'unset' : 'grayscale(1)'}
+          />
+        </Flex>
+      </Button>
+    </Flex>
+  )
+}

--- a/src/pages/Library/Content/Page/ProjectPage.tsx
+++ b/src/pages/Library/Content/Page/ProjectPage.tsx
@@ -14,12 +14,13 @@ import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { Breadcrumbs } from 'src/pages/common/Breadcrumbs/Breadcrumbs'
 import { CommentSectionSupabase } from 'src/pages/common/CommentsSupabase/CommentSectionSupabase'
 import { usefulService } from 'src/services/usefulService'
+import { onUsefulClick } from 'src/utils/onUsefulClick'
 import { Card, Flex } from 'theme-ui'
 
 import { LibraryDescription } from './LibraryDescription'
 import Step from './LibraryStep'
 
-import type { IUser, Project, ProjectStep } from 'oa-shared'
+import type { ContentType, IUser, Project, ProjectStep } from 'oa-shared'
 
 type ProjectPageProps = {
   item: Project
@@ -47,31 +48,23 @@ export const ProjectPage = observer(({ item }: ProjectPageProps) => {
     }
   }, [loggedInUser, item])
 
-  const onUsefulClick = async (
+  const configOnUsefulClick = {
+    contentType: 'projects' as ContentType,
+    contentId: item.id,
+    eventCategory: 'Library',
+    slug: item.slug,
+    setVoted,
+    setUsefulCount,
+    loggedInUser: loggedInUser,
+  }
+
+  const handleUsefulClick = async (
     vote: 'add' | 'delete',
     eventCategory = 'Library',
   ) => {
-    if (!loggedInUser?.userName) {
-      return
-    }
-
-    // Trigger update without waiting
-    if (vote === 'add') {
-      await usefulService.add('projects', item.id)
-    } else {
-      await usefulService.remove('projects', item.id)
-    }
-
-    setVoted((prev) => !prev)
-
-    setUsefulCount((prev) => {
-      return vote === 'add' ? prev + 1 : prev - 1
-    })
-
-    trackEvent({
-      category: eventCategory,
-      action: vote === 'add' ? 'ProjectUseful' : 'ProjectUsefulRemoved',
-      label: item.slug,
+    await onUsefulClick({
+      vote,
+      config: { ...configOnUsefulClick, eventCategory },
     })
   }
 
@@ -85,7 +78,7 @@ export const ProjectPage = observer(({ item }: ProjectPageProps) => {
         votedUsefulCount={usefulCount}
         hasUserVotedUseful={voted}
         onUsefulClick={() =>
-          onUsefulClick(voted ? 'delete' : 'add', 'LibraryDescription')
+          handleUsefulClick(voted ? 'delete' : 'add', 'LibraryDescription')
         }
         subscribersCount={subscribersCount}
       />
@@ -131,7 +124,7 @@ export const ProjectPage = observer(({ item }: ProjectPageProps) => {
                   hasUserVotedUseful={voted}
                   isLoggedIn={!!loggedInUser}
                   onUsefulClick={() =>
-                    onUsefulClick(
+                    handleUsefulClick(
                       voted ? 'delete' : 'add',
                       'ArticleCallToAction',
                     )

--- a/src/pages/Question/QuestionPage.tsx
+++ b/src/pages/Question/QuestionPage.tsx
@@ -11,19 +11,19 @@ import {
 } from 'oa-components'
 // eslint-disable-next-line import/no-unresolved
 import { ClientOnly } from 'remix-utils/client-only'
-import { trackEvent } from 'src/common/Analytics'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { Breadcrumbs } from 'src/pages/common/Breadcrumbs/Breadcrumbs'
 import { usefulService } from 'src/services/usefulService'
 import { formatImagesForGalleryV2 } from 'src/utils/formatImageListForGallery'
 import { buildStatisticsLabel, hasAdminRights } from 'src/utils/helpers'
+import { onUsefulClick } from 'src/utils/onUsefulClick'
 import { Box, Button, Card, Divider, Flex, Heading, Text } from 'theme-ui'
 
 import { CommentSectionSupabase } from '../common/CommentsSupabase/CommentSectionSupabase'
 import { DraftTag } from '../common/Drafts/DraftTag'
 import { UserNameTag } from '../common/UserNameTag/UserNameTag'
 
-import type { IUser, Question } from 'oa-shared'
+import type { ContentType, IUser, Question } from 'oa-shared'
 
 interface IProps {
   question: Question
@@ -56,31 +56,21 @@ export const QuestionPage = observer(({ question }: IProps) => {
     )
   }, [activeUser, question.author])
 
-  const onUsefulClick = async (vote: 'add' | 'delete') => {
-    if (!activeUser) {
-      return
-    }
 
-    if (vote === 'add') {
-      const response = await usefulService.add('questions', question.id)
+  const configOnUsefulClick = {
+    contentType: 'questions' as ContentType,
+    contentId: question.id,
+    eventCategory: 'QuestionPage',
+    slug: question.slug,
+    setVoted,
+    setUsefulCount,
+    loggedInUser: activeUser,
+  }
 
-      if (response.ok) {
-        setVoted(true)
-        setUsefulCount((prev) => prev + 1 || 1)
-      }
-    } else {
-      const response = await usefulService.remove('questions', question.id)
-
-      if (response.ok) {
-        setVoted(false)
-        setUsefulCount((prev) => prev - 1 || 0)
-      }
-    }
-
-    trackEvent({
-      category: 'QuestionPage',
-      action: vote === 'add' ? 'QuestionUseful' : 'QuestionUsefulRemoved',
-      label: question.slug,
+  const handleUsefulClick = async (vote: 'add' | 'delete') => {
+    await onUsefulClick({
+      vote,
+      config: configOnUsefulClick,
     })
   }
 
@@ -98,7 +88,7 @@ export const QuestionPage = observer(({ question }: IProps) => {
                     hasUserVotedUseful={voted}
                     isLoggedIn={!!activeUser}
                     onUsefulClick={() =>
-                      onUsefulClick(voted ? 'delete' : 'add')
+                      handleUsefulClick(voted ? 'delete' : 'add')
                     }
                   />
 

--- a/src/pages/Question/QuestionPage.tsx
+++ b/src/pages/Question/QuestionPage.tsx
@@ -56,7 +56,6 @@ export const QuestionPage = observer(({ question }: IProps) => {
     )
   }, [activeUser, question.author])
 
-
   const configOnUsefulClick = {
     contentType: 'questions' as ContentType,
     contentId: question.id,

--- a/src/pages/Research/Content/ResearchArticlePage.tsx
+++ b/src/pages/Research/Content/ResearchArticlePage.tsx
@@ -20,12 +20,13 @@ import {
 import { subscribersService } from 'src/services/subscribersService'
 import { usefulService } from 'src/services/usefulService'
 import { hasAdminRights } from 'src/utils/helpers'
+import { onUsefulClick } from 'src/utils/onUsefulClick'
 import { Box, Flex } from 'theme-ui'
 
 import ResearchDescription from './ResearchDescription'
 import ResearchUpdate from './ResearchUpdate'
 
-import type { IUser, ResearchItem } from 'oa-shared'
+import type { ContentType, IUser, ResearchItem } from 'oa-shared'
 
 interface IProps {
   research: ResearchItem
@@ -42,31 +43,23 @@ export const ResearchArticlePage = observer(({ research }: IProps) => {
   )
   const [usefulCount, setUsefulCount] = useState<number>(research.usefulCount)
 
-  const onUsefulClick = async (
+  const configOnUsefulClick = {
+    contentType: 'research' as ContentType,
+    contentId: research.id,
+    eventCategory: 'Research',
+    slug: research.slug,
+    setVoted,
+    setUsefulCount,
+    loggedInUser: loggedInUser,
+  }
+
+  const handleUsefulClick = async (
     vote: 'add' | 'delete',
-    eventCategory = 'Research',
+    eventCategory = 'Library',
   ) => {
-    if (!loggedInUser?.userName) {
-      return
-    }
-
-    // Trigger update without waiting
-    if (vote === 'add') {
-      await usefulService.add('research', research.id)
-    } else {
-      await usefulService.remove('research', research.id)
-    }
-
-    setVoted((prev) => !prev)
-
-    setUsefulCount((prev) => {
-      return vote === 'add' ? prev + 1 : prev - 1
-    })
-
-    trackEvent({
-      category: eventCategory,
-      action: vote === 'add' ? 'ResearchUseful' : 'ResearchUsefulRemoved',
-      label: research.slug,
+    await onUsefulClick({
+      vote,
+      config: { ...configOnUsefulClick, eventCategory },
     })
   }
 
@@ -163,7 +156,7 @@ export const ResearchArticlePage = observer(({ research }: IProps) => {
         hasUserVotedUseful={voted}
         hasUserSubscribed={subscribed}
         onUsefulClick={() =>
-          onUsefulClick(voted ? 'delete' : 'add', 'ResearchDescription')
+          handleUsefulClick(voted ? 'delete' : 'add', 'ResearchDescription')
         }
         onFollowClick={() => onFollowClick(subscribed ? 'remove' : 'add')}
         contributors={research.collaborators?.map((x) => ({
@@ -213,7 +206,7 @@ export const ResearchArticlePage = observer(({ research }: IProps) => {
                     votedUsefulCount={usefulCount}
                     hasUserVotedUseful={voted}
                     onUsefulClick={() =>
-                      onUsefulClick(
+                      handleUsefulClick(
                         voted ? 'delete' : 'add',
                         'ArticleCallToAction',
                       )

--- a/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
@@ -8,17 +8,17 @@ import {
   Modal,
 } from 'oa-components'
 import { UserRole } from 'oa-shared'
-import { trackEvent } from 'src/common/Analytics'
 import { AuthWrapper, isUserAuthorized } from 'src/common/AuthWrapper'
 import { FollowButtonAction } from 'src/common/FollowButtonAction'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { usefulService } from 'src/services/usefulService'
+import { onUsefulClick } from 'src/utils/onUsefulClick'
 import { Card, Flex } from 'theme-ui'
 
 import { CommentReply } from './CommentReplySupabase'
 import { CreateCommentSupabase } from './CreateCommentSupabase'
 
-import type { Comment, DiscussionContentTypes } from 'oa-shared'
+import type { Comment, ContentType, DiscussionContentTypes } from 'oa-shared'
 
 export interface ICommentItemProps {
   comment: Comment
@@ -86,31 +86,23 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
     }
   }, [comment.highlighted])
 
-  const onUsefulClick = async (
+  const configOnUsefulClick = {
+    contentType: 'comment' as ContentType,
+    contentId: comment.id,
+    eventCategory: 'Comment',
+    slug: `${comment}+${comment.id}`,
+    setVoted,
+    setUsefulCount,
+    loggedInUser: activeUser,
+  }
+
+  const handleUsefulClick = async (
     vote: 'add' | 'delete',
     eventCategory = 'Comment',
   ) => {
-    if (!activeUser?.userName) {
-      return
-    }
-
-    // Trigger update without waiting
-    if (vote === 'add') {
-      await usefulService.add('comment', comment.id)
-    } else {
-      await usefulService.remove('comment', comment.id)
-    }
-
-    setVoted((prev) => !prev)
-
-    setUsefulCount((prev) => {
-      return vote === 'add' ? prev + 1 : prev - 1
-    })
-
-    trackEvent({
-      category: eventCategory,
-      action: vote === 'add' ? 'CommentUseful' : 'CommentUsefulRemoved',
-      label: `comment-${comment.id}`,
+    await onUsefulClick({
+      vote,
+      config: { ...configOnUsefulClick, eventCategory },
     })
   }
 
@@ -174,7 +166,7 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
               />
             </AuthWrapper>
           }
-          onUsefulClick={onUsefulClick}
+          onUsefulClick={() => handleUsefulClick(voted ? 'delete' : 'add')}
           hasUserVotedUseful={voted}
           votedUsefulCount={usefulCount}
           isLoggedIn={!!activeUser}

--- a/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
@@ -8,9 +8,11 @@ import {
   Modal,
 } from 'oa-components'
 import { UserRole } from 'oa-shared'
+import { trackEvent } from 'src/common/Analytics'
 import { AuthWrapper, isUserAuthorized } from 'src/common/AuthWrapper'
 import { FollowButtonAction } from 'src/common/FollowButtonAction'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import { usefulService } from 'src/services/usefulService'
 import { Card, Flex } from 'theme-ui'
 
 import { CommentReply } from './CommentReplySupabase'
@@ -44,6 +46,8 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
   const [showReplies, setShowReplies] = useState(
     () => !!comment.replies?.some((x) => x.highlighted),
   )
+  const [usefulCount, setUsefulCount] = useState<number>(comment.voteCount)
+  const [voted, setVoted] = useState<boolean>(false)
   const {
     userStore: { activeUser },
   } = useCommonStores().stores
@@ -63,6 +67,17 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
   ])
 
   useEffect(() => {
+    const getVoted = async () => {
+      const voted = await usefulService.hasVoted('comment', comment.id)
+      setVoted(voted)
+    }
+
+    if (activeUser) {
+      getVoted()
+    }
+  }, [activeUser, comment])
+
+  useEffect(() => {
     if (comment.highlighted) {
       commentRef.current?.scrollIntoView({
         behavior: 'smooth',
@@ -70,6 +85,34 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
       })
     }
   }, [comment.highlighted])
+
+  const onUsefulClick = async (
+    vote: 'add' | 'delete',
+    eventCategory = 'Comment',
+  ) => {
+    if (!activeUser?.userName) {
+      return
+    }
+
+    // Trigger update without waiting
+    if (vote === 'add') {
+      await usefulService.add('comment', comment.id)
+    } else {
+      await usefulService.remove('comment', comment.id)
+    }
+
+    setVoted((prev) => !prev)
+
+    setUsefulCount((prev) => {
+      return vote === 'add' ? prev + 1 : prev - 1
+    })
+
+    trackEvent({
+      category: eventCategory,
+      action: vote === 'add' ? 'CommentUseful' : 'CommentUsefulRemoved',
+      label: `comment-${comment.id}`,
+    })
+  }
 
   return (
     <Flex
@@ -131,6 +174,10 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
               />
             </AuthWrapper>
           }
+          onUsefulClick={onUsefulClick}
+          hasUserVotedUseful={voted}
+          votedUsefulCount={usefulCount}
+          isLoggedIn={!!activeUser}
         />
 
         <Flex

--- a/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
@@ -8,12 +8,12 @@ import {
   Modal,
 } from 'oa-components'
 import { UserRole } from 'oa-shared'
-import { trackEvent } from 'src/common/Analytics'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
 import { usefulService } from 'src/services/usefulService'
+import { onUsefulClick } from 'src/utils/onUsefulClick'
 import { Box, Flex, Text } from 'theme-ui'
 
-import type { Reply } from 'oa-shared'
+import type { ContentType, Reply } from 'oa-shared'
 
 const DELETED_COMMENT = 'The original comment got deleted'
 
@@ -64,33 +64,23 @@ export const CommentReply = observer(
     const item = 'ReplyItem'
     const loggedInUser = userStore.activeUser
 
-    const onUsefulClick = async (
+    const configOnUsefulClick = {
+      contentType: 'comment' as ContentType,
+      contentId: comment.id,
+      eventCategory: 'Comment',
+      slug: `${comment}+${comment.id}`,
+      setVoted,
+      setUsefulCount,
+      loggedInUser: loggedInUser,
+    }
+
+    const handleUsefulClick = async (
       vote: 'add' | 'delete',
       eventCategory = 'Comment',
     ) => {
-      console.log('Reply Comment Test', vote, eventCategory)
-
-      if (!loggedInUser?.userName) {
-        return
-      }
-
-      // Trigger update without waiting
-      if (vote === 'add') {
-        await usefulService.add('comment', comment.id)
-      } else {
-        await usefulService.remove('comment', comment.id)
-      }
-
-      setVoted((prev) => !prev)
-
-      setUsefulCount((prev) => {
-        return vote === 'add' ? prev + 1 : prev - 1
-      })
-
-      trackEvent({
-        category: eventCategory,
-        action: vote === 'add' ? 'CommentUseful' : 'CommentUsefulRemoved',
-        label: `comment-${comment.id}`,
+      await onUsefulClick({
+        vote,
+        config: { ...configOnUsefulClick, eventCategory },
       })
     }
 
@@ -127,7 +117,9 @@ export const CommentReply = observer(
                 comment={comment}
                 setShowDeleteModal={setShowDeleteModal}
                 setShowEditModal={setShowEditModal}
-                onUsefulClick={onUsefulClick}
+                onUsefulClick={() =>
+                  handleUsefulClick(voted ? 'delete' : 'add')
+                }
                 hasUserVotedUseful={voted}
                 votedUsefulCount={usefulCount}
                 isLoggedIn={!!loggedInUser}

--- a/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
@@ -8,7 +8,9 @@ import {
   Modal,
 } from 'oa-components'
 import { UserRole } from 'oa-shared'
+import { trackEvent } from 'src/common/Analytics'
 import { useCommonStores } from 'src/common/hooks/useCommonStores'
+import { usefulService } from 'src/services/usefulService'
 import { Box, Flex, Text } from 'theme-ui'
 
 import type { Reply } from 'oa-shared'
@@ -26,6 +28,8 @@ export const CommentReply = observer(
     const commentRef = useRef<HTMLDivElement>()
     const [showEditModal, setShowEditModal] = useState(false)
     const [showDeleteModal, setShowDeleteModal] = useState(false)
+    const [usefulCount, setUsefulCount] = useState<number>(comment.voteCount)
+    const [voted, setVoted] = useState<boolean>(comment.hasVoted) // TODO: retrieve the info from userStore ?
 
     const { userStore } = useCommonStores().stores
     const { activeUser } = userStore
@@ -38,6 +42,17 @@ export const CommentReply = observer(
     }, [activeUser, comment])
 
     useEffect(() => {
+      const getVoted = async () => {
+        const voted = await usefulService.hasVoted('comment', comment.id)
+        setVoted(voted)
+      }
+
+      if (loggedInUser) {
+        getVoted()
+      }
+    }, [activeUser, comment])
+
+    useEffect(() => {
       if (comment.highlighted) {
         commentRef.current?.scrollIntoView({
           behavior: 'smooth',
@@ -47,6 +62,37 @@ export const CommentReply = observer(
     }, [comment.highlighted])
 
     const item = 'ReplyItem'
+    const loggedInUser = userStore.activeUser
+
+    const onUsefulClick = async (
+      vote: 'add' | 'delete',
+      eventCategory = 'Comment',
+    ) => {
+      console.log('Reply Comment Test', vote, eventCategory)
+
+      if (!loggedInUser?.userName) {
+        return
+      }
+
+      // Trigger update without waiting
+      if (vote === 'add') {
+        await usefulService.add('comment', comment.id)
+      } else {
+        await usefulService.remove('comment', comment.id)
+      }
+
+      setVoted((prev) => !prev)
+
+      setUsefulCount((prev) => {
+        return vote === 'add' ? prev + 1 : prev - 1
+      })
+
+      trackEvent({
+        category: eventCategory,
+        action: vote === 'add' ? 'CommentUseful' : 'CommentUsefulRemoved',
+        label: `comment-${comment.id}`,
+      })
+    }
 
     return (
       <Flex>
@@ -81,6 +127,10 @@ export const CommentReply = observer(
                 comment={comment}
                 setShowDeleteModal={setShowDeleteModal}
                 setShowEditModal={setShowEditModal}
+                onUsefulClick={onUsefulClick}
+                hasUserVotedUseful={voted}
+                votedUsefulCount={usefulCount}
+                isLoggedIn={!!loggedInUser}
               />
             )}
           </Flex>

--- a/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
@@ -109,7 +109,7 @@ export const CommentSectionSupabase = (props: IProps) => {
 
   const editComment = async (id: number, comment: string) => {
     try {
-      const result = await commentService.editcomment(sourceId, id, comment)
+      const result = await commentService.editComment(sourceId, id, comment)
       const now = new Date()
 
       if (result.status === 204) {
@@ -181,7 +181,7 @@ export const CommentSectionSupabase = (props: IProps) => {
 
   const editReply = async (id: number, replyText: string, parentId: number) => {
     try {
-      const result = await commentService.editcomment(sourceId, id, replyText)
+      const result = await commentService.editComment(sourceId, id, replyText)
       const now = new Date()
 
       if (result.status === 204) {

--- a/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
@@ -5,6 +5,7 @@ import { AuthWrapper } from 'src/common/AuthWrapper'
 import { FollowButtonAction } from 'src/common/FollowButtonAction'
 import { commentService } from 'src/services/commentService'
 import { subscribersService } from 'src/services/subscribersService'
+import { usefulService } from 'src/services/usefulService'
 import { Box, Button, Flex } from 'theme-ui'
 
 import { CommentItemSupabase } from './CommentItemSupabase'
@@ -73,7 +74,40 @@ export const CommentSectionSupabase = (props: IProps) => {
           }
         }
 
-        setComments(comments || [])
+        const commentsWithVotes = await Promise.all(
+          comments.map(async (comment) => {
+            // Get vote count for the main comment
+            const count = await usefulService.getVoteCount(
+              'comment',
+              comment.id,
+            )
+
+            // Get vote counts for replies if they exist
+            let repliesWithVotes = comment.replies || []
+            if (comment.replies?.length) {
+              repliesWithVotes = await Promise.all(
+                comment.replies.map(async (reply) => {
+                  const replyCount = await usefulService.getVoteCount(
+                    'comment',
+                    reply.id,
+                  )
+                  return {
+                    ...reply,
+                    voteCount: replyCount ?? 0,
+                  }
+                }),
+              )
+            }
+
+            return {
+              ...comment,
+              voteCount: count ?? 0,
+              replies: repliesWithVotes,
+            }
+          }),
+        )
+
+        setComments(commentsWithVotes || [])
       } catch (err) {
         console.error(err)
       }

--- a/src/routes/api.research.ts
+++ b/src/routes/api.research.ts
@@ -35,12 +35,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     limit_val: ITEMS_PER_PAGE,
   })
 
-  const countRersult = await client.rpc('get_research_count', {
+  const countResult = await client.rpc('get_research_count', {
     search_query: q || null,
     category_id: category,
     research_status: status || null,
   })
-  const count = countRersult.data || 0
+  const count = countResult.data || 0
 
   if (error) {
     console.error(error)

--- a/src/routes/api.useful.$contentType.$id.count.ts
+++ b/src/routes/api.useful.$contentType.$id.count.ts
@@ -1,0 +1,46 @@
+import { createSupabaseServerClient } from 'src/repository/supabase.server'
+
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import type { ContentType } from 'shared/lib/models/common'
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { client, headers } = createSupabaseServerClient(request)
+
+  const { contentType, id } = params
+
+  const allowedContentTypes = [
+    'questions',
+    'projects',
+    'research',
+    'news',
+    'comment',
+  ] as const satisfies readonly ContentType[]
+
+  if (!allowedContentTypes.includes(contentType as ContentType)) {
+    return Response.json({ error: 'Unsupported content type' }, { status: 400 })
+  }
+
+  const commentId = Number(id)
+
+  if (!commentId || commentId <= 0 || !Number.isInteger(commentId)) {
+    return Response.json({ error: 'Invalid comment ID' }, { status: 400 })
+  }
+
+  const { data, error } = await client
+    .from('useful_votes')
+    .select('content_id')
+    .eq('content_type', contentType)
+    .eq('content_id', commentId)
+
+  if (error) {
+    console.error('Supabase error:', error)
+    return Response.json(
+      { error: 'Error fetching votes' },
+      { status: 500, headers },
+    )
+  }
+
+  const count = Array.isArray(data) ? data.length : 0
+
+  return Response.json({ count }, { headers, status: 200 })
+}

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -6,7 +6,7 @@ const deleteComment = async (sourceId: string | number, id: number) => {
   })
 }
 
-const editcomment = async (
+const editComment = async (
   sourceId: string | number,
   id: number,
   comment: string,
@@ -56,6 +56,6 @@ export const commentService = {
   getComments,
   getCommentSourceId,
   postComment,
-  editcomment,
+  editComment,
   deleteComment,
 }

--- a/src/services/usefulService.d.ts
+++ b/src/services/usefulService.d.ts
@@ -1,0 +1,7 @@
+import type { ContentType } from 'oa-shared'
+
+export declare const usefulService: {
+  add: (contentType: ContentType, id: number) => Promise<Response>
+  remove: (contentType: ContentType, id: number) => Promise<Response>
+  hasVoted: (contentType: ContentType, id: number) => Promise<boolean>
+}

--- a/src/services/usefulService.ts
+++ b/src/services/usefulService.ts
@@ -26,8 +26,20 @@ const hasVoted = async (contentType: ContentType, id: number) => {
   }
 }
 
+const getVoteCount = async (contentType: ContentType, id: number) => {
+  try {
+    const response = await fetch(`/api/useful/${contentType}/${id}/count`)
+    const { count } = await response.json()
+    return count
+  } catch (error) {
+    console.error(error)
+    return 0
+  }
+}
+
 export const usefulService = {
   add,
   remove,
   hasVoted,
+  getVoteCount,
 }

--- a/src/utils/onUsefulClick.ts
+++ b/src/utils/onUsefulClick.ts
@@ -1,0 +1,63 @@
+import { trackEvent } from 'src/common/Analytics'
+import { usefulService } from 'src/services/usefulService'
+
+import type { ContentType, IUserDB } from 'shared/lib'
+
+interface UsefulClickProps {
+  vote: 'add' | 'delete'
+  config: {
+    loggedInUser: IUserDB | null | undefined
+    contentType: ContentType
+    contentId: number
+    eventCategory: string
+    setVoted: (value: boolean | ((prev: boolean) => boolean)) => void
+    setUsefulCount: (value: number | ((prev: number) => number)) => void
+    label?: string
+    slug?: string
+    checkResponse?: boolean
+  }
+}
+const onUsefulClick = async (props: UsefulClickProps) => {
+  const { vote, config } = props
+  const {
+    loggedInUser,
+    contentType,
+    contentId,
+    eventCategory,
+    label,
+    slug,
+    setVoted,
+    setUsefulCount,
+  } = config
+
+  if (!loggedInUser?.userName) {
+    return
+  }
+
+  // Trigger update without waiting
+  if (vote === 'add') {
+    await usefulService.add(contentType, contentId)
+  } else {
+    await usefulService.remove(contentType, contentId)
+  }
+
+  setVoted((prev) => !prev)
+
+  setUsefulCount((prev) => {
+    return vote === 'add' ? prev + 1 : prev - 1
+  })
+
+  trackEvent({
+    category: eventCategory,
+    action:
+      vote === 'add'
+        ? `${capitalize(contentType)}Useful`
+        : `${capitalize(contentType)}UsefulRemoved`,
+    label: label || slug || `${contentType}-${contentId}`,
+  })
+}
+
+export { onUsefulClick }
+
+const capitalize = (str: string): string =>
+  str.charAt(0).toUpperCase() + str.slice(1)


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix (fixes an issue)
- [x] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

No useful button for comments

## What is the new behavior?

Adding a useful button for comments

_Describe the new behaviour_

This PR is part of the issue #4342, is not intended to be fully working now what is missing is:

- Final UI for the `UsefulButtonLite`
- Stories for the  `UsefulButtonLite`
- The end-to-end tests

What I did so far:
The component is a smaller and slightly different version of `usefulStatsButton`.  
Since in the Figma design the count appears on the left, I needed to adjust the layout accordingly.

When the user clicks the button, it triggers the `onUsefulClick` function, which exists in both `CommentItemSupabase` and `CommentReplySupabase`.  
Before this PR, there were 5 separate instances of `onUsefulClick` across different files. I took the opportunity to export it into a shared location and have each component import and use the same function.

The `onUsefulClick` function calls either `usefulService.add` or `usefulService.remove`, depending on whether the goal is to add or remove a "like".  
From there, the process follows the existing logic until it reaches the database, where I had to update the `content_type` type to include `"comment"`.  
*(Is this change only in my local DB instance? How can the production DB be updated? @benfurber @mariojsnunes)*

To retrieve the useful count, I added a function in `CommentSectionSupabase`.  
When the initial `useEffect` runs and fetches all comments, I also call `usefulService.getVoteCount` (which is a new service) to retrieve the vote counts for both the comments and their replies.  
These counts are then added to the comment objects in the same `useEffect`.  
As a result, when passing the comments to `<DisplayComments />`, each comment already contains its count, and this data flows through to the new `usefulStatsButton`.

Pushing this now so we can start the discussion on whether these changes need anything else added.

I’ll keep working on the UI and the remaining parts. In the meantime, have a look at the UI progress so far.


https://github.com/user-attachments/assets/ab1bdc92-57cc-4bc8-a288-b57a5b8c74f1

<img width="965" height="767" alt="Screenshot 2025-08-14 at 10 11 46" src="https://github.com/user-attachments/assets/f9655d36-32b4-40c2-a133-dac8bfa0bcee" />


Bug or what? @benfurber @mariojsnunes 

When clicking “useful” right after leaving a comment, I get NaN instead of the count.
Can someone point me to where I should check for this issue?
Could it be a database retrieval problem (no comment actually stored yet) or something else?
In the console, I see "user not found", but after refreshing, everything works fine.


## Does this PR introduce a DB Schema Change or Migration?

- [x] Yes
- [ ] No

## Git Issues

Closes #4342 