### PR TITLE
feat: update styling of contributions on profile

### DIFF
--- a/src/pages/User/content/UserCreatedDocuments.tsx
+++ b/src/pages/User/content/UserCreatedDocuments.tsx
@@ -1,20 +1,21 @@
-import { Flex, Heading } from 'theme-ui';
+import { Flex, Grid, Heading } from 'theme-ui';
 
 import UserCreatedDocumentsItem from './UserCreatedDocumentsItem';
 
 import type { UserCreatedDocs } from 'oa-shared';
 
 interface IProps {
+  columns: number;
   docs: UserCreatedDocs;
 }
 
-const UserCreatedDocuments = ({ docs }: IProps) => {
+const UserCreatedDocuments = ({ columns, docs }: IProps) => {
   return (
     <>
       {(docs.projects.length > 0 || docs.research.length > 0 || docs.questions.length > 0) && (
-        <Flex sx={{ justifyContent: 'space-between', gap: 4 }}>
+        <Grid columns={[1, 1, columns]} gap={5}>
           {docs?.projects.length > 0 && (
-            <Flex sx={{ flexDirection: 'column', flexBasis: '50%', mt: 2, mb: 6 }}>
+            <Flex sx={{ flexDirection: 'column', gap: 2 }}>
               <Heading data-cy="library-contributions" as="h3" variant="small">
                 Library
               </Heading>
@@ -27,7 +28,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
                       id: item.id!,
                       slug: item.slug!,
                       title: item.title!,
-                      usefulVotes: item.usefulCount || 0,
+                      usefulCount: item.usefulCount || 0,
                     }}
                   />
                 );
@@ -35,11 +36,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
             </Flex>
           )}
           {docs?.research.length > 0 && (
-            <Flex
-              data-testid="research-contributions"
-              my={2}
-              sx={{ flexDirection: 'column', flexBasis: '50%' }}
-            >
+            <Flex data-testid="research-contributions" sx={{ flexDirection: 'column', gap: 2 }}>
               <Heading as="h3" variant="small">
                 Research
               </Heading>
@@ -52,7 +49,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
                       id: item.id!,
                       slug: item.slug!,
                       title: item.title!,
-                      usefulVotes: item.usefulCount!,
+                      usefulCount: item.usefulCount || 0,
                     }}
                   />
                 );
@@ -60,10 +57,7 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
             </Flex>
           )}
           {docs?.questions.length > 0 && (
-            <Flex
-              data-testid="question-contributions"
-              sx={{ flexDirection: 'column', flexBasis: '50%' }}
-            >
+            <Flex data-testid="question-contributions" sx={{ flexDirection: 'column', gap: 2 }}>
               <Heading as="h3" variant="small">
                 Questions
               </Heading>
@@ -76,14 +70,14 @@ const UserCreatedDocuments = ({ docs }: IProps) => {
                       id: item.id!,
                       slug: item.slug!,
                       title: item.title!,
-                      usefulVotes: item.usefulCount!,
+                      usefulCount: item.usefulCount || 0,
                     }}
                   />
                 );
               })}
             </Flex>
           )}
-        </Flex>
+        </Grid>
       )}
     </>
   );

--- a/src/pages/User/content/UserCreatedDocumentsItem.tsx
+++ b/src/pages/User/content/UserCreatedDocumentsItem.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
-import { Icon } from 'oa-components';
-import { Flex, Heading, Text } from 'theme-ui';
+import { IconCountWithTooltip } from 'oa-components';
+import { Flex, Text } from 'theme-ui';
 
 interface IProps {
   type: 'library' | 'research' | 'questions';
@@ -8,21 +8,20 @@ interface IProps {
     id: string | number;
     title: string;
     slug: string;
-    usefulVotes: number;
+    usefulCount: number;
   };
 }
 
 const UserDocumentItem = ({ type, item }: IProps) => {
-  const { id, title, slug, usefulVotes } = item;
+  const { id, title, slug, usefulCount } = item;
   const url = `/${type}/${encodeURIComponent(slug)}?utm_source=user-profile`;
 
   return (
     <Flex
-      mb={1}
       sx={{
-        width: '100%',
-        position: 'relative',
-        borderBottom: '1px solid #c7c7c7',
+        background: 'white',
+        borderRadius: 2,
+        padding: 3,
       }}
     >
       <Link
@@ -33,45 +32,38 @@ const UserDocumentItem = ({ type, item }: IProps) => {
         data-cy={`${item.slug}-link`}
       >
         <Flex
-          pb={1}
-          pt={1}
           sx={{
             flexDirection: 'row',
             justifyItems: 'center',
             justifyContent: 'space-between',
+            gap: 3,
           }}
         >
-          <Heading
+          <Text
             as="p"
-            color={'black'}
+            color="black"
             sx={{
-              fontSize: ['12px', '12px', '16px'],
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
             }}
           >
             {title}
-          </Heading>
+          </Text>
           <Flex
             sx={{
               alignItems: 'center',
               justifyContent: 'flex-end',
             }}
           >
-            {
-              <Text
-                color="black"
-                ml={3}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  fontSize: ['12px', '12px', '14px'],
-                  minWidth: '40px',
-                  justifyContent: 'flex-end',
-                }}
-              >
-                {usefulVotes}
-                <Icon glyph="star-active" ml={1} />
-              </Text>
-            }
+            <Flex
+              sx={{
+                flex: 1,
+                justifyContent: 'flex-end',
+              }}
+            >
+              <IconCountWithTooltip count={usefulCount} icon="star-active" text="Useful count" />
+            </Flex>
           </Flex>
         </Flex>
       </Link>

--- a/src/pages/User/content/UserProfile.tsx
+++ b/src/pages/User/content/UserProfile.tsx
@@ -108,7 +108,7 @@ export const UserProfile = ({ docs, isViewingOwnProfile, user }: IProps) => {
               </TabPanel>
               {hasContributed && (
                 <TabPanel value="contributions">
-                  <UserCreatedDocuments docs={docs} />
+                  <UserCreatedDocuments columns={isMember ? 1 : 2} docs={docs} />
                 </TabPanel>
               )}
               {hasImpacted && isPreciousPlastic() && (


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other:

## What is the new behavior?

The start of #4440. Basic styling updates while tech support and design questions are pending.

Before:
<img width="955" height="718" alt="Screenshot 2026-01-10 at 10 55 53" src="https://github.com/user-attachments/assets/68d473fb-31b5-4113-bc0c-a37c4a327eb0" />

After:
<img width="1165" height="788" alt="Screenshot 2026-01-10 at 12 50 51" src="https://github.com/user-attachments/assets/2b443695-a563-4d9d-9a3b-d81be828425d" />
<img width="1165" height="788" alt="Screenshot 2026-01-10 at 12 51 19" src="https://github.com/user-attachments/assets/0b97ea23-236c-42cb-8993-5ccec8ee93e4" />


## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No