### PR TITLE
fix: optimise comments layout on mobile

### DIFF
--- a/packages/components/src/CommentDisplay/CommentDisplay.tsx
+++ b/packages/components/src/CommentDisplay/CommentDisplay.tsx
@@ -1,6 +1,7 @@
 import type { Comment } from 'oa-shared';
 import { useContext } from 'react';
-import { Box, Flex, Text } from 'theme-ui';
+import { Avatar, Box, Flex, Text } from 'theme-ui';
+import defaultProfileImage from '../../assets/images/default_member.svg';
 import { CommentAvatar } from '../CommentAvatar/CommentAvatar';
 import { CommentBody } from '../CommentBody/CommentBody';
 import { DisplayDate } from '../DisplayDate/DisplayDate';
@@ -54,7 +55,7 @@ export const CommentDisplay = (props: IProps) => {
           sx={{
             flexDirection: 'column',
             position: 'relative',
-            display: 'inline-block',
+            display: ['none', 'inline-block'],
           }}
         >
           <CommentAvatar
@@ -82,6 +83,22 @@ export const CommentDisplay = (props: IProps) => {
               }}
             >
               <Flex sx={{ alignItems: 'center', gap: 2 }}>
+                <Box sx={{ display: ['flex', 'none'] }}>
+                  <Avatar
+                    src={comment.createdBy?.photo?.publicUrl ?? defaultProfileImage}
+                    sx={{
+                      objectFit: 'cover',
+                      width: '30px',
+                      height: '30px',
+                    }}
+                    alt={
+                      comment.createdBy?.displayName
+                        ? `Avatar of ${comment.createdBy.displayName}`
+                        : 'Avatar of comment author'
+                    }
+                    loading="lazy"
+                  />
+                </Box>
                 {comment.createdBy && <Username user={comment.createdBy} />}
                 <Text sx={{ fontSize: 1, color: 'darkGrey' }}>
                   <DisplayDate createdAt={comment.createdAt} showLabel={false} />

--- a/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
+++ b/src/pages/common/CommentsSupabase/CommentReplySupabase.tsx
@@ -1,5 +1,13 @@
 import { observer } from 'mobx-react';
-import { ActionSet, Button, CommentDisplay, ConfirmModal, EditComment, Icon, Modal } from 'oa-components';
+import {
+  ActionSet,
+  Button,
+  CommentDisplay,
+  ConfirmModal,
+  EditComment,
+  Icon,
+  Modal,
+} from 'oa-components';
 import type { Reply } from 'oa-shared';
 import { UserRole } from 'oa-shared';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -20,12 +28,19 @@ export const CommentReply = observer(({ comment, onEdit, onDelete }: ICommentIte
   const commentRef = useRef<HTMLDivElement>(null);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const { hasVoted, usefulCount, toggle: toggleVote } = useUsefulVote('comments', comment.id, comment.voteCount ?? 0);
+  const {
+    hasVoted,
+    usefulCount,
+    toggle: toggleVote,
+  } = useUsefulVote('comments', comment.id, comment.voteCount ?? 0);
 
   const { profile: activeUser } = useProfileStore();
 
   const isEditable = useMemo(() => {
-    return activeUser?.username === comment.createdBy?.username || activeUser?.roles?.includes(UserRole.ADMIN);
+    return (
+      activeUser?.username === comment.createdBy?.username ||
+      activeUser?.roles?.includes(UserRole.ADMIN)
+    );
   }, [activeUser, comment]);
 
   useEffect(() => {
@@ -47,12 +62,16 @@ export const CommentReply = observer(({ comment, onEdit, onDelete }: ICommentIte
       <Box
         sx={{
           paddingTop: 1,
-          paddingRight: 2,
+          paddingRight: [0, 2],
         }}
       >
         <Icon glyph="reply-outline" />
       </Box>
-      <Flex id={`comment:${comment.id}`} data-cy={isEditable ? `Own${item}` : item} sx={{ flexDirection: 'column', width: '100%' }}>
+      <Flex
+        id={`comment:${comment.id}`}
+        data-cy={isEditable ? `Own${item}` : item}
+        sx={{ flexDirection: 'column', width: '100%' }}
+      >
         <Flex sx={{ gap: 2 }} ref={commentRef as any}>
           {comment.deleted ? (
             <Box


### PR DESCRIPTION
## PR Checklist

- [x] Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the new behavior?

- Hide the large avatar column on mobile, show a small 30x30px inline avatar next to the username instead
- Reduce reply icon right padding on mobile to reclaim horizontal space for comment text
- Desktop layout remains unchanged

## Does this PR introduce a DB Schema Change or Migration?

- [ ] No

## Git Issues

Closes #4422