### PR TITLE
fix commits only with test/spec/stories (non-checked) files from failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
     "type": "git",
     "url": "https://github.com/ONEARMY/community-platform.git"
   },
-  "workspaces": [
-    "shared",
-    "packages/*",
-    "scripts"
-  ],
+  "workspaces": ["shared", "packages/*", "scripts"],
   "private": true,
   "main": "lib/index.js",
   "type": "module",
@@ -42,18 +38,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,ts,tsx,json}": [
-      "biome check --write"
-    ]
+    "*.{js,ts,tsx,json}": ["biome check --write --no-errors-on-unmatched"]
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all",
-      "iOS >= 15",
-      "safari >= 15"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all", "iOS >= 15", "safari >= 15"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other:

## What is the new behavior?

When a commit has only test/spec/stories files (which biome is configured to ignore), 
biome was erroring. This will now exit successfully instead of failing with "No files were processed."

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [ ] No

## Git Issues

Closes #

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
