### PR TITLE
fix: academy navigation now avoids a fullpage refresh

### DIFF
--- a/src/pages/Academy/Academy.tsx
+++ b/src/pages/Academy/Academy.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import ExternalEmbed from 'src/pages/Academy/ExternalEmbed/ExternalEmbed';
 
@@ -11,14 +11,23 @@ export const getFrameSrc = (base: string, path: string): string =>
 const Academy = () => {
   const location = useLocation();
 
-  return (
-    <ExternalEmbed
-      src={getFrameSrc(
-        import.meta.env.VITE_ACADEMY_RESOURCE || process.env.VITE_ACADEMY_RESOURCE || '',
-        location.pathname,
-      )}
-    />
+  const [initial, setInitial] = useState<string>(
+    import.meta.env.VITE_ACADEMY_RESOURCE || process.env.VITE_ACADEMY_RESOURCE || '',
   );
+
+  useEffect(() => {
+    // set initial only once
+    const newInitial = getFrameSrc(
+      import.meta.env.VITE_ACADEMY_RESOURCE || process.env.VITE_ACADEMY_RESOURCE || '',
+      location.pathname,
+    );
+
+    if (newInitial !== initial) {
+      setInitial(newInitial);
+    }
+  }, []);
+
+  return <ExternalEmbed src={initial} />;
 };
 
 export default Academy;

--- a/src/pages/Academy/ExternalEmbed/ExternalEmbed.tsx
+++ b/src/pages/Academy/ExternalEmbed/ExternalEmbed.tsx
@@ -17,7 +17,7 @@ interface IProps {
 const ExternalEmbed = ({ src }: IProps) => {
   const navigate = useNavigate();
   const url = new URL(src);
-  const targetOrigin = url.protocol + '//' + url.hostname;
+  const targetOrigin = url.protocol + '//' + url.hostname + (url.port ? ':' + url.port : '');
 
   useEffect(() => {
     // TODO - possible compatibility fallback for addEventListener (IE8)
@@ -47,7 +47,7 @@ const ExternalEmbed = ({ src }: IProps) => {
         if (!newPathName.startsWith(`/academy`)) {
           newPathName = `/academy${newPathName}`;
         }
-        navigate(newPathName);
+        navigate(newPathName, { viewTransition: true });
       }
       // communicate a href link clicks, open link in new tab
       if (e.data && e.data.linkClick) {


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## What is the new behavior?

Improvement to the academy navigation. Before it was flashing the page on every navigation.
With this solution, the iframe url isn't updated anymore so the page doesn't refresh.
The browser url still updates and goes to the correct page upon refresh.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No
