### PR TITLE
chore: fix removing e2e test accounts

### DIFF
--- a/packages/cypress/src/utils/supabaseTestsService.ts
+++ b/packages/cypress/src/utils/supabaseTestsService.ts
@@ -47,7 +47,7 @@ export class SupabaseTestsService {
       if (!data.users.length) break;
 
       for (const user of data.users) {
-        if (user.email?.includes(`+${this.tenantId}@`)) {
+        if (user.email?.includes(`+${this.tenantId}`)) {
           toDelete.push(user.id);
         }
       }


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🧪 Tests — adds or updates tests only

## What is the new behavior?

Test accounts were not being removed
