### PR TITLE
feat: show number of comments remaining

### DIFF
--- a/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
@@ -34,10 +34,12 @@ export const CommentSectionSupabase = (props: IProps) => {
   const newComments = useMemo(() => {
     return comments.filter((x) => newCommentIds.includes(x.id))
   }, [comments, newCommentIds])
-  const displayShowMore = useMemo(
-    () => comments.length - newCommentIds.length > commentLimit,
-    [comments, commentLimit, newCommentIds],
-  )
+
+  const remainingCommentsCount = useMemo(() => {
+    const nonNewCount = comments.length - newCommentIds.length
+    const shown = Math.min(commentLimit, nonNewCount)
+    return Math.max(0, nonNewCount - shown)
+  }, [comments, newCommentIds, commentLimit])
 
   useEffect(() => {
     const fetchComments = async () => {
@@ -266,7 +268,7 @@ export const CommentSectionSupabase = (props: IProps) => {
           </Box>
         ))}
 
-        {displayShowMore && (
+        {remainingCommentsCount > 0 && (
           <Flex>
             <Button
               type="button"
@@ -275,7 +277,7 @@ export const CommentSectionSupabase = (props: IProps) => {
               data-cy="show-more-comments"
               onClick={() => setCommentLimit((prev) => prev + commentPageSize)}
             >
-              show more comments
+              {`show ${remainingCommentsCount} more comment${remainingCommentsCount === 1 ? '' : 's'}`}
             </Button>
           </Flex>
         )}


### PR DESCRIPTION
## PR Checklist

- [x] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)
I don't see any existing unit tests for the comment component.

## PR Type

What kind of change does this PR introduce?

- [x] Feature (adds functionality)

## What is the current behavior?
Currently shows "Show more comments"

## What is the new behavior?
"Show # more comments" or "Show 1 more comment" if just 1 left.

<img width="241" height="62" alt="comments" src="https://github.com/user-attachments/assets/eeb058cd-db6f-4295-82b2-00f634fae365" />

<img width="224" height="54" alt="comment" src="https://github.com/user-attachments/assets/97982b82-69de-4213-82e2-9f2ab69bbc20" />

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4247 

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
