### PR TITLE
ci: add automatic retry to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ jobs:
 workflows:
   version: 2
   main_workflow:
+    max_auto_reruns: 2
     # by default jobs will run concurrently, so specify requires if want to run sequentially
     jobs:
       - lint:


### PR DESCRIPTION
This should reduce the number of times that we need to manually re-run a workflow due to flaky tests. Also a way to burn more circle ci cycles (the billing unit), so also worth keeping an eye on and not rely on this too much.