### PR TITLE
fix: do not show '0 items' while list is still loading

### DIFF
--- a/src/pages/Library/Content/List/LibraryList.tsx
+++ b/src/pages/Library/Content/List/LibraryList.tsx
@@ -14,9 +14,9 @@ import { ProjectCard } from './ProjectCard';
 const siteName = import.meta.env.VITE_SITE_NAME;
 
 export const LibraryList = () => {
-  const [isFetching, setIsFetching] = useState<boolean>(true);
+  const [isFetching, setIsFetching] = useState(true);
   const [projects, setProjects] = useState<Project[]>([]);
-  const [total, setTotal] = useState<number>(0);
+  const [total, setTotal] = useState(0);
   const { draftCount, isFetchingDrafts, drafts, showDrafts, handleShowDrafts } = useDrafts<Project>(
     {
       getDraftCount: libraryService.getDraftCount,
@@ -75,8 +75,8 @@ export const LibraryList = () => {
   return (
     <Flex sx={{ flexDirection: 'column', gap: [2, 3] }}>
       <LibraryListHeader
-        itemCount={total}
-        draftCount={draftCount}
+        itemCount={isFetching ? undefined : total}
+        draftCount={isFetchingDrafts ? undefined : draftCount}
         handleShowDrafts={handleShowDrafts}
         showDrafts={showDrafts}
       />

--- a/src/pages/Library/Content/List/LibraryListHeader.tsx
+++ b/src/pages/Library/Content/List/LibraryListHeader.tsx
@@ -16,7 +16,7 @@ import { LibrarySortOptions } from './LibrarySortOptions';
 
 interface IProps {
   itemCount?: number;
-  draftCount: number;
+  draftCount?: number;
   handleShowDrafts: () => void;
   showDrafts: boolean;
 }
@@ -164,7 +164,7 @@ export const LibraryListHeader = (props: IProps) => {
 
   return (
     <ListHeader
-      itemCount={showDrafts ? draftCount : itemCount || 0}
+      itemCount={showDrafts ? draftCount : itemCount}
       actionComponents={actionComponents}
       showDrafts={showDrafts}
       headingTitle={headingTitle}

--- a/src/pages/Question/QuestionListHeader.tsx
+++ b/src/pages/Question/QuestionListHeader.tsx
@@ -16,7 +16,7 @@ import { QuestionSearchParams } from './question.service';
 
 interface IProps {
   itemCount?: number;
-  draftCount: number;
+  draftCount?: number;
   handleShowDrafts: () => void;
   showDrafts: boolean;
 }
@@ -169,7 +169,7 @@ export const QuestionListHeader = (props: IProps) => {
 
   return (
     <ListHeader
-      itemCount={showDrafts ? draftCount : itemCount || 0}
+      itemCount={showDrafts ? draftCount : itemCount}
       actionComponents={actionComponents}
       showDrafts={false}
       headingTitle={headings.list}

--- a/src/pages/Question/QuestionListing.tsx
+++ b/src/pages/Question/QuestionListing.tsx
@@ -74,8 +74,8 @@ export const QuestionListing = () => {
   return (
     <Flex sx={{ flexDirection: 'column', gap: [2, 3] }}>
       <QuestionListHeader
-        itemCount={total}
-        draftCount={draftCount}
+        itemCount={isFetching ? undefined: total}
+        draftCount={isFetchingDrafts ? undefined : draftCount}
         handleShowDrafts={handleShowDrafts}
         showDrafts={showDrafts}
       />

--- a/src/pages/Research/Content/ResearchList.tsx
+++ b/src/pages/Research/Content/ResearchList.tsx
@@ -13,14 +13,14 @@ import ResearchListItem from './ResearchListItem';
 import { ResearchSearchParams } from './ResearchSearchParams';
 
 const ResearchList = () => {
-  const [isFetching, setIsFetching] = useState<boolean>(true);
+  const [isFetching, setIsFetching] = useState(true);
   const [researchItems, setResearchItems] = useState<ResearchItem[]>([]);
   const { draftCount, isFetchingDrafts, drafts, showDrafts, handleShowDrafts } =
     useDrafts<ResearchItem>({
       getDraftCount: researchService.getDraftCount,
       getDrafts: researchService.getDrafts,
     });
-  const [total, setTotal] = useState<number>(0);
+  const [total, setTotal] = useState(0);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const q = searchParams.get(ResearchSearchParams.q) || '';
@@ -79,8 +79,8 @@ const ResearchList = () => {
   return (
     <Flex sx={{ flexDirection: 'column', gap: [2, 3] }}>
       <ResearchFilterHeader
-        itemCount={total}
-        draftCount={draftCount}
+        itemCount={isFetching ? undefined : total}
+        draftCount={isFetchingDrafts ? undefined : draftCount}
         handleShowDrafts={handleShowDrafts}
         showDrafts={showDrafts}
       />

--- a/src/pages/Research/Content/ResearchListHeader.tsx
+++ b/src/pages/Research/Content/ResearchListHeader.tsx
@@ -18,8 +18,8 @@ import { ResearchSortOptions } from '../ResearchSortOptions';
 import { ResearchSearchParams } from './ResearchSearchParams';
 
 interface IProps {
-  itemCount: number;
-  draftCount: number;
+  itemCount?: number;
+  draftCount?: number;
   handleShowDrafts: () => void;
   showDrafts: boolean;
 }

--- a/src/pages/common/Drafts/DraftButton.tsx
+++ b/src/pages/common/Drafts/DraftButton.tsx
@@ -1,16 +1,15 @@
 import { Button } from 'oa-components';
-
 import { drafts } from '../labels';
 
 type DraftButtonProps = {
   showDrafts: boolean;
-  draftCount: number;
+  draftCount?: number;
   handleShowDrafts: () => void;
 };
 
 const DraftButton = ({ showDrafts, draftCount, handleShowDrafts }: DraftButtonProps) => {
   if (!draftCount) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/src/pages/common/Layout/ListHeader.tsx
+++ b/src/pages/common/Layout/ListHeader.tsx
@@ -1,7 +1,7 @@
 import { Flex, Heading, Text } from 'theme-ui';
 
 interface IProps {
-  itemCount: number;
+  itemCount?: number;
   actionComponents: React.ReactNode;
   headingTitle: string;
   categoryComponent: React.ReactNode;


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the new behavior?

'0 items' is no longer displayed if the list is still loading.
Applies to the library, research and questions list pages.
