### PR TITLE
feat: show errors when edit comment issue

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -21,7 +21,7 @@ export const Banner = (props: IProps) => {
       onClick={onClick}
       variant={variant || 'failure'}
       sx={{
-        borderRadius: 0,
+        borderRadius: 2,
         alignItems: 'center',
         flex: '1',
         justifyContent: 'center',

--- a/packages/components/src/EditComment/EditComment.stories.tsx
+++ b/packages/components/src/EditComment/EditComment.stories.tsx
@@ -11,8 +11,9 @@ export const Default: StoryFn<typeof EditComment> = () => (
   <EditComment
     isReply={false}
     comment="A short comment"
+    setShowEditModal={() => null}
     handleCancel={() => null}
-    handleSubmit={() => null}
+    handleSubmit={() => Promise.resolve(new Response(''))}
   />
 )
 
@@ -20,7 +21,8 @@ export const EditReply: StoryFn<typeof EditComment> = () => (
   <EditComment
     isReply={true}
     comment="A short comment here..."
+    setShowEditModal={() => null}
     handleCancel={() => null}
-    handleSubmit={() => null}
+    handleSubmit={() => Promise.resolve(new Response(''))}
   />
 )

--- a/packages/components/src/EditComment/EditComment.test.tsx
+++ b/packages/components/src/EditComment/EditComment.test.tsx
@@ -8,7 +8,7 @@ import { EditComment, type IProps } from './EditComment'
 import { Default, EditReply } from './EditComment.stories'
 
 describe('EditComment', () => {
-  const mockOnSubmit = vi.fn()
+  const mockOnSubmit = vi.fn().mockImplementation(() => new Response())
   const mockOnCancel = vi.fn()
 
   it('showed correct title when a comment', () => {
@@ -17,17 +17,20 @@ describe('EditComment', () => {
     expect(getByText('Edit Comment')).toBeInTheDocument()
     expect(() => getByText('Edit Reply')).toThrow()
   })
+
   it('showed correct title when a reply', () => {
     const { getByText } = render(<EditReply {...(EditReply.args as IProps)} />)
 
     expect(getByText('Edit Reply')).toBeInTheDocument()
     expect(() => getByText('Edit Comment')).toThrow()
   })
+
   it('enables save button when comment is not empty', () => {
     const screen = render(
       <EditComment
         isReply={false}
         comment="Test comment"
+        setShowEditModal={() => null}
         handleCancel={mockOnCancel}
         handleSubmit={mockOnSubmit}
       />,
@@ -40,6 +43,7 @@ describe('EditComment', () => {
       <EditComment
         isReply={false}
         comment="Test comment"
+        setShowEditModal={() => null}
         handleCancel={mockOnCancel}
         handleSubmit={mockOnSubmit}
       />,
@@ -48,22 +52,26 @@ describe('EditComment', () => {
     fireEvent.click(button)
     expect(mockOnSubmit).toHaveBeenCalledWith('Test comment')
   })
+
   it('disables save button when comment is empty', () => {
     const screen = render(
       <EditComment
         isReply={false}
         comment=""
+        setShowEditModal={() => null}
         handleCancel={mockOnCancel}
         handleSubmit={mockOnSubmit}
       />,
     )
     expect(screen.getByTestId('edit-comment-submit')).toBeDisabled()
   })
+
   it('should dispaly error message when the comment is empty', () => {
     const screen = render(
       <EditComment
         isReply={false}
         comment=""
+        setShowEditModal={() => null}
         handleCancel={mockOnCancel}
         handleSubmit={mockOnSubmit}
       />,

--- a/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentItemSupabase.tsx
@@ -19,10 +19,10 @@ import type { Comment, DiscussionContentTypes } from 'oa-shared'
 
 export interface ICommentItemProps {
   comment: Comment
-  onEdit: (id: number, comment: string) => void
+  onEdit: (id: number, comment: string) => Promise<Response>
   onDelete: (id: number) => void
   onReply: (reply: string) => void
-  onEditReply: (id: number, reply: string) => void
+  onEditReply: (id: number, reply: string) => Promise<Response>
   onDeleteReply: (id: number) => void
   sourceType: DiscussionContentTypes
 }
@@ -122,9 +122,9 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
                 <CommentReply
                   key={x.id}
                   comment={x}
-                  onEdit={(id: number, comment: string) =>
-                    onEditReply(id, comment)
-                  }
+                  onEdit={async (id: number, comment: string) => {
+                    return await onEditReply(id, comment)
+                  }}
                   onDelete={(id: number) => onDeleteReply(id)}
                 />
               ))}
@@ -148,9 +148,9 @@ export const CommentItemSupabase = observer((props: ICommentItemProps) => {
         <EditComment
           comment={comment.comment}
           handleSubmit={async (commentText) => {
-            onEdit(comment.id, commentText)
-            setShowEditModal(false)
+            return await onEdit(comment.id, commentText)
           }}
+          setShowEditModal={setShowEditModal}
           handleCancel={() => setShowEditModal(false)}
           isReply={false}
         />

--- a/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
@@ -17,7 +17,7 @@ const DELETED_COMMENT = 'The original comment got deleted'
 
 export interface ICommentItemProps {
   comment: Reply
-  onEdit: (id: number, comment: string) => void
+  onEdit: (id: number, comment: string) => Promise<Response>
   onDelete: (id: number) => void
 }
 
@@ -88,9 +88,9 @@ export const CommentReply = observer(
             <EditComment
               comment={comment.comment}
               handleSubmit={async (commentText) => {
-                onEdit(comment.id, commentText)
-                setShowEditModal(false)
+                return await onEdit(comment.id, commentText)
               }}
+              setShowEditModal={setShowEditModal}
               handleCancel={() => setShowEditModal(false)}
               isReply={true}
             />

--- a/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentSectionSupabase.tsx
@@ -22,9 +22,10 @@ const commentPageSize = 10
 
 export const CommentSectionSupabase = (props: IProps) => {
   const { authors, setSubscribersCount, sourceId, sourceType } = props
+
   const [comments, setComments] = useState<Comment[]>([])
-  const [newCommentIds, setNewCommentIds] = useState<number[]>([])
   const [commentLimit, setCommentLimit] = useState<number>(commentPageSize)
+  const [newCommentIds, setNewCommentIds] = useState<number[]>([])
 
   const displayedComments = useMemo(() => {
     return comments
@@ -100,11 +101,11 @@ export const CommentSectionSupabase = (props: IProps) => {
 
         setComments((comments) => [...comments, newComment])
         setNewCommentIds([...newCommentIds, newComment.id])
-      } else {
-        // show error
       }
+      return result
     } catch (err) {
       console.error(err)
+      return err
     }
   }
 
@@ -123,11 +124,11 @@ export const CommentSectionSupabase = (props: IProps) => {
             return x
           }),
         )
-      } else {
-        // TODO: show error
       }
+      return result
     } catch (err) {
       console.error(err)
+      return err
     }
   }
 
@@ -144,9 +145,8 @@ export const CommentSectionSupabase = (props: IProps) => {
             return x
           }),
         )
-      } else {
-        // show error
       }
+      return result
     } catch (err) {
       console.error(err)
     }
@@ -172,9 +172,8 @@ export const CommentSectionSupabase = (props: IProps) => {
             return comment
           }),
         )
-      } else {
-        // show error
       }
+      return result
     } catch (err) {
       console.error(err)
     }
@@ -200,11 +199,11 @@ export const CommentSectionSupabase = (props: IProps) => {
             return comment
           }),
         )
-      } else {
-        // show error
       }
+      return result
     } catch (err) {
       console.error(err)
+      return err
     }
   }
 
@@ -226,11 +225,11 @@ export const CommentSectionSupabase = (props: IProps) => {
             return comment
           }),
         )
-      } else {
-        // show error
       }
+      return result
     } catch (err) {
       console.error(err)
+      return err
     }
   }
 


### PR DESCRIPTION
Currently the research discussion tests are the mostly likely to fail and have been blocking a release all day. To understand why I've added the display of comment errors which should help visibility.