### PR TITLE
chore: add DisplayName storybook and fix react-dom version mismatch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -196,6 +196,7 @@
     "@types/react": "19.2.7",
     "__note1__": "Pin react version consistently in all child workspaces",
     "react": "19.2.1",
+    "react-dom": "19.2.1",
   },
   "packages": {
     "@actions/core": ["@actions/core@3.0.0", "", { "dependencies": { "@actions/exec": "^3.0.0", "@actions/http-client": "^4.0.0" } }, "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg=="],
@@ -4304,8 +4305,6 @@
 
     "react-select/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
 
-    "react-zdog/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
-
     "read-package-up/type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
     "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
@@ -4691,8 +4690,6 @@
     "pkg-conf/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
     "react-native/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "react-zdog/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "read-pkg/parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "resolutions": {
     "__note1__": "Pin react version consistently in all child workspaces",
     "react": "19.2.1",
+    "react-dom": "19.2.1",
     "@types/react": "19.2.7"
   },
   "dependencies": {

--- a/packages/components/src/Username/DisplayName.stories.tsx
+++ b/packages/components/src/Username/DisplayName.stories.tsx
@@ -1,0 +1,81 @@
+import { faker } from '@faker-js/faker';
+import { DisplayName } from './DisplayName';
+import type { Meta } from '@storybook/react-vite';
+import type { Author } from 'oa-shared';
+
+export default {
+  title: 'Components/DisplayName',
+  component: DisplayName,
+} as Meta<typeof DisplayName>;
+
+export const Default = {
+  args: {
+    user: {
+      username: 'cool-maker',
+      displayName: 'Cool Maker',
+      country: 'de',
+    } as Author,
+  },
+};
+
+export const WithBadge = {
+  args: {
+    user: {
+      username: 'pro-user',
+      displayName: 'Pro User',
+      country: 'nl',
+      badges: [
+        {
+          id: 1,
+          name: 'pro',
+          displayName: 'PRO',
+          imageUrl: faker.image.avatar(),
+        },
+      ],
+    } as Author,
+  },
+};
+
+export const WithMultipleBadges = {
+  args: {
+    user: {
+      username: 'super-user',
+      displayName: 'Super User',
+      country: 'pt',
+      badges: [
+        {
+          id: 1,
+          name: 'pro',
+          displayName: 'PRO',
+          imageUrl: faker.image.avatar(),
+        },
+        {
+          id: 2,
+          name: 'supporter',
+          displayName: 'Supporter',
+          actionUrl: faker.internet.url(),
+          imageUrl: faker.image.avatar(),
+        },
+      ],
+    } as Author,
+  },
+};
+
+export const UsernameOnly = {
+  args: {
+    user: {
+      username: 'just-a-username',
+    } as Author,
+  },
+};
+
+export const NotALink = {
+  args: {
+    user: {
+      username: 'static-user',
+      displayName: 'Static User',
+      country: 'fr',
+    } as Author,
+    isLink: false,
+  },
+};

--- a/packages/components/src/Username/DisplayName.tsx
+++ b/packages/components/src/Username/DisplayName.tsx
@@ -1,7 +1,9 @@
+import { countryToAlpha2 } from 'country-to-iso';
 import type { Author } from 'oa-shared';
 import type { HTMLAttributeAnchorTarget } from 'react';
 import type { ThemeUIStyleObject } from 'theme-ui';
 import { Flex, Text } from 'theme-ui';
+import { FlagIcon } from '../FlagIcon/FlagIcon';
 import { InternalLink } from '../InternalLink/InternalLink';
 import { UserBadge } from './UserBadge';
 
@@ -14,6 +16,7 @@ export interface DisplayNameProps {
 
 export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProps) => {
   const { username, displayName, country, badges } = user;
+  const countryCode = country ? countryToAlpha2(country) : null;
 
   const DisplayNameBody = (
     <Flex
@@ -37,18 +40,7 @@ export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProp
           return <UserBadge key={badge.id} badge={badge} />;
         })}
 
-      {country && (
-        <Text
-          sx={{
-            color: 'grey',
-            fontSize: 1,
-            whiteSpace: 'nowrap',
-            flexShrink: 0,
-          }}
-        >
-          {country}
-        </Text>
-      )}
+      {countryCode && <FlagIcon countryCode={countryCode} />}
     </Flex>
   );
 


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## What is the new behavior?

- Adds Storybook stories for the `DisplayName` component (Default, WithBadge, WithMultipleBadges, UsernameOnly, NotALink)
- Pins `react-dom` to `19.2.1` in resolutions to fix the react/react-dom version mismatch that was breaking Storybook

## Does this PR introduce a DB Schema Change or Migration?

- [x] No