### PR TITLE
fix: textarea resize and rows

### DIFF
--- a/packages/components/src/EditComment/EditComment.tsx
+++ b/packages/components/src/EditComment/EditComment.tsx
@@ -72,12 +72,11 @@ export const EditComment = (props: IProps) => {
             as="form"
             sx={{
               flexDirection: 'column',
-              padding: 2,
               gap: 2,
             }}
             onSubmit={handleSubmit}
           >
-            <Label as="label" htmlFor="comment" sx={{ marginBottom: '6px', fontSize: 3 }}>
+            <Label as="label" htmlFor="comment" sx={{ fontSize: 3 }}>
               Edit {isReply ? 'Reply' : 'Comment'}
             </Label>
 
@@ -89,11 +88,11 @@ export const EditComment = (props: IProps) => {
               id="comment"
               validate={required}
               name="comment"
-              rows={2}
+              rows={4}
               sx={{ padding: 1 }}
             />
-            <Flex mt={4} ml="auto">
-              <Button type="button" small mr={4} variant="outline" onClick={() => props?.handleCancel()}>
+            <Flex sx={{ gap: 2, justifyContent: 'flex-end' }}>
+              <Button type="button" small variant="outline" onClick={() => props?.handleCancel()}>
                 Cancel
               </Button>
               <Button

--- a/packages/components/src/FieldTextarea/FieldTextarea.tsx
+++ b/packages/components/src/FieldTextarea/FieldTextarea.tsx
@@ -45,8 +45,10 @@ export const FieldTextarea = ({
   ...rest
 }: Props) => {
   const curLength = useMemo<number>(() => input?.value?.length ?? 0, [input?.value]);
+  const { sx: restSx, ...restWithoutSx } = rest;
+
   return (
-    <Flex sx={{ flexDirection: 'column', gap: 1 }}>
+    <Flex sx={{ flexDirection: 'column', gap: 1, width: '100%' }}>
       {meta.error && meta.touched && <Text sx={{ fontSize: 1, color: 'error' }}>{meta.error}</Text>}
 
       <Textarea
@@ -58,9 +60,12 @@ export const FieldTextarea = ({
         sx={{
           resize: rest?.style?.resize ? rest.style.resize : 'vertical',
           minWidth: '100%',
+          height: 'auto',
+          fieldSizing: 'fixed',
+          ...restSx,
         }}
         {...input}
-        {...rest}
+        {...restWithoutSx}
         onBlur={(e) => {
           if (modifiers) {
             e.target.value = processInputModifiers(e.target.value, modifiers);

--- a/src/pages/Library/Content/Common/LibraryDescription.field.tsx
+++ b/src/pages/Library/Content/Common/LibraryDescription.field.tsx
@@ -22,11 +22,7 @@ export const LibraryDescriptionField = () => {
         modifiers={{ capitalize: true, trim: true }}
         isEqual={COMPARISONS.textInput}
         component={FieldTextarea}
-        style={{
-          resize: 'none',
-          flex: 1,
-          minHeight: '150px',
-        }}
+        rows={10}
         maxLength={LIBRARY_DESCRIPTION_MAX_LENGTH}
         showCharacterCount
         placeholder={description}

--- a/src/pages/Library/Content/Common/LibraryStep.field.tsx
+++ b/src/pages/Library/Content/Common/LibraryStep.field.tsx
@@ -193,7 +193,7 @@ export const LibraryStepField = ({
             data-testid="step-description"
             modifiers={{ capitalize: true, trim: true }}
             component={FieldTextarea}
-            style={{ resize: 'vertical', height: '300px' }}
+            rows={10}
             validate={(value, allValues) =>
               draftValidationWrapper(
                 value,

--- a/src/pages/Research/Content/Common/FormFields/ResearchDescriptionField.tsx
+++ b/src/pages/Research/Content/Common/FormFields/ResearchDescriptionField.tsx
@@ -20,11 +20,7 @@ export const ResearchDescriptionField = () => {
         validateFields={[]}
         isEqual={COMPARISONS.textInput}
         component={FieldTextarea}
-        style={{
-          resize: 'none',
-          flex: 1,
-          minHeight: '150px',
-        }}
+        rows={10}
         maxLength={RESEARCH_MAX_LENGTH}
         showCharacterCount
         placeholder={placeholder}

--- a/src/pages/Research/Content/CreateResearch/Form/DescriptionField.tsx
+++ b/src/pages/Research/Content/CreateResearch/Form/DescriptionField.tsx
@@ -23,11 +23,7 @@ export const DescriptionField = () => {
         validateFields={[]}
         isEqual={COMPARISONS.textInput}
         component={FieldTextarea}
-        style={{
-          resize: 'none',
-          flex: 1,
-          minHeight: '150px',
-        }}
+        rows={10}
         maxLength={RESEARCH_MAX_LENGTH}
         showCharacterCount
         placeholder={placeholder}

--- a/src/pages/User/contact/UserContactFieldMessage.tsx
+++ b/src/pages/User/contact/UserContactFieldMessage.tsx
@@ -6,28 +6,21 @@ import { required } from 'src/utils/validators';
 import { Box, Label } from 'theme-ui';
 
 export const UserContactFieldMessage = () => {
-  const { title, placeholder } = contact.message;
   const name = 'message';
-
-  const sx = {
-    backgroundColor: 'white',
-    height: '300px',
-    resize: 'vertical',
-  };
 
   return (
     <Box>
-      <Label htmlFor={name}>{`${title} *`}</Label>
+      <Label htmlFor={name}>{`${contact.message.title} *`}</Label>
       <Field
         name={name}
-        placeholder={placeholder}
+        placeholder={contact.message.placeholder}
         minLength={MESSAGE_MIN_CHARACTERS}
         maxLength={MESSAGE_MAX_CHARACTERS}
         data-cy={name}
         data-testid={name}
         modifiers={{ capitalize: true, trim: true }}
         component={FieldTextarea}
-        sx={sx}
+        sx={{ backgroundColor: 'white' }}
         validate={required}
         validateFields={[]}
         showCharacterCount


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality

## What is the new behavior?

Textareas were shrinking in size, adapting to the text.
This change forces the textarea to always occupy the full width.
Also fixes an issue with theme-ui Textarea where the rows were being overridden.

## Git Issues

Closes #4688
