### PR TITLE
fix: pass COMMIT_SHA build arg to bust Docker cache on preview deploys

### DIFF
--- a/.github/workflows/pr-preview-fly-deploy.yml
+++ b/.github/workflows/pr-preview-fly-deploy.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           config: fly-preview.toml
           name: community-platform-pr-${{ github.event.number }}
+          args: --build-arg COMMIT_SHA=${{ github.event.pull_request.head.sha }}
 
       - name: Set Fly.io Secrets
         run: |


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the new behavior?

The `Dockerfile.preview` already defines a cache-busting `ARG COMMIT_SHA` before `COPY . .`, but the deploy workflow never passed it. This meant Fly.io's remote Docker builder reused cached layers on subsequent pushes, so code changes weren't reflected in the preview app.

This PR passes `--build-arg COMMIT_SHA=<head_sha>` to `fly deploy`, which invalidates the Docker cache from that point onwards — ensuring new code is copied and rebuilt on every push.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No

## Git Issues

Closes #4127