### PR TITLE
fix: prevent iOS Safari auto-zoom on comment textarea

### DIFF
--- a/packages/components/src/CreateComment/CreateComment.css
+++ b/packages/components/src/CreateComment/CreateComment.css
@@ -28,7 +28,7 @@
   padding: 15px;
   word-wrap: anywhere;
   border-color: transparent;
-  font-size: 12px;
+  font-size: 16px;
 
   /* Place on top of each other */
   grid-area: 1 / 1 / 2 / 2;


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the new behavior?

iOS Safari auto-zooms on input focus when the font-size is below 16px. The comment textarea in `CreateComment.css` had `font-size: 12px`, triggering this zoom every time a user taps to type a comment on mobile.

Changed to `font-size: 16px` which prevents the auto-zoom while keeping the text readable.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No

## Git Issues

Closes #4652