### PR TITLE
fix: no notifications displaying when one errors

### DIFF
--- a/src/routes/api.notifications.ts
+++ b/src/routes/api.notifications.ts
@@ -10,11 +10,15 @@ const transformNotificationList = async (
   dbNotifications: DBNotification[],
   client: SupabaseClient,
 ) => {
-  return Promise.all(
+  return Promise.allSettled(
     dbNotifications.map((dbNotification) =>
       transformNotification(dbNotification, client),
     ),
-  )
+  ).then((results) => {
+    return results
+      .filter((result) => result.status === 'fulfilled')
+      .map((result) => result.value)
+  })
 }
 
 export const transformNotification = async (
@@ -39,6 +43,8 @@ export const transformNotification = async (
 
     if (content.data) {
       notification.content = content.data
+    } else {
+      throw Error('Comment not found, probably deleted')
     }
 
     const sourceContentType = resolveType(notification.sourceContentType)


### PR DESCRIPTION
For some users, their notifications haven't been displaying. This is because if ANY notification errors for some reason, none of them are displayed. This is probably when a comment has been deleted and thus the information about that comment can't be retreived. 
