### PR TITLE
feat: add news notifications

### DIFF
--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -1,205 +1,217 @@
 import { users } from 'oa-shared/mocks/data';
 
-import { generateAlphaNumeric, getTenantUser } from '../../utils/TestUtils';
-
-let initialRandomId;
+import { generateAlphaNumeric, getTenantUser, generateNewUserDetails } from '../../utils/TestUtils';
 
 describe('[News.Write]', () => {
-  describe('[Create a news item]', () => {
-    beforeEach(() => {
-      initialRandomId = generateAlphaNumeric(8).toLowerCase();
+  it('Create and update', () => {
+    const initialRandomId = generateAlphaNumeric(8).toLowerCase();
+
+    const initialTitle = `${initialRandomId} Amazing new thing`;
+    const initialExpectedSlug = `/news/${initialRandomId}-amazing-new-thing`;
+    const initialNewsBodyOne = 'Yo.';
+    const initialNewsBodyTwo = 'HiHi!';
+    const initialNewsBodyThree = 'We did good.';
+    const initialSummary = `${initialNewsBodyOne} ${initialNewsBodyTwo} ${initialNewsBodyThree}`;
+    const category = 'Moulds';
+    const tag1 = 'product';
+    const tag2 = 'workshop';
+    const updatedTitle = `Still an amazing thing ${initialRandomId}`;
+    const updatedExpectedSlug = `news/still-an-amazing-thing-${initialRandomId}`;
+    const updatedNewsBody = 'PLUS sparkles!';
+    const updatedSummary = `${updatedNewsBody} ${initialNewsBodyOne} ${initialNewsBodyTwo}`;
+
+    cy.visit('/news');
+    const user = getTenantUser(users.admin);
+    cy.signIn(user.email, user.password);
+
+    cy.step('Create a news item');
+    cy.visit('/news/create');
+    cy.get('[data-cy=field-title]', { timeout: 20000 });
+    cy.get('[data-cy=field-title]').clear().type(initialTitle).blur({ force: true });
+    cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic1.jpg', { force: true });
+
+    cy.step('Can add draft news');
+    cy.get('[data-cy=field-title]').clear().type(initialTitle).blur({ force: true });
+
+    cy.addToMarkdownField(initialNewsBodyOne);
+    cy.addToMarkdownField(initialNewsBodyTwo);
+    cy.addToMarkdownField(initialNewsBodyThree);
+
+    cy.get('[data-cy=draft]').click();
+    cy.wait(2000);
+    cy.url().should('include', initialExpectedSlug);
+
+    cy.step('Can get to drafts');
+    cy.visit('/news');
+    cy.contains(initialTitle).should('not.exist');
+    cy.get('[data-cy=my-drafts]').first().click({ force: true });
+    cy.contains(initialTitle).click();
+
+    cy.step('Shows draft news');
+    cy.get('[data-cy=draft-tag]').should('be.visible');
+    cy.contains(initialNewsBodyOne);
+
+    cy.step('No notification generated yet')
+    cy.expectNoNewNotification()
+
+    cy.step('Submit news');
+    cy.get('[data-cy=edit]').click();
+
+    cy.selectTag(category, '[data-cy=category-select]');
+    cy.selectTag(tag1, '[data-cy="tag-select"]');
+    cy.selectTag(tag2, '[data-cy="tag-select"]');
+
+    cy.get('[data-cy=errors-container]').should('not.exist');
+    cy.wait(2000);
+    cy.get('[data-cy=submit]').click();
+
+    cy.wait(2000);
+    cy.url().should('include', initialExpectedSlug);
+
+    cy.step('All news fields shown');
+    cy.visit('/news');
+    cy.get('[data-cy=news-list-item-summary]').first().contains(initialSummary);
+    cy.get('[data-cy=news-list-item]').contains(initialTitle).click();
+
+    cy.contains(initialTitle);
+    cy.contains(initialNewsBodyOne);
+    cy.contains(initialNewsBodyTwo);
+    cy.contains(initialNewsBodyThree);
+    cy.contains(category);
+    cy.contains(tag1);
+    cy.contains(tag2);
+    // contains images
+
+    cy.step('All ready for a discussion');
+    cy.get('[data-cy=DiscussionTitle]').contains('Start the discussion');
+    cy.get('[data-cy=follow-button]').contains('Following Comments');
+
+    cy.step('Notification generated for update');
+    cy.expectNewNotification({
+      content: initialNewsBodyOne,
+      path: initialExpectedSlug,
+      title: initialTitle,
+      username: user.username,
     });
 
-    it('[By Authenticated]', () => {
-      const initialTitle = `${initialRandomId} Amazing new thing`;
-      const initialExpectedSlug = `${initialRandomId}-amazing-new-thing`;
-      const initialNewsBodyOne = 'Yo.';
-      const initialNewsBodyTwo = 'HiHi!';
-      const initialNewsBodyThree = 'We did good.';
-      const initialSummary = `${initialNewsBodyOne} ${initialNewsBodyTwo} ${initialNewsBodyThree}`;
-      const category = 'Moulds';
-      const tag1 = 'product';
-      const tag2 = 'workshop';
-      const updatedTitle = `Still an amazing thing ${initialRandomId}`;
-      const updatedExpectedSlug = `still-an-amazing-thing-${initialRandomId}`;
-      const updatedNewsBody = 'PLUS sparkles!';
-      const updatedSummary = `${updatedNewsBody} ${initialNewsBodyOne} ${initialNewsBodyTwo}`;
+    cy.step('Edit fields');
+    cy.wait(2000);
+    cy.get('[data-cy=edit]').click();
+    cy.wait(2000);
+    cy.url().should('include', `${initialExpectedSlug}/edit`);
 
-      cy.visit('/news');
-      const user = getTenantUser(users.admin);
-      cy.signIn(user.email, user.password);
+    cy.get('[data-cy=field-title]').clear().type(updatedTitle).blur();
+    cy.get('.mdxeditor-root-contenteditable').type('{selectAll}{del}');
 
-      cy.step("Can't add news from main page");
-      cy.visit('/news');
-      cy.get('[data-cy=create-news]').should('not.exist');
+    cy.addToMarkdownField(updatedNewsBody);
+    cy.addToMarkdownField(initialNewsBodyOne);
+    cy.addToMarkdownField(initialNewsBodyTwo);
+    cy.addToMarkdownField(initialNewsBodyThree);
 
-      cy.step('Can go direct to url');
-      cy.visit('/news/create');
-      cy.get('[data-cy=field-title]', { timeout: 20000 });
+    cy.step('Replace hero image');
+    cy.get('[data-cy=existingHeroImage]').should('exist');
+    cy.get('[data-cy=existingHeroImage]').find('[data-cy=delete-image]').click({force: true});
+    cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic2.jpg', { force: true });
+    cy.get('[data-cy=delete-image]').should('exist');
 
-      cy.step('Cannot be published when empty');
-      cy.get('[data-cy=submit]').click();
-      cy.get('[data-cy=errors-container]');
+    cy.step('Updated news details shown');
+    cy.wait(2000);
+    cy.get('[data-cy=submit]').click();
+    cy.wait(2000);
+    cy.url().should('include', updatedExpectedSlug);
+    cy.contains(updatedNewsBody);
 
-      cy.step('Add image');
-      cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic1.jpg', { force: true });
+    cy.contains(updatedTitle);
+    cy.contains(updatedNewsBody);
+    cy.contains(initialNewsBodyOne);
+    cy.contains(initialNewsBodyTwo);
+    cy.contains(initialNewsBodyThree);
+    cy.get('[data-cy=follow-button]').first().should('contain', 'Following Comments');
 
-      cy.step('Can add draft news');
-      cy.get('[data-cy=field-title]').clear().type(initialTitle).blur({ force: true });
+    cy.step('Can access the news with the previous slug');
+    cy.visit(initialExpectedSlug);
+    cy.contains(updatedTitle);
 
-      cy.addToMarkdownField(initialNewsBodyOne);
-      cy.addToMarkdownField(initialNewsBodyTwo);
-      cy.addToMarkdownField(initialNewsBodyThree);
-
-      cy.get('[data-cy=draft]').click();
-      cy.wait(2000);
-      cy.url().should('include', `/news/${initialExpectedSlug}`);
-
-      cy.step('Can get to drafts');
-      cy.visit('/news');
-      cy.contains(initialTitle).should('not.exist');
-      cy.get('[data-cy=my-drafts]').first().click({ force: true });
-      cy.contains(initialTitle).click();
-
-      cy.step('Shows draft news');
-      cy.get('[data-cy=draft-tag]').should('be.visible');
-      cy.contains(initialNewsBodyOne);
-
-      cy.step('Submit news');
-      cy.get('[data-cy=edit]').click();
-
-      cy.selectTag(category, '[data-cy=category-select]');
-      cy.selectTag(tag1, '[data-cy="tag-select"]');
-      cy.selectTag(tag2, '[data-cy="tag-select"]');
-
-      cy.get('[data-cy=errors-container]').should('not.exist');
-      cy.wait(2000);
-      cy.get('[data-cy=submit]').click();
-
-      cy.wait(2000);
-      cy.url().should('include', `/news/${initialExpectedSlug}`);
-
-      cy.step('All news fields shown');
-      cy.visit('/news');
-      cy.get('[data-cy=news-list-item-summary]').first().contains(initialSummary);
-      cy.get('[data-cy=news-list-item]').contains(initialTitle).click();
-
-      cy.contains(initialTitle);
-      cy.contains(initialNewsBodyOne);
-      cy.contains(initialNewsBodyTwo);
-      cy.contains(initialNewsBodyThree);
-      cy.contains(category);
-      cy.contains(tag1);
-      cy.contains(tag2);
-      // contains images
-
-      cy.step('All ready for a discussion');
-      cy.get('[data-cy=DiscussionTitle]').contains('Start the discussion');
-      cy.get('[data-cy=follow-button]').contains('Following Comments');
-
-      cy.step('Edit fields');
-      cy.wait(2000);
-      cy.get('[data-cy=edit]').click();
-      cy.wait(2000);
-      cy.url().should('include', `/news/${initialExpectedSlug}/edit`);
-
-      cy.get('[data-cy=field-title]').clear().type(updatedTitle).blur();
-      cy.get('.mdxeditor-root-contenteditable').type('{selectAll}{del}');
-
-      cy.addToMarkdownField(updatedNewsBody);
-      cy.addToMarkdownField(initialNewsBodyOne);
-      cy.addToMarkdownField(initialNewsBodyTwo);
-      cy.addToMarkdownField(initialNewsBodyThree);
-
-      cy.step('Replace hero image');
-      cy.get('[data-cy=existingHeroImage]').should('exist');
-      cy.get('[data-cy=existingHeroImage]').find('[data-cy=delete-image]').click({force: true});
-      cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic2.jpg', { force: true });
-      cy.get('[data-cy=delete-image]').should('exist');
-
-      cy.step('Updated news details shown');
-      cy.wait(2000);
-      cy.get('[data-cy=submit]').click();
-      cy.wait(2000);
-      cy.url().should('include', `/news/${updatedExpectedSlug}`);
-      cy.contains(updatedNewsBody);
-
-      cy.contains(updatedTitle);
-      cy.contains(updatedNewsBody);
-      cy.contains(initialNewsBodyOne);
-      cy.contains(initialNewsBodyTwo);
-      cy.contains(initialNewsBodyThree);
-      cy.get('[data-cy=follow-button]').first().should('contain', 'Following Comments');
-
-      cy.step('Can access the news with the previous slug');
-      cy.visit(`/news/${initialExpectedSlug}`);
-      cy.contains(updatedTitle);
-
-      cy.step('All updated fields visible on list');
-      cy.visit('/news');
-      cy.contains(updatedSummary);
-      cy.contains(updatedTitle);
-      cy.contains(category);
-
-    });
-
-    it('[Profile badge restricts visibility]', () => {
-      const title = `${initialRandomId} Profile badge news`;
-      const expectedSlug = `${initialRandomId}-profile-badge-news`;
-      const newsBody = 'only news';
-
-      cy.visit('/news');
-      const user = getTenantUser(users.admin);
-      cy.signIn(user.email, user.password);
-
-      cy.step('Create a news item');
-      cy.visit('/news/create');
-      cy.get('[data-cy=field-title]', { timeout: 20000 });
-      cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
-      cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic1.jpg', { force: true });
-      cy.addToMarkdownField(newsBody);
-      cy.selectTag('Moulds', '[data-cy=category-select]');
-      cy.wait(2000);
-      cy.get('[data-cy=submit]').click();
-      cy.wait(2000);
-      cy.url().should('include', `/news/${expectedSlug}`);
-
-      cy.step('Can add profile badge');
-      cy.visit(`/news/${expectedSlug}/edit`);
-      cy.wait(1000);
-      cy.selectTag('PRO', '[data-cy=profileBadge-select]');
-      cy.get('[data-cy=submit]').click().url().should('include', `/news/${expectedSlug}`);
-      cy.get('[data-cy=profileBadge]').contains('only news');
-
-      cy.step('Not visible to logged out users');
-      cy.wait(1000);
-      cy.logout();
-      cy.reload();
-      cy.url().should('include', `/sign-in?returnUrl=%2Fnews%2F${expectedSlug}`);
-
-      cy.step('Not visible on the list view');
-      cy.visit('/news');
-      cy.contains(title).should('not.exist');
-
-      cy.step("Logged in user (who is not an admin) can't view item");
-      cy.signUpNewUser();
-      cy.visit(`/news/${expectedSlug}`);
-      cy.reload();
-      cy.url().should('include', `/news`);
-      cy.url().should('not.include', expectedSlug);
-    });
-
-    it('[By Anonymous]', () => {
-      cy.step('Ask users to login before creating a news');
-      cy.visit('/news');
-      cy.get('[data-cy=create-news]').should('not.exist');
-
-      cy.visit('/news/create');
-      cy.url().should('contain', '/sign-in?returnUrl=%2Fnews%2Fcreate');
-    });
-
-    // it('[Admin]', () => {
-    // Should check an admin can edit other's content
-    // })
+    cy.step('All updated fields visible on list');
+    cy.visit('/news');
+    cy.contains(updatedSummary);
+    cy.contains(updatedTitle);
+    cy.contains(category);
   });
+
+  it('Create only for badgers', () => {
+    const initialRandomId = generateAlphaNumeric(5).toLowerCase();
+    const title = `Important update for PRO: ${initialRandomId}`;
+    const path = `/news/important-update-for-pro-${initialRandomId}`;
+    const content = 'PRO Badger update';
+
+    cy.step("Create a new (non-badge) user")
+    cy.visit('/news');
+    const user = generateNewUserDetails();
+    cy.signUpNewUser(user);
+
+    cy.step('Create a news item');
+    cy.logout();
+    const creator = getTenantUser(users.admin);
+
+    cy.signIn(creator.email, creator.password);
+    cy.visit('/news/create');
+    cy.get('[data-cy=field-title]', { timeout: 20000 });
+    cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
+    cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic1.jpg', { force: true });
+    cy.addToMarkdownField(content);
+    cy.selectTag("PRO", '[data-cy=profileBadge-select]');
+
+    cy.get('[data-cy=errors-container]').should('not.exist');
+    cy.wait(2000);
+    cy.get('[data-cy=submit]').click();
+
+    cy.wait(2000);
+    cy.url().should('include', path);
+
+    cy.step("Shows it's for PRO badgers only")
+    cy.get('[data-cy=profileBadge]').contains('only news');
+
+    cy.step('For creator, notification generated for update');
+    cy.reload() // Annoying delay generating the notification
+    cy.expectNewNotification({
+      content,
+      path,
+      title,
+      username: creator.username,
+    });
+
+    cy.step('Not visible to logged out users');
+    cy.wait(1000);
+    cy.logout();
+    cy.reload();
+    cy.url().should('include', `/sign-in?returnUrl=%2Fnews%2Fimportant-update-for-pro-${initialRandomId}`);
+
+    cy.step('Not visible on the list view');
+    cy.visit('/news');
+    cy.contains(title).should('not.exist');
+
+    cy.step("Logged in user (who is not an admin) can't view item");
+    cy.signIn(user.email, user.password)
+    cy.visit(path);
+    cy.reload();
+    cy.url().should('include', `news`);
+    cy.url().should('not.include', path);
+
+    cy.step('For user, no notification generated for update');
+    cy.expectNoNewNotification();
+  });
+
+  it('[By Anonymous]', () => {
+    cy.step('Ask users to login before creating a news');
+    cy.visit('/news');
+    cy.get('[data-cy=create-news]').should('not.exist');
+
+    cy.visit('/news/create');
+    cy.url().should('contain', '/sign-in?returnUrl=%2Fnews%2Fcreate');
+  });
+
+  // it('[Admin]', () => {
+  // Should check an admin can edit other's content
+  // })
 });

--- a/packages/cypress/src/integration/notifications.spec.ts
+++ b/packages/cypress/src/integration/notifications.spec.ts
@@ -9,12 +9,18 @@ describe('[Notifications]', () => {
     cy.get('[data-cy=SupabaseNotifications-field-comments]').click();
     cy.get('[data-cy=SupabaseNotifications-field-replies]').invoke('prop', 'indeterminate', true);
     cy.get('[data-cy=SupabaseNotifications-field-replies]').click();
+    cy.get('[data-cy=SupabaseNotifications-field-research_updates]').invoke('prop', 'indeterminate', true);
+    cy.get('[data-cy=SupabaseNotifications-field-research_updates]').click();
+    cy.get('[data-cy=SupabaseNotifications-field-news]').invoke('prop', 'indeterminate', true);
+    cy.get('[data-cy=SupabaseNotifications-field-news]').click();
 
     cy.get('[data-cy=save-notifications-preferences]').click();
 
     cy.contains('Preferences updated');
     cy.get('[data-cy=SupabaseNotifications-field-comments]').invoke('prop', 'indeterminate', false);
     cy.get('[data-cy=SupabaseNotifications-field-replies]').invoke('prop', 'indeterminate', false);
+    cy.get('[data-cy=SupabaseNotifications-field-research_updates]').invoke('prop', 'indeterminate', false);
+    cy.get('[data-cy=SupabaseNotifications-field-news]').invoke('prop', 'indeterminate', false);
 
     cy.step('Changing messaging updates preferences form');
     cy.get('[data-cy=messages-link]').contains('Stop receiving messages').click();

--- a/shared/models/notificationsPreferences.ts
+++ b/shared/models/notificationsPreferences.ts
@@ -2,6 +2,7 @@ export class NotificationsPreferences {
   id?: number;
   user_id?: number;
   comments: boolean;
+  news: boolean;
   replies: boolean;
   researchUpdates: boolean;
   isUnsubscribed: boolean;
@@ -9,6 +10,7 @@ export class NotificationsPreferences {
 
 export class DBNotificationsPreferencesFields {
   comments: boolean;
+  news: boolean;
   replies: boolean;
   research_updates: boolean;
   is_unsubscribed: boolean;
@@ -28,6 +30,7 @@ export type NotificationsPreferenceTypes = 'comments' | 'replies' | 'research_up
 
 export interface NotificationsPreferencesFormData {
   comments: boolean;
+  news: boolean;
   replies: boolean;
   research_updates: boolean;
   id?: number;
@@ -35,6 +38,7 @@ export interface NotificationsPreferencesFormData {
 
 export interface NotificationsPreferencesViaEmailFormData {
   comments: boolean;
+  news: boolean;
   replies: boolean;
   research_updates: boolean;
   userCode: string;

--- a/shared/models/profile.ts
+++ b/shared/models/profile.ts
@@ -119,8 +119,8 @@ export class Profile {
 
 // Notifications here to avoid circular dependencies
 
-export type NotificationActionType = 'newContent' | 'newComment' | 'newReply';
-export const NotificationContentTypes = ['research_updates', 'comments'] as const;
+export type NotificationActionType = 'newContent' | 'newComment' | 'newReply' | 'news';
+export const NotificationContentTypes = ['research_updates', 'comments', 'news'] as const;
 export type NotificationContentType = (typeof NotificationContentTypes)[number];
 export type BasicAuthorDetails = Pick<Profile, 'id' | 'username' | 'photo'>;
 export type ProfileListItem = Pick<
@@ -292,6 +292,9 @@ export class NotificationDisplay {
       case 'comments': {
         return (notification.content as Comment).comment;
       }
+      case 'news': {
+        return (notification.content as News).summary || '';
+      }
       default: {
         return '';
       }
@@ -314,6 +317,9 @@ export class NotificationDisplay {
       }
       case 'newReply': {
         return `left a reply`;
+      }
+      case 'news': {
+        return `published a news article: ${notification.title}`;
       }
       default: {
         return notification.title;
@@ -501,6 +507,8 @@ export type SubscribedUser = {
   profile_created_at: string;
   email: string;
   is_unsubscribed: boolean;
+  badge_ids: number[];
+  roles: string[];
   replies: boolean;
   comments: boolean;
   research_updates: boolean;

--- a/src/pages/UserSettings/SupabaseNotificationsForm.tsx
+++ b/src/pages/UserSettings/SupabaseNotificationsForm.tsx
@@ -1,5 +1,12 @@
 import type { GridFormFields } from 'oa-components';
-import { ConfirmModal, FieldCheckbox, GridForm, InformationTooltip, InternalLink, Loader } from 'oa-components';
+import {
+  ConfirmModal,
+  FieldCheckbox,
+  GridForm,
+  InformationTooltip,
+  InternalLink,
+  Loader,
+} from 'oa-components';
 import type { DBNotificationsPreferences } from 'oa-shared';
 import { useContext, useMemo, useState } from 'react';
 import { Field, Form } from 'react-final-form';
@@ -12,27 +19,53 @@ const formId = 'SupabaseNotifications';
 
 const baseFields: GridFormFields[] = [
   {
-    component: <Field component={FieldCheckbox} data-cy={`${formId}-field-comments`} name="comments" />,
+    component: (
+      <Field component={FieldCheckbox} data-cy={`${formId}-field-comments`} name="comments" />
+    ),
     description: 'Top-level comments on your contributions or contributions you follow',
     glyph: 'comment',
     name: 'New comments',
   },
   {
-    component: <Field component={FieldCheckbox} data-cy={`${formId}-field-replies`} name="replies" />,
+    component: (
+      <Field component={FieldCheckbox} data-cy={`${formId}-field-replies`} name="replies" />
+    ),
     description:
       "Replies under your comment or a comment thread that you follow. Note that you can always choose to follow or unfollow a single reply thread in the comment's options.",
     glyph: 'reply',
     name: 'New replies',
   },
   {
-    component: <Field component={FieldCheckbox} data-cy={`${formId}-field-research_updates`} name="research_updates" />,
+    component: (
+      <Field
+        component={FieldCheckbox}
+        data-cy={`${formId}-field-research_updates`}
+        name="research_updates"
+      />
+    ),
     description: 'Updates for the research that you follow.',
     glyph: 'update',
     name: 'Research Updates',
   },
   {
     component: (
-      <InformationTooltip glyph="information" size={22} tooltip="Afriad we've got to send these to you,<br/>so you can't opt-out. " />
+      <Field
+        component={FieldCheckbox}
+        data-cy={`${formId}-field-news`}
+        name="news"
+      />
+    ),
+    description: 'Receive all our news updates.',
+    glyph: 'thunderbolt',
+    name: 'Latest news',
+  },
+  {
+    component: (
+      <InformationTooltip
+        glyph="information"
+        size={22}
+        tooltip="Afriad we've got to send these to you,<br/>so you can't opt-out. "
+      />
     ),
     description: 'Password resets, email verifications and other service emails',
     glyph: 'service-email',
@@ -50,7 +83,8 @@ interface IProps {
 }
 
 export const SupabaseNotificationsForm = (props: IProps) => {
-  const { initialValues, isLoading, onSubmit, onUnsubscribe, profileIsContactable, submitResults } = props;
+  const { initialValues, isLoading, onSubmit, onUnsubscribe, profileIsContactable, submitResults } =
+    props;
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const tenantContext = useContext(TenantContext);
   const showMessagingSetting = !tenantContext?.noMessaging;

--- a/src/routes/api.news.$id.ts
+++ b/src/routes/api.news.$id.ts
@@ -5,6 +5,7 @@ import { News } from 'oa-shared';
 import type { LoaderFunctionArgs, Params } from 'react-router';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { ContentServiceServer } from 'src/services/contentService.server';
+import { BroadcastCoordinationServiceServer } from 'src/services/broadcastCoordinationService.server';
 import { NewsServiceServer } from 'src/services/newsService.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
 import { getSummaryFromMarkdown } from 'src/utils/getSummaryFromMarkdown';
@@ -75,6 +76,16 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
     }
 
     const news = News.fromDB(newsResult.data[0], []);
+    const profileService = new ProfileServiceServer(client);
+    const profile = await profileService.getByAuthId(claims.data.claims.sub);
+
+    const broadcastCoordinationServiceServer = new BroadcastCoordinationServiceServer(client)
+    broadcastCoordinationServiceServer.news(
+      newsResult.data[0],
+      profile,
+      request,
+      currentNews,
+    );
 
     new ProfileServiceServer(client).updateUserActivity(claims.data.claims.sub);
 

--- a/src/routes/api.news.ts
+++ b/src/routes/api.news.ts
@@ -1,13 +1,14 @@
 // TODO: split this in separate files once we update remix to NOT use file-based routing
 
 import { HTTPException } from 'hono/http-exception';
+import { AuthError } from 'node_modules/@supabase/supabase-js';
 import type { DBMedia, DBNews, DBProfile, Moderation, NewsDTO } from 'oa-shared';
 import { News } from 'oa-shared';
 import type { LoaderFunctionArgs } from 'react-router';
 import { ITEMS_PER_PAGE } from 'src/pages/News/constants';
 import type { NewsSortOption } from 'src/pages/News/NewsSortOptions';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { discordServiceServer } from 'src/services/discordService.server';
+import { BroadcastCoordinationServiceServer } from 'src/services/broadcastCoordinationService.server';
 import { NewsServiceServer } from 'src/services/newsService.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
 import { SubscribersServiceServer } from 'src/services/subscribersService.server';
@@ -141,7 +142,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       return Response.json({}, { headers, status: 401 });
     }
 
-    await validateRequest(request, data);
+    await validateRequest(request, data, claims.error);
 
     const slug = convertToSlug(data.title);
 
@@ -187,11 +188,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
 
     const news = News.fromDB(newsResult.data[0], []);
     new SubscribersServiceServer(client).add('news', news.id, profile.id);
-
-    if (!news.isDraft) {
-      notifyDiscord(news, profile, new URL(request.url).origin.replace('http:', 'https:'));
-    }
-
+    new BroadcastCoordinationServiceServer(client).news(newsResult.data[0], profile, request);
     await new ProfileServiceServer(client).updateUserActivity(claims.data.claims.sub);
 
     return Response.json({ news }, { headers, status: 201 });
@@ -205,16 +202,14 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
   }
 };
 
-function notifyDiscord(news: News, profile: DBProfile, siteUrl: string) {
-  const title = news.title;
-  const slug = news.slug;
+async function validateRequest(request: Request, data: any, authError: AuthError | null) {
+  if (authError) {
+    return {
+      status: authError?.status,
+      statusText: authError?.message || 'Unknown authentication error',
+    };
+  }
 
-  discordServiceServer.postWebhookRequest(
-    `📰 ${profile.username} has news: ${title}\n<${siteUrl}/news/${slug}>`,
-  );
-}
-
-async function validateRequest(request: Request, data: NewsDTO): Promise<void> {
   if (request.method !== 'POST') {
     throw methodNotAllowedError();
   }

--- a/src/routes/api.notifications-preferences.ts
+++ b/src/routes/api.notifications-preferences.ts
@@ -5,6 +5,7 @@ import { ProfileServiceServer } from 'src/services/profileService.server';
 
 export const DEFAULT_NOTIFICATION_PREFERENCES: DBNotificationsPreferencesFields = {
   comments: true,
+  news: true,
   replies: true,
   research_updates: true,
   is_unsubscribed: false,
@@ -37,6 +38,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const formData = await request.formData();
     const id = formData.has('id') ? Number(formData.get('id') as string) : null;
     const comments = formData.get('comments') === 'true';
+    const news = formData.get('news') === 'true';
     const replies = formData.get('replies') === 'true';
     const research_updates = formData.get('research_updates') === 'true';
     const is_unsubscribed = formData.get('is_unsubscribed') === 'true';
@@ -58,6 +60,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         .from('notifications_preferences')
         .update({
           comments,
+          news,
           replies,
           research_updates,
           is_unsubscribed,
@@ -82,6 +85,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     await client.from('notifications_preferences').insert({
       user_id: data.id,
       comments,
+      news,
       replies,
       research_updates,
       is_unsubscribed,

--- a/src/services/broadcastCoordinationService.server.ts
+++ b/src/services/broadcastCoordinationService.server.ts
@@ -1,10 +1,32 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { DBProfile, DBResearchUpdate, ResearchUpdate } from 'oa-shared';
+import type { DBNews, DBProfile, DBResearchUpdate, ResearchUpdate } from 'oa-shared';
 import { discordServiceServer } from './discordService.server';
 import { NotificationsSupabaseServiceServer } from './notificationsSupabaseService.server';
 
 export class BroadcastCoordinationServiceServer {
   constructor(private client: SupabaseClient) {}
+
+  news(
+    news: DBNews,
+    profile: DBProfile | null,
+    request: Request,
+    oldNews?: DBNews,
+  ) {
+    const beforeCheck = oldNews ? !!oldNews.is_draft : true;
+    const siteUrl = new URL(request.url).origin.replace('http:', 'https:');
+
+    if (!news || !profile || news?.is_draft) {
+      return;
+    }
+
+    if (beforeCheck && news.is_draft === false) {
+      new NotificationsSupabaseServiceServer(this.client).createNotificationsNews(news);
+
+      discordServiceServer.postWebhookRequest(
+        `📰 ${profile.username} has news: ${news.title}\n<${siteUrl}/news/${news.slug}>`,
+      );
+    }
+  }
 
   researchUpdate(
     update: ResearchUpdate,

--- a/src/services/contentRedirectService.server.ts
+++ b/src/services/contentRedirectService.server.ts
@@ -11,7 +11,21 @@ export class ContentRedirectServiceServer {
         return this.resolveResearchUpdateUrl(id);
       case 'comments':
         return this.resolveCommentUrl(id);
+      case 'news':
+        return this.resolveNewsUrl(id);
+      default:
+        return null;
     }
+  }
+
+  private async resolveNewsUrl(id: number) {
+    const { data, error } = await this.client.from('news').select('slug').eq('id', id).single();
+
+    if (error || !data || !data.slug) {
+      return null;
+    }
+
+    return `/news/${data.slug}`;
   }
 
   private async resolveResearchUpdateUrl(updateId: number) {
@@ -54,6 +68,8 @@ export class ContentRedirectServiceServer {
           comment.source_id!,
           comment.id,
         );
+      default:
+        return null
     }
   }
 

--- a/src/services/notificationsPreferencesService.ts
+++ b/src/services/notificationsPreferencesService.ts
@@ -16,6 +16,7 @@ const setPreferences = async (data: NotificationsPreferencesFormData) => {
 
   data.id && body.append('id', data.id.toString());
   body.append('comments', data.comments.toString());
+  body.append('news', data.news.toString());
   body.append('replies', data.replies.toString());
   body.append('research_updates', data.research_updates.toString());
   body.append('is_unsubscribed', 'false');
@@ -31,6 +32,7 @@ const setUnsubscribe = async (id: number | undefined) => {
 
   id && body.append('id', id.toString());
   body.append('comments', 'false');
+  body.append('news', 'false');
   body.append('replies', 'false');
   body.append('research_updates', 'false');
   body.append('is_unsubscribed', 'true');

--- a/src/services/notificationsPreferencesViaEmailService.ts
+++ b/src/services/notificationsPreferencesViaEmailService.ts
@@ -27,6 +27,7 @@ const setPreferences = async (
 ): Promise<Response> => {
   const formData = new FormData();
   formData.append('comments', data.comments.toString());
+  formData.append('news', data.comments.toString());
   formData.append('replies', data.replies.toString());
   formData.append('research_updates', data.research_updates.toString());
   formData.append('is_unsubscribed', 'false');
@@ -43,6 +44,7 @@ const setUnsubscribe = async (userCode: string, id?: number): Promise<Response> 
     formData.append('id', id.toString());
   }
   formData.append('comments', 'false');
+  formData.append('news', 'false');
   formData.append('replies', 'false');
   formData.append('research_updates', 'false');
   formData.append('is_unsubscribed', 'true');

--- a/src/services/notificationsSupabaseService.server.ts
+++ b/src/services/notificationsSupabaseService.server.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type {
   DBComment,
+  DBNews,
   DBProfile,
   DBResearchItem,
   ResearchUpdate,
@@ -12,19 +13,34 @@ import { NotificationEmailServiceServer } from './notificationEmailService.serve
 
 export class NotificationsSupabaseServiceServer {
   constructor(private client: SupabaseClient) {}
-
+  
   async getSubscribedUsers(
     contentId: number,
     contentType: SubscribableContentTypes,
   ): Promise<SubscribedUser[]> {
     try {
-      const { error, data } = await this.client.rpc('get_subscribed_users_emails_to_notify', {
-        p_content_id: contentId,
-        p_content_type: contentType,
-      });
+      let data;
 
-      if (error || data.length === 0) {
-        throw error || new Error('No emails to send');
+      if (contentType === 'news') {
+        const response = await this.client.from('profiles').select(
+          `id,
+          roles,
+          badges:profile_badges_relations(
+            profile_badges(id)
+          )
+          `
+        );
+        data = response.data && response.data.map(({ id, roles, badges }) => ({ 
+          badge_ids: badges ? badges.map(({profile_badges}) => profile_badges).flat().map((badge) => badge.id) : [],
+          profile_id: id,
+          roles,
+        }));
+      } else {
+        const response = await this.client.rpc('get_subscribed_users_emails_to_notify', {
+          p_content_id: contentId,
+          p_content_type: contentType,
+        });
+        data = response.data;
       }
 
       return data as SubscribedUser[];
@@ -112,14 +128,31 @@ export class NotificationsSupabaseServiceServer {
       );
     } catch (error) {
       console.error(error);
+    }
+  }
 
-      return Response.json(
-        { error },
-        {
-          status: 500,
-          statusText: 'Error creating notifications: Comments',
-        },
-      );
+  async createNotificationsNews(news: DBNews) {
+    try {
+      const contentId = news.id;
+
+      let subscribers = await this.getSubscribedUsers(contentId, 'news');
+      if (news.profile_badge) {
+        subscribers = subscribers.filter(
+          subscriber => subscriber.badge_ids.includes(news.profile_badge as unknown as number) || (subscriber.roles && subscriber.roles.includes('admin'))
+        )
+      }
+
+      const notification = new DBNotification({
+        action_type: 'news',
+        content_id: contentId,
+        title: news.title,
+        triggered_by_id: news.created_by!,
+        content_type: 'news',
+      });
+
+      await this.createNotifications(notification, subscribers);
+    } catch (error) {
+      console.error(error);
     }
   }
 
@@ -140,14 +173,14 @@ export class NotificationsSupabaseServiceServer {
         triggered_by: profile,
       });
 
-      await this.createNotifications(notification, subscribers);
+        await this.createNotifications(notification, subscribers);
 
-      await new NotificationEmailServiceServer(this.client).sendInstantNotificationEmails(
-        subscribers,
-        notification,
-      );
-    } catch (error) {
-      console.error('Error creating notifications: Research update', error);
+        await new NotificationEmailServiceServer(this.client).sendInstantNotificationEmails(
+          subscribers,
+          notification,
+        );
+      } catch (error) {
+        console.error(error);
+      }
     }
-  }
 }

--- a/src/stores/Subscription/subscription.store.tsx
+++ b/src/stores/Subscription/subscription.store.tsx
@@ -40,7 +40,10 @@ export class SubscriptionStore {
     return this.subscriptions.get(key)?.isLoading ?? false;
   }
 
-  async checkAndCacheSubscription(contentType: SubscribableContentTypes, itemId: number): Promise<boolean> {
+  async checkAndCacheSubscription(
+    contentType: SubscribableContentTypes,
+    itemId: number,
+  ): Promise<boolean> {
     const key = this.getCacheKey(contentType, itemId);
     const existing = this.subscriptions.get(key);
 
@@ -164,16 +167,23 @@ export class SubscriptionStore {
     }
   }
 
-  async toggleSubscription(contentType: SubscribableContentTypes, itemId: number): Promise<boolean> {
+  async toggleSubscription(
+    contentType: SubscribableContentTypes,
+    itemId: number,
+  ): Promise<boolean> {
     const currentState = this.isSubscribed(contentType, itemId);
 
     if (currentState === undefined) {
       // Not loaded yet, check first
       const isSubscribed = await this.checkAndCacheSubscription(contentType, itemId);
-      return isSubscribed ? this.unsubscribe(contentType, itemId) : this.subscribe(contentType, itemId);
+      return isSubscribed
+        ? this.unsubscribe(contentType, itemId)
+        : this.subscribe(contentType, itemId);
     }
 
-    return currentState ? this.unsubscribe(contentType, itemId) : this.subscribe(contentType, itemId);
+    return currentState
+      ? this.unsubscribe(contentType, itemId)
+      : this.subscribe(contentType, itemId);
   }
 
   clearCache() {
@@ -181,8 +191,12 @@ export class SubscriptionStore {
   }
 
   // TODO: have an endpoint to fetch multiple subscriptions
-  async preloadSubscriptions(items: Array<{ contentType: SubscribableContentTypes; itemId: number }>): Promise<void> {
-    await Promise.all(items.map((item) => this.checkAndCacheSubscription(item.contentType, item.itemId)));
+  async preloadSubscriptions(
+    items: Array<{ contentType: SubscribableContentTypes; itemId: number }>,
+  ): Promise<void> {
+    await Promise.all(
+      items.map((item) => this.checkAndCacheSubscription(item.contentType, item.itemId)),
+    );
   }
 }
 
@@ -200,7 +214,11 @@ export const SubscriptionStoreProvider = ({ children }: { children: React.ReactN
     }
   }, [profile]);
 
-  return <SubscriptionStoreContext.Provider value={subscriptionStore}>{children}</SubscriptionStoreContext.Provider>;
+  return (
+    <SubscriptionStoreContext.Provider value={subscriptionStore}>
+      {children}
+    </SubscriptionStoreContext.Provider>
+  );
 };
 
 export const useSubscriptionStore = () => {

--- a/src/test/routes/api.notifications-preferences.test.ts
+++ b/src/test/routes/api.notifications-preferences.test.ts
@@ -68,6 +68,7 @@ describe('loader', () => {
     const defaultPreferences = {
       comments: true,
       replies: true,
+      news: true,
       research_updates: true,
       is_unsubscribed: false,
     };
@@ -123,6 +124,7 @@ describe('action', () => {
       id: '1',
       comments: 'false',
       replies: 'true',
+      news: 'false',
       research_updates: 'false',
       is_unsubscribed: 'true',
     });
@@ -144,6 +146,7 @@ describe('action', () => {
     expect(mockClient.mocks.update).toHaveBeenCalledWith({
       comments: false,
       replies: true,
+      news: false,
       research_updates: false,
       is_unsubscribed: true,
     });
@@ -157,6 +160,7 @@ describe('action', () => {
     const formData = createFormData({
       comments: 'true',
       replies: 'false',
+      news: 'true',
       research_updates: 'true',
       is_unsubscribed: 'false',
     });
@@ -181,6 +185,7 @@ describe('action', () => {
       user_id: 456,
       comments: true,
       replies: false,
+      news: true,
       research_updates: true,
       is_unsubscribed: false,
       tenant_id: 'test-tenant',

--- a/src/test/services/notificationsPreferencesService.test.ts
+++ b/src/test/services/notificationsPreferencesService.test.ts
@@ -53,6 +53,7 @@ describe('notificationsPreferencesService', () => {
       const formData = {
         id: 123,
         comments: true,
+        news: true,
         replies: false,
         research_updates: true,
       };
@@ -81,6 +82,7 @@ describe('notificationsPreferencesService', () => {
 
       const formData = {
         comments: false,
+        news: false,
         replies: true,
         research_updates: false,
       };
@@ -102,6 +104,7 @@ describe('notificationsPreferencesService', () => {
       const formData = {
         id: undefined,
         comments: true,
+        news: true,
         replies: true,
         research_updates: true,
       };
@@ -131,6 +134,7 @@ describe('notificationsPreferencesService', () => {
 
       expect(body.get('id')).toBe('456');
       expect(body.get('comments')).toBe('false');
+      expect(body.get('news')).toBe('false');
       expect(body.get('replies')).toBe('false');
       expect(body.get('research_updates')).toBe('false');
       expect(body.get('is_unsubscribed')).toBe('true');
@@ -147,6 +151,7 @@ describe('notificationsPreferencesService', () => {
 
       expect(body.get('id')).toBeNull();
       expect(body.get('comments')).toBe('false');
+      expect(body.get('news')).toBe('false');
       expect(body.get('replies')).toBe('false');
       expect(body.get('research_updates')).toBe('false');
       expect(body.get('is_unsubscribed')).toBe('true');

--- a/src/test/services/notificationsPreferencesViaEmailService.test.ts
+++ b/src/test/services/notificationsPreferencesViaEmailService.test.ts
@@ -85,6 +85,7 @@ describe('notificationsPreferencesViaEmailService', () => {
 
       const testData = {
         comments: true,
+        news: true,
         replies: false,
         research_updates: true,
         userCode: 'user123',
@@ -102,6 +103,7 @@ describe('notificationsPreferencesViaEmailService', () => {
 
       const formData = (fetch as any).mock.calls[0][1].body;
       expect(formData.get('comments')).toBe('true');
+      expect(formData.get('news')).toBe('true');
       expect(formData.get('replies')).toBe('false');
       expect(formData.get('research_updates')).toBe('true');
       expect(formData.get('is_unsubscribed')).toBe('false');
@@ -114,6 +116,7 @@ describe('notificationsPreferencesViaEmailService', () => {
 
       const testData = {
         comments: false,
+        news: false,
         replies: false,
         research_updates: false,
         userCode: 'user123',
@@ -123,6 +126,7 @@ describe('notificationsPreferencesViaEmailService', () => {
 
       const formData = (fetch as any).mock.calls[0][1].body;
       expect(formData.get('comments')).toBe('false');
+      expect(formData.get('news')).toBe('false');
       expect(formData.get('replies')).toBe('false');
       expect(formData.get('research_updates')).toBe('false');
     });
@@ -146,6 +150,7 @@ describe('notificationsPreferencesViaEmailService', () => {
       const formData = (fetch as any).mock.calls[0][1].body;
       expect(formData.get('id')).toBe('456');
       expect(formData.get('comments')).toBe('false');
+      expect(formData.get('news')).toBe('false');
       expect(formData.get('replies')).toBe('false');
       expect(formData.get('research_updates')).toBe('false');
       expect(formData.get('is_unsubscribed')).toBe('true');
@@ -161,6 +166,7 @@ describe('notificationsPreferencesViaEmailService', () => {
       const formData = (fetch as any).mock.calls[0][1].body;
       expect(formData.get('id')).toBeNull();
       expect(formData.get('comments')).toBe('false');
+      expect(formData.get('news')).toBe('false');
       expect(formData.get('replies')).toBe('false');
       expect(formData.get('research_updates')).toBe('false');
       expect(formData.get('is_unsubscribed')).toBe('true');

--- a/supabase/migrations/20260328093904_add_news_notifications.sql
+++ b/supabase/migrations/20260328093904_add_news_notifications.sql
@@ -1,0 +1,5 @@
+alter table "public"."notifications" alter column "action_type" set data type text using "action_type"::text;
+
+drop type "public"."notification_action_types";
+
+


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## What is the new behavior?

<img width="911" height="385" alt="Screenshot 2026-03-30 at 10 52 19" src="https://github.com/user-attachments/assets/edb0ede2-bdd2-4c10-9a55-346ca97023c3" />

<img width="1082" height="887" alt="Screenshot 2026-03-30 at 10 56 24" src="https://github.com/user-attachments/assets/438bc982-b5a1-4aa9-aaa1-9772f46956b0" />

This adds the generating of all app notifications to **all users**.


## Does this PR introduce a DB Schema Change or Migration?

- [x] Yes
- [ ] No

## (At least) Two design considerations

1. The layout of the notification - uses the existing pattern that it's the user that generated a notification, but news appears as if it's been generated by the platform. How should this be layed out?
2. I've included the email preference already. Can either hide it for the moment, or change the text to read something like "we don't email about news yet, but will be soon."