### PR TITLE
fix: profile badges cache

### DIFF
--- a/src/routes/api.profile-badges.ts
+++ b/src/routes/api.profile-badges.ts
@@ -26,7 +26,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const profileBadges = data?.map((badge) => ProfileBadge.fromDB(badge as DBProfileBadge));
 
   if (profileBadges && profileBadges.length > 0) {
-    cache.set('profileBadges', data, 3600000);
+    cache.set('profileBadges', profileBadges, 3600000);
   }
 
   return Response.json(profileBadges, { headers, status: 200 });


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality

## What is the new behavior?

Profile badges were being cached with raw database data instead of mapped data.
Causing the badge picker to not work when fetching badges from cache (most of the time).

## Does this PR introduce a DB Schema Change or Migration?

- [x] No
