### PR TITLE
feat: improve update copy clipboard

### DIFF
--- a/src/pages/Research/Content/ResearchLinkToUpdate.tsx
+++ b/src/pages/Research/Content/ResearchLinkToUpdate.tsx
@@ -15,7 +15,10 @@ export const ResearchLinkToUpdate = ({ research, update }: IProps) => {
   const [showCheck, setShowCheck] = useState(false);
 
   const copyURLtoClipboard = async (slug: string, id: number) => {
-    await navigator.clipboard.writeText(`${location.origin}/research/${slug}#update_${id}`);
+    try {
+      // this try-catch is mainly for cypress not to error
+      await navigator.clipboard.writeText(`${location.origin}/research/${slug}#update_${id}`);
+    } catch (_) {}
     setShowCheck(true);
 
     setTimeout(() => {


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the new behavior?

The current behavior actually sets the page url to the link and scrolls to it.
It defeats the purpose of having a "Link copied" message.

The new behavior:
- no longer "navigates" to the update link.
- changes the icon to a green checkbox for 2 seconds for better user feedback.

https://github.com/user-attachments/assets/3fd5edfc-864b-4054-8854-f402cd2b3d4e

Notes:
- There is still a small flicker of the tooltip changing, I couldn't solve it.
- Could explore other approaches: having a snackbar (new component for the platform) or modal with a readonly input with the link.