### PR TITLE
fix: set minWidth on FieldTextarea to fill container

### DIFF
--- a/packages/components/src/FieldTextarea/FieldTextarea.tsx
+++ b/packages/components/src/FieldTextarea/FieldTextarea.tsx
@@ -57,6 +57,7 @@ export const FieldTextarea = ({
         rows={rows ? rows : 5}
         sx={{
           resize: rest?.style?.resize ? rest.style.resize : 'vertical',
+          minWidth: '100%',
         }}
         {...input}
         {...rest}


### PR DESCRIPTION
## Summary

The textarea in the question description form was shrinking instead of using all the available width. Added `minWidth: '100%'` to the `FieldTextarea` component's `sx` prop so it fills its container properly.

## Changes

One-liner in `packages/components/src/FieldTextarea/FieldTextarea.tsx` (line 60): added `minWidth: '100%'` to the Textarea's `sx` prop.

Checked all 9 usages of `FieldTextarea` across the platform (EditComment, ResearchDescription, LibraryDescription, LibraryStep, UserContact, QuestionDescription, VisitorSection, UserInfos). They all render the textarea inside flex containers that should fill available width, so this change is safe across all contexts.

## Testing

Visual verification against the issue screenshot. The textarea now correctly fills its parent container width.

Fixes #4688

This contribution was developed with AI assistance (Claude Code).