### PR TITLE
fix: strip all markdown tokens for news description

### DIFF
--- a/src/utils/getSummaryFromMarkdown.ts
+++ b/src/utils/getSummaryFromMarkdown.ts
@@ -17,5 +17,14 @@ export const getSummaryFromMarkdown = (text: string) => {
     .slice(0, 3)
     .map((token) => token['text'] && token['text'].trim());
 
-  return flattenedLines.join(' ');
+  return flattenedLines
+    .join(' ')
+    .replaceAll('*', '')
+    .replaceAll('_', '')
+    .replaceAll('~~', '')
+    .replaceAll('`', '')
+    .replaceAll('<u>', '')
+    .replaceAll('</u>', '')
+    .replaceAll('<code>', '')
+    .replaceAll('</code>', '');
 };


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the new behavior?

Better markdown cleanup for the news description.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No

## Git Issues

Closes #4570
