### PR TITLE
fix: markdown rendering on older browsers

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,6 +48,7 @@
     "react-router-dom": "^6.26.0",
     "react-select": "^5.8.1",
     "react-tooltip": "^5.28.0",
+    "rehype-raw": "^7.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-youtube": "^1.3.2",

--- a/packages/components/src/DisplayMarkdown/DisplayMarkdown.tsx
+++ b/packages/components/src/DisplayMarkdown/DisplayMarkdown.tsx
@@ -1,4 +1,5 @@
 import Markdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
 import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 import remarkYoutube from 'remark-youtube'
@@ -31,6 +32,7 @@ export const DisplayMarkdown = ({ body }: IProps) => {
           remarkGfm,
           [remarkYoutube, { width: 760, height: 420 }],
         ]}
+        rehypePlugins={[rehypeRaw]}
         skipHtml={true}
       >
         {body}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21476,6 +21476,7 @@ __metadata:
     react-router-dom: "npm:^6.26.0"
     react-select: "npm:^5.8.1"
     react-tooltip: "npm:^5.28.0"
+    rehype-raw: "npm:^7.0.0"
     remark-breaks: "npm:^4.0.0"
     remark-gfm: "npm:^4.0.1"
     remark-youtube: "npm:^1.3.2"


### PR DESCRIPTION
We're having issues with older browsers (specifically Safari) rendering the pages that call the markdown display packages we're using.

This is draft PR branch for me to investigate.