### PR TITLE
feat: add badge only news

### DIFF
--- a/packages/components/src/ProfileBadgeContentLabel/ProfileBadgeContentLabel.stories.tsx
+++ b/packages/components/src/ProfileBadgeContentLabel/ProfileBadgeContentLabel.stories.tsx
@@ -1,0 +1,19 @@
+import { ProfileBadgeContentLabel } from './ProfileBadgeContentLabel'
+
+import type { Meta, StoryFn } from '@storybook/react-vite'
+
+export default {
+  title: 'Components/ProfileBadgeContentLabel',
+  component: ProfileBadgeContentLabel,
+} as Meta<typeof ProfileBadgeContentLabel>
+
+export const Default: StoryFn<typeof ProfileBadgeContentLabel> = () => {
+  const profileBadge = {
+    id: 1,
+    name: 'prop',
+    displayName: 'PRO',
+    imageUrl:
+      'https://wbskztclbriekwpehznv.supabase.co/storage/v1/object/public/one-army/icons/pro.svg',
+  }
+  return <ProfileBadgeContentLabel profileBadge={profileBadge} />
+}

--- a/packages/components/src/ProfileBadgeContentLabel/ProfileBadgeContentLabel.tsx
+++ b/packages/components/src/ProfileBadgeContentLabel/ProfileBadgeContentLabel.tsx
@@ -1,0 +1,30 @@
+import { Flex, Text } from 'theme-ui'
+
+import { UserBadge } from '../Username/UserBadge'
+
+import type { ProfileBadge } from 'oa-shared'
+
+export interface Props {
+  profileBadge: ProfileBadge
+}
+
+export const ProfileBadgeContentLabel = ({ profileBadge }: Props) => {
+  return (
+    <Flex
+      data-cy="profileBadge"
+      sx={{
+        alignItems: 'center',
+        fontSize: 1,
+        color: '#555555',
+        backgroundColor: 'softblue',
+        paddingX: 1,
+        paddingY: 1,
+        borderRadius: 1,
+        gap: 1,
+      }}
+    >
+      <UserBadge badge={profileBadge} />
+      <Text>only news</Text>
+    </Flex>
+  )
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -69,6 +69,7 @@ export { NotificationListSupabase } from './NotificationListSupabase/Notificatio
 export { NotificationsModal } from './NotificationsModal/NotificationsModal'
 export { OsmGeocoding } from './OsmGeocoding/OsmGeocoding'
 export { PinProfile } from './PinProfile/PinProfile'
+export { ProfileBadgeContentLabel } from './ProfileBadgeContentLabel/ProfileBadgeContentLabel'
 export { ProfileLink } from './ProfileLink/ProfileLink'
 export { ProfileTagsList } from './ProfileTagsList/ProfileTagsList'
 export { ResearchEditorOverview } from './ResearchEditorOverview/ResearchEditorOverview'

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -71,6 +71,7 @@ export const fakeNewsSB = (newsOverloads: Partial<News> = {}): News => ({
   body: faker.word.words(50),
   heroImage: null,
   isDraft: false,
+  profileBadge: null,
   ...newsOverloads,
 })
 

--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -142,12 +142,44 @@
 //       cy.visit(`/news/${initialExpectedSlug}`)
 //       cy.contains(updatedTitle)
 
-//       cy.step('All updated fields visible on list')
-//       cy.visit('/news')
-//       cy.contains(updatedSummary)
-//       cy.contains(updatedTitle)
-//       cy.contains(category)
-//     })
+//  cy.step('All updated fields visible on list')
+// cy.visit('/news')
+// cy.contains(updatedSummary)
+// cy.contains(updatedTitle)
+// cy.contains(category)
+
+// cy.step('Can add profile badge')
+// cy.visit(`/news/${updatedExpectedSlug}/edit`)
+// cy.wait(1000)
+// cy.selectTag('PRO', '[data-cy=profileBadge-select]')
+// cy.get('[data-cy=submit]')
+//   .click()
+//   .url()
+//   .should('include', `/news/${updatedExpectedSlug}`)
+// cy.get('[data-cy=profileBadge]').contains('only news')
+
+// cy.step('Not visible to logged out users')
+// cy.wait(1000)
+// cy.logout()
+// cy.reload()
+// cy.url().should(
+//   'include',
+//   `/sign-in?returnUrl=%2Fnews%2F${updatedExpectedSlug}`,
+// )
+
+// cy.step('Not visible on the list view')
+// cy.visit('/news')
+// cy.contains(updatedTitle).should('not.exist')
+
+// cy.step("Logged in user (who is not an admin) can't view item")
+// cy.signUpNewUser()
+// cy.visit(`/news/${updatedExpectedSlug}`)
+// cy.reload()
+// cy.url().should('include', `/news`)
+// cy.url().should('not.include', `updatedExpectedSlug`)
+
+// Should also check that a user with the right badge (and not an admin) can view
+// })
 
 //     it('[By Anonymous]', () => {
 //       cy.step('Ask users to login before creating a news')

--- a/packages/cypress/src/support/commandsUi.ts
+++ b/packages/cypress/src/support/commandsUi.ts
@@ -236,7 +236,7 @@ Cypress.Commands.add('screenClick', () => {
 Cypress.Commands.add(
   'selectTag',
   (tagName: string, selector = '[data-cy=tag-select]') => {
-    cy.log('select tag', tagName)
+    cy.log('Select tag', tagName)
     cy.get(`${selector} input`).click({ force: true })
     cy.get(`${selector} input`).type(tagName, { force: true })
     cy.get(`${selector} .data-cy__menu-list`).contains(tagName).click()

--- a/seed.ts
+++ b/seed.ts
@@ -133,8 +133,20 @@ const seedProfileTypes = (): Partial<profile_typesScalars>[] => [
 ]
 
 const seedBadges = (): Partial<profile_badgesScalars>[] => [
-  { ..._BADGES_BASE, name: 'supporter', display_name: 'Supporter' },
-  { ..._BADGES_BASE, name: 'pro', display_name: 'PRO' },
+  {
+    ..._BADGES_BASE,
+    name: 'supporter',
+    display_name: 'Supporter',
+    image_url:
+      'https://wbskztclbriekwpehznv.supabase.co/storage/v1/object/public/one-army/icons/supporter.svg',
+  },
+  {
+    ..._BADGES_BASE,
+    name: 'pro',
+    display_name: 'PRO',
+    image_url:
+      'https://wbskztclbriekwpehznv.supabase.co/storage/v1/object/public/one-army/icons/pro.svg',
+  },
 ]
 
 /// populates badges: 2/3 of profiles to have: 1 and 2 badges, others remain with no badge

--- a/shared/models/news.ts
+++ b/shared/models/news.ts
@@ -1,5 +1,6 @@
 import { Author } from './author'
 import { Category } from './category'
+import { ProfileBadge } from './profileBadge'
 
 import type { DBAuthor } from './author'
 import type { DBCategory } from './category'
@@ -7,6 +8,7 @@ import type { IConvertedFileMeta } from './common'
 import type { IContentDoc, IDBContentDoc } from './content'
 import type { DBMedia, Image } from './media'
 import type { SelectValue } from './other'
+import type { DBProfileBadge } from './profileBadge'
 import type { Tag } from './tag'
 
 export class DBNews implements IDBContentDoc {
@@ -24,6 +26,7 @@ export class DBNews implements IDBContentDoc {
   readonly title: string
   readonly total_views?: number
   readonly previous_slugs: string[]
+  readonly profile_badge: DBProfileBadge | null
   readonly slug: string
   readonly summary: string | null
   readonly tags: number[]
@@ -34,50 +37,54 @@ export class DBNews implements IDBContentDoc {
 
 export class News implements IContentDoc {
   id: number
-  isDraft: boolean
-  createdAt: Date
-  modifiedAt: Date | null
   author: Author | null
+  body: string
   category: Category | null
   commentCount: number
+  createdAt: Date
   deleted: boolean
-  title: string
+  heroImage: Image | null
+  isDraft: boolean
+  modifiedAt: Date | null
+  profileBadge: ProfileBadge | null
   previousSlugs: string[]
   slug: string
   subscriberCount: number
   summary: string | null
   tags: Tag[]
   tagIds?: number[]
+  title: string
   totalViews: number
   usefulCount: number
-  body: string
-  heroImage: Image | null
 
-  constructor(obj: any) {
-    Object.assign(this, obj)
+  constructor(news: Partial<News>) {
+    Object.assign(this, news)
   }
 
-  static fromDB(obj: DBNews, tags: Tag[], heroImage?: Image | null) {
+  static fromDB(news: DBNews, tags: Tag[], heroImage?: Image | null) {
     return new News({
-      id: obj.id,
-      author: obj.author ? Author.fromDB(obj.author) : null,
-      body: obj.body,
-      category: obj.category ? Category.fromDB(obj.category) : null,
-      commentCount: obj.comment_count || 0,
-      createdAt: new Date(obj.created_at),
-      deleted: obj.deleted || false,
-      isDraft: obj.is_draft || false,
+      id: news.id,
+      author: news.author ? Author.fromDB(news.author) : null,
+      body: news.body,
+      category: news.category ? Category.fromDB(news.category) : null,
+      commentCount: news.comment_count || 0,
+      createdAt: new Date(news.created_at),
+      deleted: news.deleted || false,
+      isDraft: news.is_draft || false,
       heroImage: heroImage || null,
-      modifiedAt: obj.modified_at ? new Date(obj.modified_at) : null,
-      previousSlugs: obj.previous_slugs,
-      slug: obj.slug,
-      subscriberCount: obj.subscriber_count || 0,
-      summary: obj.summary || null,
-      tagIds: obj.tags,
+      modifiedAt: news.modified_at ? new Date(news.modified_at) : null,
+      profileBadge: news.profile_badge
+        ? ProfileBadge.fromDB(news.profile_badge)
+        : null,
+      previousSlugs: news.previous_slugs,
+      slug: news.slug,
+      subscriberCount: news.subscriber_count || 0,
+      summary: news.summary || null,
+      tagIds: news.tags,
       tags,
-      title: obj.title,
-      totalViews: obj.total_views || 0,
-      usefulCount: obj.useful_count || 0,
+      title: news.title,
+      totalViews: news.total_views || 0,
+      usefulCount: news.useful_count || 0,
     })
   }
 }
@@ -88,6 +95,7 @@ export type NewsFormData = {
   existingHeroImage: Image | null
   heroImage: IConvertedFileMeta | null
   isDraft: boolean | null
-  title: string
+  profileBadge: SelectValue | null
   tags?: number[]
+  title: string
 }

--- a/src/pages/News/Content/Common/NewsForm.tsx
+++ b/src/pages/News/Content/Common/NewsForm.tsx
@@ -5,6 +5,7 @@ import { FormWrapper } from 'src/common/Form/FormWrapper'
 import { UnsavedChangesDialog } from 'src/common/Form/UnsavedChangesDialog'
 import { logger } from 'src/logger'
 import { CategoryField } from 'src/pages/common/FormFields/Category.field'
+import { ProfileBadgeField } from 'src/pages/common/FormFields/ProfileBadgeField'
 import { TagsField } from 'src/pages/common/FormFields/Tags.field'
 import { TitleField } from 'src/pages/common/FormFields/Title.field'
 import { errorSet } from 'src/pages/Library/Content/utils/transformLibraryErrors'
@@ -35,6 +36,7 @@ export const NewsForm = (props: IProps) => {
     existingHeroImage: null,
     isDraft: null,
     heroImage: null,
+    profileBadge: null,
     tags: [],
     title: '',
   })
@@ -59,6 +61,13 @@ export const NewsForm = (props: IProps) => {
       existingHeroImage: news.heroImage,
       isDraft: news.isDraft,
       heroImage: null,
+      profileBadge: news.profileBadge
+        ? {
+            value: news.profileBadge.id?.toString(),
+            label: news.profileBadge.displayName,
+          }
+        : null,
+
       tags: news.tagIds,
       title: news.title,
     })
@@ -78,6 +87,7 @@ export const NewsForm = (props: IProps) => {
         heroImage: formValues.heroImage || null,
         isDraft: isDraft,
         existingHeroImage: initialValues.existingHeroImage || null,
+        profileBadge: formValues.profileBadge || null,
         tags: formValues.tags,
         title: formValues.title!,
       })
@@ -183,6 +193,10 @@ export const NewsForm = (props: IProps) => {
             />
             <CategoryField type="news" />
             <TagsField title={LABELS.fields.tags.title} />
+            <ProfileBadgeField
+              placeholder={LABELS.fields.profileBadge.placeholder as string}
+              title={LABELS.fields.profileBadge.title}
+            />
             <NewsBodyField imageUpload={imageUpload} />
           </FormWrapper>
         )

--- a/src/pages/News/NewsListItem.tsx
+++ b/src/pages/News/NewsListItem.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   IconCountWithTooltip,
   InternalLink,
+  ProfileBadgeContentLabel,
   // ModerationStatus,
 } from 'oa-components'
 import { Highlighter } from 'src/common/Highlighter'
@@ -73,6 +74,9 @@ export const NewsListItem = ({ news, query }: IProps) => {
 
             {news.category && (
               <Category category={news.category} sx={{ fontSize: 2 }} />
+            )}
+            {news.profileBadge && (
+              <ProfileBadgeContentLabel profileBadge={news.profileBadge} />
             )}
           </Flex>
 

--- a/src/pages/News/NewsPage.tsx
+++ b/src/pages/News/NewsPage.tsx
@@ -6,6 +6,7 @@ import {
   ContentStatistics,
   DisplayDate,
   DisplayMarkdown,
+  ProfileBadgeContentLabel,
   TagList,
 } from 'oa-components'
 // eslint-disable-next-line import/no-unresolved
@@ -69,6 +70,9 @@ export const NewsPage = observer(({ news }: IProps) => {
         >
           <Flex sx={{ alignItems: 'center', gap: 2 }}>
             {news.category && <Category category={news.category} />}
+            {news.profileBadge && (
+              <ProfileBadgeContentLabel profileBadge={news.profileBadge} />
+            )}
             {news.tags && (
               <TagList
                 data-cy="news-tags"

--- a/src/pages/News/labels.ts
+++ b/src/pages/News/labels.ts
@@ -22,6 +22,10 @@ export const fields: ILabels = {
       'Write and structure the body of your article. Markdown is also supported.',
     title: 'Body',
   },
+  profileBadge: {
+    title: 'Limit to badged users',
+    placeholder: 'Select if this is for profiles with a certain profile badge',
+  },
   summary: {
     title: 'Summary',
     description: 'What will show on the main page',

--- a/src/pages/common/FormFields/ProfileBadgeField.tsx
+++ b/src/pages/common/FormFields/ProfileBadgeField.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { Field } from 'react-final-form'
+import { Select } from 'oa-components'
+import { FieldContainer } from 'src/common/Form/FieldContainer'
+import { ProfileBadgeService } from 'src/services/profileBadgeService'
+
+import { FormFieldWrapper } from './FormFieldWrapper'
+
+import type { SelectValue } from 'oa-shared'
+
+interface IProps {
+  placeholder: string
+  title: string
+}
+
+export const ProfileBadgeField = ({ placeholder, title }: IProps) => {
+  const [profileBadges, setProfileBadges] = useState<SelectValue[]>([])
+  const name = 'profileBadge'
+
+  useEffect(() => {
+    const initCategories = async () => {
+      const badges = await ProfileBadgeService.getProfileBadges()
+      if (!badges) {
+        return
+      }
+
+      const selectBadges = badges.map((badge) => ({
+        value: badge.id.toString(),
+        label: badge.displayName,
+      }))
+      setProfileBadges(selectBadges)
+    }
+
+    initCategories()
+  }, [])
+
+  return (
+    <FormFieldWrapper htmlFor={name} text={title}>
+      <Field
+        name={name}
+        id={name}
+        isEqual={(a, b) => !!a && a?.value === b?.value}
+        render={({ input, ...rest }) => (
+          <FieldContainer data-cy="profileBadge-select">
+            <Select
+              {...rest}
+              variant="form"
+              options={profileBadges || []}
+              value={input.value}
+              onChange={(changedValue) => {
+                input.onChange(changedValue ?? null)
+              }}
+              isClearable={true}
+              placeholder={placeholder}
+            />
+          </FieldContainer>
+        )}
+      />
+    </FormFieldWrapper>
+  )
+}

--- a/src/routes/api.news.$id.ts
+++ b/src/routes/api.news.$id.ts
@@ -23,6 +23,9 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
         ? Number(formData.get('category'))
         : null,
       isDraft: formData.get('is_draft') === 'true',
+      profileBadge: formData.has('profileBadge')
+        ? (formData.get('profileBadge') as string)
+        : null,
       tags: formData.has('tags')
         ? formData.getAll('tags').map((x) => Number(x))
         : null,
@@ -79,6 +82,7 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
         modified_at: new Date(),
         slug: data.slug,
         previous_slugs: previousSlugs,
+        profile_badge: data.profileBadge,
         summary: getSummaryFromMarkdown(data.body),
         tags: data.tags,
         title: data.title,

--- a/src/routes/api.profile-badges.ts
+++ b/src/routes/api.profile-badges.ts
@@ -1,0 +1,36 @@
+import Keyv from 'keyv'
+import { ProfileBadge } from 'oa-shared'
+import { isProductionEnvironment } from 'src/config/config'
+import { createSupabaseServerClient } from 'src/repository/supabase.server'
+
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import type { DBProfileBadge } from 'oa-shared'
+
+const cache = new Keyv<ProfileBadge[]>({ ttl: 3600000 }) // ttl: 60 minutes
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client, headers } = createSupabaseServerClient(request)
+
+  const cachedProfileBadges = await cache.get('profileBadges')
+
+  if (
+    cachedProfileBadges &&
+    Array.isArray(cachedProfileBadges) &&
+    cachedProfileBadges.length &&
+    isProductionEnvironment()
+  ) {
+    return Response.json(cachedProfileBadges, { headers, status: 200 })
+  }
+
+  const { data } = await client.from('profile_badges').select('*')
+
+  const profileBadges = data?.map((badge) =>
+    ProfileBadge.fromDB(badge as DBProfileBadge),
+  )
+
+  if (profileBadges && profileBadges.length > 0) {
+    cache.set('profileBadges', data, 3600000)
+  }
+
+  return Response.json(profileBadges, { headers, status: 200 })
+}

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -3,7 +3,7 @@ import { News } from 'oa-shared'
 import type { DBNews, NewsFormData } from 'oa-shared'
 
 const upsert = async (id: number | null, form: NewsFormData) => {
-  const { category, tags, title } = form
+  const { category, profileBadge, tags, title } = form
   const body = new FormData()
   body.append('title', title)
   body.append('body', form.body)
@@ -13,6 +13,10 @@ const upsert = async (id: number | null, form: NewsFormData) => {
     for (const tag of tags) {
       body.append('tags', tag.toString())
     }
+  }
+
+  if (profileBadge) {
+    body.append('profileBadge', profileBadge.value.toString())
   }
 
   if (category) {

--- a/src/services/profileBadgeService.ts
+++ b/src/services/profileBadgeService.ts
@@ -1,0 +1,17 @@
+import { logger } from 'src/logger'
+
+import type { ProfileBadge } from 'oa-shared'
+
+const getProfileBadges = async () => {
+  try {
+    const response = await fetch(`/api/profile-badges`)
+    return (await response.json()) as ProfileBadge[]
+  } catch (error) {
+    logger.error('Failed to fetch profile badges', { error })
+    return []
+  }
+}
+
+export const ProfileBadgeService = {
+  getProfileBadges,
+}

--- a/src/services/profileService.server.ts
+++ b/src/services/profileService.server.ts
@@ -19,6 +19,15 @@ export class ProfileServiceServer {
       .from('profiles')
       .select(
         `*,
+        badges:profile_badges_relations(
+          profile_badges(
+            id,
+            name,
+            display_name,
+            image_url,
+            action_url
+          )
+        ),
         type:profile_types(
           id,
           name,

--- a/src/test/factories/News.ts
+++ b/src/test/factories/News.ts
@@ -64,5 +64,6 @@ export const FactoryNewsItem = (newsOverloads: Partial<News> = {}): News => ({
   commentCount: faker.number.int(),
   totalViews: faker.number.int(),
   usefulCount: faker.number.int(),
+  profileBadge: null,
   ...newsOverloads,
 })

--- a/supabase/migrations/20250819103736_add_badge_id_to_news.sql
+++ b/supabase/migrations/20250819103736_add_badge_id_to_news.sql
@@ -1,0 +1,6 @@
+alter table "public"."news" add column "profile_badge" bigint;
+
+alter table "public"."news" add constraint "news_profile_badge_fkey" FOREIGN KEY (profile_badge) REFERENCES profile_badges(id) ON DELETE SET NULL not valid;
+
+alter table "public"."news" validate constraint "news_profile_badge_fkey";
+


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [x] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)


## What is the new behavior?

Add the option on news for the content creator to limit view access of a news article to logged in users (profiles) which have the defined profile badge.

<img width="659" height="221" alt="Screenshot 2025-08-19 at 11 39 48" src="https://github.com/user-attachments/assets/98fa664a-247d-4012-987e-0883f35e68f8" />
<img width="806" height="206" alt="Screenshot 2025-08-19 at 11 41 05" src="https://github.com/user-attachments/assets/d617ac42-8808-4c43-b435-b280286a94ff" />

If news has a badge, it is also displayed to the corresponding users (and admins) in the list view. 
<img width="759" height="737" alt="Screenshot 2025-08-22 at 12 13 30" src="https://github.com/user-attachments/assets/ee445e1a-bd32-47e9-8d54-064a689947f7" />


## Does this PR introduce a DB Schema Change or Migration?

- [x] Yes
- [ ] No
