### PR TITLE
fix: questions page: prevent input from resetting when typing

### DIFF
--- a/src/pages/Library/Content/List/LibraryListHeader.tsx
+++ b/src/pages/Library/Content/List/LibraryListHeader.tsx
@@ -31,21 +31,15 @@ interface IProps {
 export const LibraryListHeader = (props: IProps) => {
   const { draftCount, handleShowDrafts, showDrafts } = props
   const [categories, setCategories] = useState<Category[]>([])
-  const [searchString, setSearchString] = useState<string>('')
-
   const [searchParams, setSearchParams] = useSearchParams()
+  const q = searchParams.get(LibrarySearchParams.q)
+  const [searchString, setSearchString] = useState<string>(q ?? '')
+
   const categoryParam = Number(searchParams.get(LibrarySearchParams.category))
   const category = categories?.find((x) => x.id === categoryParam) ?? null
-  const q = searchParams.get(LibrarySearchParams.q)
   const sort = searchParams.get(LibrarySearchParams.sort) as LibrarySortOption
 
   const headingTitle = import.meta.env.VITE_HOWTOS_HEADING
-
-  useEffect(() => {
-    if (q && q.length > 0) {
-      setSearchString(q)
-    }
-  }, [q])
 
   useEffect(() => {
     const initCategories = async () => {

--- a/src/pages/Question/QuestionListHeader.tsx
+++ b/src/pages/Question/QuestionListHeader.tsx
@@ -32,13 +32,13 @@ export const QuestionListHeader = (props: IProps) => {
   const { draftCount, handleShowDrafts, showDrafts } = props
 
   const [categories, setCategories] = useState<Category[]>([])
-  const [searchString, setSearchString] = useState<string>('')
-
   const [searchParams, setSearchParams] = useSearchParams()
+  const q = searchParams.get(QuestionSearchParams.q)
+  const [searchString, setSearchString] = useState<string>(() => q ?? '')
+
   const categoryParam = searchParams.get(QuestionSearchParams.category)
   const category =
     (categoryParam && categories?.find((x) => x.id === +categoryParam)) ?? null
-  const q = searchParams.get(QuestionSearchParams.q)
   const sort = searchParams.get(QuestionSearchParams.sort) as QuestionSortOption
 
   useEffect(() => {
@@ -50,10 +50,6 @@ export const QuestionListHeader = (props: IProps) => {
 
     initCategories()
   }, [])
-
-  useEffect(() => {
-    setSearchString(q || '')
-  }, [q])
 
   const updateFilter = useCallback(
     (key: QuestionSearchParams, value: string) => {


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?
When typing into the search box, if you type again after the initial fetch, it would overwrite your new search with the previous values. I was able to replicate by throttling the network dev tools.

## What is the new behavior?
Now it will keep the new type input and re-fetch as needed.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4387 
