### PR TITLE
fix: missing display of useful for contributions

### DIFF
--- a/src/pages/User/content/UserCreatedDocumentsItem.tsx
+++ b/src/pages/User/content/UserCreatedDocumentsItem.tsx
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 const UserDocumentItem = ({ type, item }: IProps) => {
-  const { id, commentCount, coverImage, title, slug } = item;
+  const { id, commentCount, coverImage, slug, title, usefulCount } = item;
   const url = `/${type}/${encodeURIComponent(slug)}?utm_source=user-profile`;
 
   return (
@@ -64,6 +64,7 @@ const UserDocumentItem = ({ type, item }: IProps) => {
               justifyContent: 'space-between',
               flex: 1,
               padding: 3,
+              gap: 2,
             }}
           >
             <Text
@@ -90,6 +91,7 @@ const UserDocumentItem = ({ type, item }: IProps) => {
                   justifyContent: 'flex-end',
                 }}
               >
+                <IconCountWithTooltip count={usefulCount} icon="star-active" text="Useful count" />
                 <IconCountWithTooltip
                   count={commentCount || 0}
                   icon="comment"


### PR DESCRIPTION
<img width="530" height="331" alt="Screenshot 2026-02-21 at 08 23 15" src="https://github.com/user-attachments/assets/6c0e51b4-4185-4aa8-8d67-ecf9f806bf35" />

Adds back in the missing useful count on the contributions display on profile pages (plus some missing spasing) from #4582.