### PR TITLE
fix: rename Comments label to Most Comments

### DIFF
--- a/src/pages/Question/QuestionSortOptions.ts
+++ b/src/pages/Question/QuestionSortOptions.ts
@@ -8,7 +8,7 @@ export type QuestionSortOption =
 const BaseOptions = new Map<QuestionSortOption, string>()
 BaseOptions.set('Newest', 'Newest')
 // BaseOptions.set('LatestComments', 'Latest Comments')
-BaseOptions.set('Comments', 'Comments')
+BaseOptions.set('Comments', 'Most Comments')
 BaseOptions.set('LeastComments', 'Least Comments')
 
 const QueryParamOptions = new Map<QuestionSortOption, string>(BaseOptions)


### PR DESCRIPTION
## PR Checklist

- [ ] - Commit [messages are descriptive](https://github.com/ONEARMY/community-platform/blob/master/CONTRIBUTING.md#--commit-style-guide), it will be used in our [Release Notes](https://github.com/ONEARMY/community-platform/releases/)
- [ ] - Unit and e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ✅] Bugfix (fixes an issue)
- [ ] Feature (adds functionality)
- [ ] Code style update
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?

_Describe the new behaviour_
_If useful, provide screenshot or capture to highlight main changes_

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [ ✅] No

## Git Issues

Closes #4425

NOTE : I only updated the UI by changing BaseOptions.set('Comments', 'Most Comments'). Updating the URL would require database and schema changes, which I’m not handling. if you want to also make changes in URL part then Please remove me from issue #4425 since I won’t be working on the URL changes.

## What happens next?

Thanks for the contribution! We try to make sure all PRs are reviewed ahead of our monthly maintainers call (first Monday of the month)

If the PR is working as intended it'll be merged and included in the next platform release, if not changes will be requested and re-reviewed once updated.

If you need more immediate feedback you can try reaching out on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
