### PR TITLE
feat: improve map module list and pin cards

### DIFF
--- a/packages/components/src/CardListItem/CardListItem.tsx
+++ b/packages/components/src/CardListItem/CardListItem.tsx
@@ -1,12 +1,10 @@
 import type { MapPin } from 'oa-shared';
 import { Box } from 'theme-ui';
 import { CardButton } from '../CardButton/CardButton';
-import type { CardVariant } from '../CardProfile/CardProfile';
 import { CardProfile } from '../CardProfile/CardProfile';
 import { InternalLink } from '../InternalLink/InternalLink';
 
 export interface IProps {
-  cardVariant?: CardVariant;
   item: MapPin;
   isSelectedPin: boolean;
   onPinClick: (arg: MapPin) => void;
@@ -14,12 +12,12 @@ export interface IProps {
 }
 
 export const CardListItem = (props: IProps) => {
-  const { cardVariant, item, onPinClick, isSelectedPin, viewport } = props;
+  const { item, onPinClick, isSelectedPin, viewport } = props;
   const testProp = `CardListItem${isSelectedPin ? '-selected' : ''}`;
 
   const Card = (
     <CardButton isSelected={isSelectedPin} extrastyles={{ minWidth: '230px', maxWidth: '400px' }}>
-      <CardProfile item={item} cardVariant={cardVariant} />
+      <CardProfile item={item} variant="list" />
     </CardButton>
   );
 

--- a/packages/components/src/CardListItem/CardListItem.tsx
+++ b/packages/components/src/CardListItem/CardListItem.tsx
@@ -1,24 +1,25 @@
 import type { MapPin } from 'oa-shared';
 import { Box } from 'theme-ui';
 import { CardButton } from '../CardButton/CardButton';
+import type { CardVariant } from '../CardProfile/CardProfile';
 import { CardProfile } from '../CardProfile/CardProfile';
 import { InternalLink } from '../InternalLink/InternalLink';
 
 export interface IProps {
+  cardVariant?: CardVariant;
   item: MapPin;
   isSelectedPin: boolean;
   onPinClick: (arg: MapPin) => void;
-  variant?: 'pin' | 'list';
   viewport: string;
 }
 
 export const CardListItem = (props: IProps) => {
-  const { item, onPinClick, isSelectedPin, viewport, variant } = props;
+  const { cardVariant, item, onPinClick, isSelectedPin, viewport } = props;
   const testProp = `CardListItem${isSelectedPin ? '-selected' : ''}`;
 
   const Card = (
     <CardButton isSelected={isSelectedPin} extrastyles={{ minWidth: '230px', maxWidth: '400px' }}>
-      <CardProfile item={item} variant={variant} />
+      <CardProfile item={item} cardVariant={cardVariant} />
     </CardButton>
   );
 

--- a/packages/components/src/CardListItem/CardListItem.tsx
+++ b/packages/components/src/CardListItem/CardListItem.tsx
@@ -8,16 +8,17 @@ export interface IProps {
   item: MapPin;
   isSelectedPin: boolean;
   onPinClick: (arg: MapPin) => void;
+  variant?: 'pin' | 'list';
   viewport: string;
 }
 
 export const CardListItem = (props: IProps) => {
-  const { item, onPinClick, isSelectedPin, viewport } = props;
+  const { item, onPinClick, isSelectedPin, viewport, variant } = props;
   const testProp = `CardListItem${isSelectedPin ? '-selected' : ''}`;
 
   const Card = (
-    <CardButton isSelected={isSelectedPin}>
-      <CardProfile item={item} />
+    <CardButton isSelected={isSelectedPin} extrastyles={{ minWidth: '230px', maxWidth: '400px' }}>
+      <CardProfile item={item} variant={variant} />
     </CardButton>
   );
 

--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -1,20 +1,26 @@
-import type { PinProfile } from 'oa-shared';
+import type { MapPin } from 'oa-shared';
 import { Avatar, Box, Flex, Text } from 'theme-ui';
 import defaultProfileImage from '../../assets/images/default_member.svg';
 import { MemberBadge } from '../MemberBadge/MemberBadge';
 import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
 import { DisplayName } from '../Username/DisplayName';
+import type { CardVariant } from './CardProfile';
 
 interface IProps {
-  profile: PinProfile;
+  cardVariant?: CardVariant;
+  item: MapPin;
   isLink: boolean;
-  variant?: 'pin' | 'list';
+  sendMessageButton?: React.ReactNode;
 }
 
-export const CardDetailsMemberProfile = ({ profile, isLink, variant = 'pin' }: IProps) => {
+export const CardDetailsMemberProfile = ({
+  cardVariant,
+  item,
+  isLink,
+  sendMessageButton,
+}: IProps) => {
+  const { profile } = item;
   const photoUrl = profile.photo?.publicUrl;
-  const aboutText =
-    profile.about && profile.about.length > 80 ? profile.about.slice(0, 78) + '...' : profile.about;
 
   return (
     <Flex
@@ -51,12 +57,12 @@ export const CardDetailsMemberProfile = ({ profile, isLink, variant = 'pin' }: I
         </Box>
         <Flex sx={{ flexDirection: 'column' }}>
           <DisplayName
-            user={profile}
+            user={{ ...profile, country: item.country }}
             sx={{ alignSelf: 'flex-start' }}
             isLink={isLink}
             target="_blank"
           />
-          {variant == 'list' && (
+          {cardVariant === 'list' && (
             <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
               {profile.tags && profile.tags.length > 0 && (
                 <ProfileTagsList tags={profile.tags} isSpace={false} />
@@ -65,14 +71,14 @@ export const CardDetailsMemberProfile = ({ profile, isLink, variant = 'pin' }: I
           )}
         </Flex>
       </Flex>
-      {variant == 'pin' && (
+      {cardVariant === 'pin' && (
         <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
           {profile.tags && profile.tags.length > 0 && (
             <ProfileTagsList tags={profile.tags} isSpace={false} />
           )}
         </Flex>
       )}
-      {variant == 'pin' && aboutText && (
+      {cardVariant === 'pin' && profile.about && (
         <Text
           variant="quiet"
           sx={{
@@ -84,9 +90,10 @@ export const CardDetailsMemberProfile = ({ profile, isLink, variant = 'pin' }: I
             wordBreak: 'break-word',
           }}
         >
-          {aboutText}
+          {profile.about}
         </Text>
       )}
+      {sendMessageButton}
     </Flex>
   );
 };

--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -1,17 +1,20 @@
 import type { PinProfile } from 'oa-shared';
-import { Avatar, Box, Flex } from 'theme-ui';
+import { Avatar, Box, Flex, Text } from 'theme-ui';
 import defaultProfileImage from '../../assets/images/default_member.svg';
 import { MemberBadge } from '../MemberBadge/MemberBadge';
 import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
-import { Username } from '../Username/Username';
+import { DisplayName } from '../Username/DisplayName';
 
 interface IProps {
   profile: PinProfile;
   isLink: boolean;
+  variant?: 'pin' | 'list';
 }
 
-export const CardDetailsMemberProfile = ({ profile, isLink }: IProps) => {
+export const CardDetailsMemberProfile = ({ profile, isLink, variant = 'pin' }: IProps) => {
   const photoUrl = profile.photo?.publicUrl;
+  const aboutText =
+    profile.about && profile.about.length > 80 ? profile.about.slice(0, 78) + '...' : profile.about;
 
   return (
     <Flex
@@ -19,38 +22,71 @@ export const CardDetailsMemberProfile = ({ profile, isLink }: IProps) => {
       sx={{
         gap: 2,
         justifyContent: 'center',
-        alignItems: 'center',
-        padding: 2,
+        alignItems: 'start',
+        p: 3,
         alignContent: 'stretch',
+        flexDirection: 'column',
       }}
     >
-      <Box sx={{ aspectRatio: 1, width: '60px', height: '60px' }}>
-        <Flex
+      <Flex sx={{ gap: 2, alignItems: 'center' }}>
+        <Box sx={{ aspectRatio: 1, width: '60px', height: '60px' }}>
+          <Flex
+            sx={{
+              alignContent: 'flex-start',
+              justifyContent: 'flex-end',
+              flexWrap: 'wrap',
+            }}
+          >
+            <Avatar
+              src={photoUrl || defaultProfileImage}
+              sx={{ width: '60px', height: '60px', objectFit: 'cover' }}
+              loading="lazy"
+            />
+            <MemberBadge
+              profileType={profile.type || undefined}
+              size={22}
+              sx={{ transform: 'translateY(-22px)' }}
+            />
+          </Flex>
+        </Box>
+        <Flex sx={{ flexDirection: 'column' }}>
+          <DisplayName
+            user={profile}
+            sx={{ alignSelf: 'flex-start' }}
+            isLink={isLink}
+            target="_blank"
+          />
+          {variant == 'list' && (
+            <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
+              {profile.tags && profile.tags.length > 0 && (
+                <ProfileTagsList tags={profile.tags} isSpace={false} />
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+      {variant == 'pin' && (
+        <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
+          {profile.tags && profile.tags.length > 0 && (
+            <ProfileTagsList tags={profile.tags} isSpace={false} />
+          )}
+        </Flex>
+      )}
+      {variant == 'pin' && aboutText && (
+        <Text
+          variant="quiet"
           sx={{
-            alignContent: 'flex-start',
-            justifyContent: 'flex-end',
-            flexWrap: 'wrap',
+            fontSize: 2,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
           }}
         >
-          <Avatar
-            src={photoUrl || defaultProfileImage}
-            sx={{ width: '60px', height: '60px', objectFit: 'cover' }}
-            loading="lazy"
-          />
-          <MemberBadge
-            profileType={profile.type || undefined}
-            size={22}
-            sx={{ transform: 'translateY(-22px)' }}
-          />
-        </Flex>
-      </Box>
-
-      <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
-        <Username user={profile} sx={{ alignSelf: 'flex-start' }} isLink={isLink} target="_blank" />
-        {profile.tags && profile.tags.length > 0 && (
-          <ProfileTagsList tags={profile.tags} isSpace={false} />
-        )}
-      </Flex>
+          {aboutText}
+        </Text>
+      )}
     </Flex>
   );
 };

--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -5,22 +5,23 @@ import { MemberBadge } from '../MemberBadge/MemberBadge';
 import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
 import { DisplayName } from '../Username/DisplayName';
 import type { CardVariant } from './CardProfile';
+import { SendMessageButton } from './SendMessageButton';
 
 interface IProps {
-  cardVariant?: CardVariant;
+  variant: CardVariant;
   item: MapPin;
   isLink: boolean;
-  sendMessageButton?: React.ReactNode;
 }
 
-export const CardDetailsMemberProfile = ({
-  cardVariant,
-  item,
-  isLink,
-  sendMessageButton,
-}: IProps) => {
+export const CardDetailsMemberProfile = ({ variant, item, isLink }: IProps) => {
   const { profile } = item;
   const photoUrl = profile.photo?.publicUrl;
+  const tagsBlock =
+    profile.tags && profile.tags.length > 0 ? (
+      <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
+        <ProfileTagsList tags={profile.tags} isSpace={false} />
+      </Flex>
+    ) : null;
 
   return (
     <Flex
@@ -62,23 +63,11 @@ export const CardDetailsMemberProfile = ({
             isLink={isLink}
             target="_blank"
           />
-          {cardVariant === 'list' && (
-            <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
-              {profile.tags && profile.tags.length > 0 && (
-                <ProfileTagsList tags={profile.tags} isSpace={false} />
-              )}
-            </Flex>
-          )}
+          {variant === 'list' && tagsBlock}
         </Flex>
       </Flex>
-      {cardVariant === 'pin' && (
-        <Flex sx={{ flexDirection: 'column', gap: 1, flex: 1, minWidth: 0, pt: 1 }}>
-          {profile.tags && profile.tags.length > 0 && (
-            <ProfileTagsList tags={profile.tags} isSpace={false} />
-          )}
-        </Flex>
-      )}
-      {cardVariant === 'pin' && profile.about && (
+      {variant === 'pin' && tagsBlock}
+      {variant === 'pin' && profile.about && (
         <Text
           variant="quiet"
           sx={{
@@ -93,7 +82,7 @@ export const CardDetailsMemberProfile = ({
           {profile.about}
         </Text>
       )}
-      {sendMessageButton}
+      {variant === 'pin' && <SendMessageButton item={item} />}
     </Flex>
   );
 };

--- a/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
@@ -1,8 +1,9 @@
 import type { PinProfile } from 'oa-shared';
-import { Box, Flex, Image, Text } from 'theme-ui';
+import { Avatar, Box, Flex, Image, Text } from 'theme-ui';
+import defaultProfileImage from '../../assets/images/default_member.svg';
 import { MemberBadge } from '../MemberBadge/MemberBadge';
 import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
-import { Username } from '../Username/Username';
+import { DisplayName } from '../Username/DisplayName';
 
 interface IProps {
   profile: PinProfile;
@@ -33,36 +34,45 @@ export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
               loading="lazy"
             />
           </Flex>
-          <Box
-            sx={{
-              position: 'relative',
-              height: 0,
-              top: '-20px',
-              width: '100%',
-            }}
-          >
-            <MemberBadge
-              profileType={profile.type || undefined}
-              size={40}
-              sx={{
-                float: 'right',
-                marginX: 2,
-              }}
-            />
-          </Box>
         </>
       )}
       <Flex
         sx={{
           alignItems: 'flex-start',
           flexDirection: 'column',
-          gap: 1,
-          padding: 2,
+          gap: 2,
+          p: 3,
         }}
       >
-        <Flex sx={{ gap: 2, minWidth: 0, width: '100%' }}>
-          {!hasImage && <MemberBadge profileType={profile.type || undefined} size={30} />}
-          <Username
+        <Flex sx={{ gap: 2, minWidth: 0, width: '100%', alignItems: 'end' }}>
+          <Box
+            sx={{
+              position: 'relative',
+              width: '80px',
+              height: '80px',
+              flexShrink: 0,
+              marginTop: '-40px',
+            }}
+          >
+            <Avatar
+              src={profileUrl || defaultProfileImage}
+              sx={{
+                width: '80px',
+                height: '80px',
+                objectFit: 'cover',
+                flexShrink: 0,
+                border: '3px solid white',
+                boxSizing: 'border-box',
+              }}
+              loading="lazy"
+            />
+            <MemberBadge
+              profileType={profile.type || undefined}
+              size={22}
+              sx={{ position: 'absolute', bottom: 0, right: 0, m: '3px' }}
+            />
+          </Box>
+          <DisplayName
             user={profile}
             sx={{ alignSelf: 'flex-start' }}
             isLink={isLink}
@@ -75,7 +85,17 @@ export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
         )}
 
         {aboutText && (
-          <Text variant="quiet" sx={{ fontSize: 2, wordBreak: 'break-word' }}>
+          <Text
+            variant="quiet"
+            sx={{
+              fontSize: 2,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              wordBreak: 'break-word',
+            }}
+          >
             {aboutText}
           </Text>
         )}

--- a/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
@@ -4,14 +4,16 @@ import defaultProfileImage from '../../assets/images/default_member.svg';
 import { MemberBadge } from '../MemberBadge/MemberBadge';
 import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
 import { DisplayName } from '../Username/DisplayName';
+import type { CardVariant } from './CardProfile';
+import { SendMessageButton } from './SendMessageButton';
 
 interface IProps {
   item: MapPin;
   isLink: boolean;
-  sendMessageButton?: React.ReactNode;
+  variant: CardVariant;
 }
 
-export const CardDetailsSpaceProfile = ({ item, isLink, sendMessageButton }: IProps) => {
+export const CardDetailsSpaceProfile = ({ item, isLink, variant }: IProps) => {
   const { profile } = item;
   const coverImage =
     profile.coverImages && profile.coverImages[0] && profile.coverImages[0]?.publicUrl;
@@ -98,7 +100,7 @@ export const CardDetailsSpaceProfile = ({ item, isLink, sendMessageButton }: IPr
             {profile.about}
           </Text>
         )}
-        {sendMessageButton}
+        {variant === 'pin' && <SendMessageButton item={item} />}
       </Flex>
     </Flex>
   );

--- a/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
@@ -1,4 +1,4 @@
-import type { PinProfile } from 'oa-shared';
+import type { MapPin } from 'oa-shared';
 import { Avatar, Box, Flex, Image, Text } from 'theme-ui';
 import defaultProfileImage from '../../assets/images/default_member.svg';
 import { MemberBadge } from '../MemberBadge/MemberBadge';
@@ -6,18 +6,17 @@ import { ProfileTagsList } from '../ProfileTagsList/ProfileTagsList';
 import { DisplayName } from '../Username/DisplayName';
 
 interface IProps {
-  profile: PinProfile;
+  item: MapPin;
   isLink: boolean;
+  sendMessageButton?: React.ReactNode;
 }
 
-export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
+export const CardDetailsSpaceProfile = ({ item, isLink, sendMessageButton }: IProps) => {
+  const { profile } = item;
   const coverImage =
     profile.coverImages && profile.coverImages[0] && profile.coverImages[0]?.publicUrl;
   const profileUrl = profile.photo?.publicUrl;
   const hasImage = coverImage || profileUrl;
-
-  const aboutText =
-    profile.about && profile.about.length > 80 ? profile.about.slice(0, 78) + '...' : profile.about;
 
   return (
     <Flex data-testid="CardDetailsSpaceProfile" sx={{ flexDirection: 'column', width: '100%' }}>
@@ -73,7 +72,7 @@ export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
             />
           </Box>
           <DisplayName
-            user={profile}
+            user={{ ...profile, country: item.country }}
             sx={{ alignSelf: 'flex-start' }}
             isLink={isLink}
             target="_blank"
@@ -84,7 +83,7 @@ export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
           <ProfileTagsList tags={profile.tags} isSpace={true} />
         )}
 
-        {aboutText && (
+        {profile.about && (
           <Text
             variant="quiet"
             sx={{
@@ -96,9 +95,10 @@ export const CardDetailsSpaceProfile = ({ profile, isLink }: IProps) => {
               wordBreak: 'break-word',
             }}
           >
-            {aboutText}
+            {profile.about}
           </Text>
         )}
+        {sendMessageButton}
       </Flex>
     </Flex>
   );

--- a/packages/components/src/CardProfile/CardProfile.tsx
+++ b/packages/components/src/CardProfile/CardProfile.tsx
@@ -6,9 +6,10 @@ import { CardDetailsSpaceProfile } from './CardDetailsSpaceProfile';
 export interface IProps {
   item: MapPin;
   isLink?: boolean;
+  variant?: 'pin' | 'list';
 }
 
-export const CardProfile = ({ item, isLink = false }: IProps) => {
+export const CardProfile = ({ item, isLink = false, variant }: IProps) => {
   const { profile } = item;
 
   const isWorkspace = profile?.type && profile?.type.isSpace;
@@ -18,7 +19,7 @@ export const CardProfile = ({ item, isLink = false }: IProps) => {
       {isWorkspace ? (
         <CardDetailsSpaceProfile profile={profile} isLink={isLink} />
       ) : (
-        <CardDetailsMemberProfile profile={profile} isLink={isLink} />
+        <CardDetailsMemberProfile profile={profile} isLink={isLink} variant={variant} />
       )}
     </Flex>
   );

--- a/packages/components/src/CardProfile/CardProfile.tsx
+++ b/packages/components/src/CardProfile/CardProfile.tsx
@@ -3,23 +3,36 @@ import { Flex } from 'theme-ui';
 import { CardDetailsMemberProfile } from './CardDetailsMemberProfile';
 import { CardDetailsSpaceProfile } from './CardDetailsSpaceProfile';
 
+export type CardVariant = 'pin' | 'list';
+
 export interface IProps {
+  cardVariant?: CardVariant;
   item: MapPin;
   isLink?: boolean;
-  variant?: 'pin' | 'list';
+  sendMessageButton?: React.ReactNode;
 }
 
-export const CardProfile = ({ item, isLink = false, variant }: IProps) => {
-  const { profile } = item;
-
-  const isWorkspace = profile?.type && profile?.type.isSpace;
+export const CardProfile = ({
+  cardVariant = 'pin',
+  item,
+  isLink = false,
+  sendMessageButton,
+}: IProps) => {
+  const isWorkspace = item.profile?.type && item.profile?.type.isSpace;
+  const isContactable = item.profile?.isContactable !== false && item.profile?.username;
+  const messageButton = isContactable ? sendMessageButton : undefined;
 
   return (
     <Flex sx={{ alignItems: 'stretch', alignContent: 'stretch' }}>
       {isWorkspace ? (
-        <CardDetailsSpaceProfile profile={profile} isLink={isLink} />
+        <CardDetailsSpaceProfile item={item} isLink={isLink} sendMessageButton={messageButton} />
       ) : (
-        <CardDetailsMemberProfile profile={profile} isLink={isLink} variant={variant} />
+        <CardDetailsMemberProfile
+          item={item}
+          isLink={isLink}
+          cardVariant={cardVariant}
+          sendMessageButton={messageButton}
+        />
       )}
     </Flex>
   );

--- a/packages/components/src/CardProfile/CardProfile.tsx
+++ b/packages/components/src/CardProfile/CardProfile.tsx
@@ -6,33 +6,20 @@ import { CardDetailsSpaceProfile } from './CardDetailsSpaceProfile';
 export type CardVariant = 'pin' | 'list';
 
 export interface IProps {
-  cardVariant?: CardVariant;
+  variant?: CardVariant;
   item: MapPin;
   isLink?: boolean;
-  sendMessageButton?: React.ReactNode;
 }
 
-export const CardProfile = ({
-  cardVariant = 'pin',
-  item,
-  isLink = false,
-  sendMessageButton,
-}: IProps) => {
+export const CardProfile = ({ variant = 'pin', item, isLink = false }: IProps) => {
   const isWorkspace = item.profile?.type && item.profile?.type.isSpace;
-  const isContactable = item.profile?.isContactable !== false && item.profile?.username;
-  const messageButton = isContactable ? sendMessageButton : undefined;
 
   return (
     <Flex sx={{ alignItems: 'stretch', alignContent: 'stretch' }}>
       {isWorkspace ? (
-        <CardDetailsSpaceProfile item={item} isLink={isLink} sendMessageButton={messageButton} />
+        <CardDetailsSpaceProfile item={item} isLink={isLink} variant={variant} />
       ) : (
-        <CardDetailsMemberProfile
-          item={item}
-          isLink={isLink}
-          cardVariant={cardVariant}
-          sendMessageButton={messageButton}
-        />
+        <CardDetailsMemberProfile item={item} isLink={isLink} variant={variant} />
       )}
     </Flex>
   );

--- a/packages/components/src/CardProfile/SendMessageButton.tsx
+++ b/packages/components/src/CardProfile/SendMessageButton.tsx
@@ -1,0 +1,23 @@
+import type { MapPin } from 'oa-shared';
+import { Button } from '../Button/Button';
+import { InternalLink } from '../InternalLink/InternalLink';
+
+interface IProps {
+  item: MapPin;
+}
+
+export const SendMessageButton = ({ item }: IProps) => {
+  const isContactable = (item.profile?.isContactable ?? true) && item.profile?.username;
+  return isContactable ? (
+    <InternalLink
+      sx={{ alignSelf: 'flex-end' }}
+      to={`/u/${item.profile?.username}#contact`}
+      data-cy="PinProfileMessageLink"
+      target="_blank"
+    >
+      <Button icon="contact" small>
+        Send Message
+      </Button>
+    </InternalLink>
+  ) : null;
+};

--- a/packages/components/src/FlagIcon/FlagIcon.tsx
+++ b/packages/components/src/FlagIcon/FlagIcon.tsx
@@ -2,11 +2,9 @@ import { ReactCountryFlag } from 'react-country-flag';
 
 interface IProps {
   countryCode: string;
-  height?: string;
-  width?: string;
 }
 
-export const FlagIcon = ({ countryCode, height = '14px', width = '21px' }: IProps) => {
+export const FlagIcon = ({ countryCode }: IProps) => {
   return (
     <ReactCountryFlag
       data-cy={`country:${countryCode}`}
@@ -16,8 +14,8 @@ export const FlagIcon = ({ countryCode, height = '14px', width = '21px' }: IProp
       style={{
         borderRadius: '3px',
         backgroundSize: 'cover',
-        height,
-        width,
+        width: '21px',
+        height: '14px',
       }}
     />
   );

--- a/packages/components/src/FlagIcon/FlagIcon.tsx
+++ b/packages/components/src/FlagIcon/FlagIcon.tsx
@@ -2,9 +2,11 @@ import { ReactCountryFlag } from 'react-country-flag';
 
 interface IProps {
   countryCode: string;
+  height?: string;
+  width?: string;
 }
 
-export const FlagIcon = ({ countryCode }: IProps) => {
+export const FlagIcon = ({ countryCode, height = '14px', width = '21px' }: IProps) => {
   return (
     <ReactCountryFlag
       data-cy={`country:${countryCode}`}
@@ -14,8 +16,8 @@ export const FlagIcon = ({ countryCode }: IProps) => {
       style={{
         borderRadius: '3px',
         backgroundSize: 'cover',
-        height: '14px',
-        width: '21px',
+        height,
+        width,
       }}
     />
   );

--- a/packages/components/src/MapCardList/MapCardList.tsx
+++ b/packages/components/src/MapCardList/MapCardList.tsx
@@ -4,11 +4,9 @@ import { useEffect, useState } from 'react';
 import { Box, Flex, Text } from 'theme-ui';
 import { Button } from '../Button/Button';
 import { CardListItem } from '../CardListItem/CardListItem';
-import type { CardVariant } from '../CardProfile/CardProfile';
 import { Icon } from '../Icon/Icon';
 
 export interface IProps {
-  cardVariant?: CardVariant;
   list: MapPin[];
   onPinClick: (arg: MapPin) => void;
   selectedPin?: MapPin | null;
@@ -21,7 +19,7 @@ const ITEMS_PER_RENDER = 20;
 export const MapCardList = (props: IProps) => {
   const [renderCount, setRenderCount] = useState<number>(ITEMS_PER_RENDER);
   const [displayItems, setDisplayItems] = useState<JSX.Element[]>([]);
-  const { cardVariant = 'list', list, onPinClick, selectedPin, viewport } = props;
+  const { list, onPinClick, selectedPin, viewport } = props;
 
   useEffect(() => {
     setRenderCount(ITEMS_PER_RENDER);
@@ -33,7 +31,6 @@ export const MapCardList = (props: IProps) => {
 
       return (
         <CardListItem
-          cardVariant={cardVariant}
           item={item}
           key={item.id}
           isSelectedPin={isSelectedPin}
@@ -44,7 +41,7 @@ export const MapCardList = (props: IProps) => {
     });
 
     setDisplayItems(toRender);
-  }, [renderCount, list, cardVariant]);
+  }, [renderCount, list]);
 
   const addRenderItems = () => setRenderCount((count) => count + ITEMS_PER_RENDER);
 

--- a/packages/components/src/MapCardList/MapCardList.tsx
+++ b/packages/components/src/MapCardList/MapCardList.tsx
@@ -65,9 +65,9 @@ export const MapCardList = (props: IProps) => {
         <>
           <Box
             sx={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
-              gap: 0,
+              columnWidth: '240px',
+              columnGap: 0,
+              '& > *': { breakInside: 'avoid' },
             }}
           >
             {displayItems}

--- a/packages/components/src/MapCardList/MapCardList.tsx
+++ b/packages/components/src/MapCardList/MapCardList.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from 'react';
 import { Box, Flex, Text } from 'theme-ui';
 import { Button } from '../Button/Button';
 import { CardListItem } from '../CardListItem/CardListItem';
+import type { CardVariant } from '../CardProfile/CardProfile';
 import { Icon } from '../Icon/Icon';
 
 export interface IProps {
+  cardVariant?: CardVariant;
   list: MapPin[];
   onPinClick: (arg: MapPin) => void;
   selectedPin?: MapPin | null;
@@ -19,7 +21,7 @@ const ITEMS_PER_RENDER = 20;
 export const MapCardList = (props: IProps) => {
   const [renderCount, setRenderCount] = useState<number>(ITEMS_PER_RENDER);
   const [displayItems, setDisplayItems] = useState<JSX.Element[]>([]);
-  const { list, onPinClick, selectedPin, viewport } = props;
+  const { cardVariant = 'list', list, onPinClick, selectedPin, viewport } = props;
 
   useEffect(() => {
     setRenderCount(ITEMS_PER_RENDER);
@@ -31,18 +33,18 @@ export const MapCardList = (props: IProps) => {
 
       return (
         <CardListItem
+          cardVariant={cardVariant}
           item={item}
           key={item.id}
           isSelectedPin={isSelectedPin}
           onPinClick={onPinClick}
-          variant="list"
           viewport={viewport}
         />
       );
     });
 
     setDisplayItems(toRender);
-  }, [renderCount, list]);
+  }, [renderCount, list, cardVariant]);
 
   const addRenderItems = () => setRenderCount((count) => count + ITEMS_PER_RENDER);
 

--- a/packages/components/src/MapCardList/MapCardList.tsx
+++ b/packages/components/src/MapCardList/MapCardList.tsx
@@ -35,6 +35,7 @@ export const MapCardList = (props: IProps) => {
           key={item.id}
           isSelectedPin={isSelectedPin}
           onPinClick={onPinClick}
+          variant="list"
           viewport={viewport}
         />
       );
@@ -62,7 +63,13 @@ export const MapCardList = (props: IProps) => {
       {isListEmpty && EMPTY_LIST}
       {!isListEmpty && (
         <>
-          <Box sx={{ columnCount: [1, 2, 2, 3], columnGap: 0, '& > *': { breakInside: 'avoid' } }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+              gap: 0,
+            }}
+          >
             {displayItems}
           </Box>
           {hasMore && (

--- a/packages/components/src/PinProfile/PinProfile.stories.tsx
+++ b/packages/components/src/PinProfile/PinProfile.stories.tsx
@@ -36,7 +36,7 @@ export const DefaultMember: StoryFn<typeof PinProfile> = () => {
 
   return (
     <div style={{ width: '230px', position: 'fixed' }}>
-      <PinProfile item={item} onClose={() => console.log()} />
+      <PinProfile item={item} />
     </div>
   );
 };
@@ -79,7 +79,7 @@ export const DefaultSpace: StoryFn<typeof PinProfile> = () => {
 
   return (
     <div style={{ width: '230px', position: 'fixed' }}>
-      <PinProfile item={item} onClose={() => console.log()} />
+      <PinProfile item={item} />
     </div>
   );
 };

--- a/packages/components/src/PinProfile/PinProfile.tsx
+++ b/packages/components/src/PinProfile/PinProfile.tsx
@@ -1,42 +1,33 @@
 import type { MapPin } from 'oa-shared';
 import { Box, Flex } from 'theme-ui';
 import { Button } from '../Button/Button';
-import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
 import { CardButton } from '../CardButton/CardButton';
 import { CardProfile } from '../CardProfile/CardProfile';
 import { InternalLink } from '../InternalLink/InternalLink';
 
 export interface IProps {
   item: MapPin;
-  onClose: () => void;
 }
 
-export const PinProfile = ({ item, onClose }: IProps) => {
+export const PinProfile = ({ item }: IProps) => {
   const isContactable = item.profile?.isContactable !== false && item.profile?.username;
 
   return (
-    <CardButton sx={{ '&:hover': 'none' }} data-cy="PinProfile">
-      <Box sx={{ position: 'absolute', right: 0 }}>
-        <Box sx={{ float: 'right', marginTop: 1, marginRight: '8px' }}>
-          <ButtonIcon
-            data-cy="PinProfileCloseButton"
-            icon="close"
-            onClick={() => onClose()}
-            sx={{ borderWidth: 0, height: 'auto' }}
-          />
-        </Box>
-      </Box>
+    <CardButton
+      extrastyles={{ '&:hover': {}, '&:active': {}, width: '325px' }}
+      data-cy="PinProfile"
+    >
       <Box sx={{ width: '100%', height: '100%', zIndex: 2 }}>
         <CardProfile item={item} isLink />
 
         {isContactable && (
-          <Flex sx={{ justifyContent: 'flex-end' }}>
+          <Flex sx={{ justifyContent: 'flex-end', pr: 3, pb: 3 }}>
             <InternalLink
               to={`/u/${item.profile?.username}#contact`}
               data-cy="PinProfileMessageLink"
               target="_blank"
             >
-              <Button icon="contact" sx={{ margin: 1 }} small>
+              <Button icon="contact" small>
                 Send Message
               </Button>
             </InternalLink>

--- a/packages/components/src/PinProfile/PinProfile.tsx
+++ b/packages/components/src/PinProfile/PinProfile.tsx
@@ -1,5 +1,5 @@
 import type { MapPin } from 'oa-shared';
-import { Box, Flex } from 'theme-ui';
+import { Box } from 'theme-ui';
 import { Button } from '../Button/Button';
 import { CardButton } from '../CardButton/CardButton';
 import { CardProfile } from '../CardProfile/CardProfile';
@@ -10,7 +10,18 @@ export interface IProps {
 }
 
 export const PinProfile = ({ item }: IProps) => {
-  const isContactable = item.profile?.isContactable !== false && item.profile?.username;
+  const sendMessageButton = (
+    <InternalLink
+      sx={{ alignSelf: 'flex-end' }}
+      to={`/u/${item.profile?.username}#contact`}
+      data-cy="PinProfileMessageLink"
+      target="_blank"
+    >
+      <Button icon="contact" small>
+        Send Message
+      </Button>
+    </InternalLink>
+  );
 
   return (
     <CardButton
@@ -18,21 +29,7 @@ export const PinProfile = ({ item }: IProps) => {
       data-cy="PinProfile"
     >
       <Box sx={{ width: '100%', height: '100%', zIndex: 2 }}>
-        <CardProfile item={item} isLink />
-
-        {isContactable && (
-          <Flex sx={{ justifyContent: 'flex-end', pr: 3, pb: 3 }}>
-            <InternalLink
-              to={`/u/${item.profile?.username}#contact`}
-              data-cy="PinProfileMessageLink"
-              target="_blank"
-            >
-              <Button icon="contact" small>
-                Send Message
-              </Button>
-            </InternalLink>
-          </Flex>
-        )}
+        <CardProfile item={item} isLink sendMessageButton={sendMessageButton} />
       </Box>
     </CardButton>
   );

--- a/packages/components/src/PinProfile/PinProfile.tsx
+++ b/packages/components/src/PinProfile/PinProfile.tsx
@@ -1,35 +1,20 @@
 import type { MapPin } from 'oa-shared';
 import { Box } from 'theme-ui';
-import { Button } from '../Button/Button';
 import { CardButton } from '../CardButton/CardButton';
 import { CardProfile } from '../CardProfile/CardProfile';
-import { InternalLink } from '../InternalLink/InternalLink';
 
 export interface IProps {
   item: MapPin;
 }
 
 export const PinProfile = ({ item }: IProps) => {
-  const sendMessageButton = (
-    <InternalLink
-      sx={{ alignSelf: 'flex-end' }}
-      to={`/u/${item.profile?.username}#contact`}
-      data-cy="PinProfileMessageLink"
-      target="_blank"
-    >
-      <Button icon="contact" small>
-        Send Message
-      </Button>
-    </InternalLink>
-  );
-
   return (
     <CardButton
       extrastyles={{ '&:hover': {}, '&:active': {}, width: '325px' }}
       data-cy="PinProfile"
     >
       <Box sx={{ width: '100%', height: '100%', zIndex: 2 }}>
-        <CardProfile item={item} isLink sendMessageButton={sendMessageButton} />
+        <CardProfile item={item} isLink />
       </Box>
     </CardButton>
   );

--- a/packages/components/src/ProfileTagsList/ProfileTagsList.tsx
+++ b/packages/components/src/ProfileTagsList/ProfileTagsList.tsx
@@ -32,7 +32,7 @@ const Tag = ({ color, dataCy, label, large, onClick }: TagProps) => {
     : {
         fontSize: 1,
         paddingX: '7.5px',
-        paddingY: '5px',
+        paddingY: '2px',
       };
   return (
     <Text

--- a/packages/components/src/Username/DisplayName.tsx
+++ b/packages/components/src/Username/DisplayName.tsx
@@ -21,26 +21,41 @@ export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProp
   const DisplayNameBody = (
     <Flex
       data-cy="DisplayName"
-      sx={{ fontFamily: 'body', gap: 1, alignItems: 'center', minWidth: 0 }}
+      sx={{
+        fontFamily: 'title',
+        gap: 1,
+        alignItems: 'start',
+        minWidth: 0,
+        flexDirection: 'row',
+        paddingY: '3px',
+      }}
     >
-      <Text
-        sx={{
-          color: 'black',
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
-        }}
-        title={displayName || username || ''}
-      >
-        {displayName || username}
-      </Text>
+      <Flex sx={{ flexDirection: 'column', gap: 1 }}>
+        <Flex>
+          <Text
+            sx={{
+              color: 'black',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+            title={displayName || username || ''}
+          >
+            {displayName || username}
+          </Text>
 
-      {badges &&
-        badges.map((badge) => {
-          return <UserBadge key={badge.id} badge={badge} />;
-        })}
-
-      {countryCode && <FlagIcon countryCode={countryCode} />}
+          {badges &&
+            badges.map((badge) => {
+              return <UserBadge key={badge.id} badge={badge} />;
+            })}
+        </Flex>
+        <Flex sx={{ gap: 1, alignItems: 'center' }}>
+          {countryCode && <FlagIcon countryCode={countryCode} width="13.33px" height="10px" />}
+          <Text sx={{ color: 'grey', fontSize: 1, fontFamily: 'body', lineHeight: '100%' }}>
+            {country}
+          </Text>
+        </Flex>
+      </Flex>
     </Flex>
   );
 
@@ -58,7 +73,6 @@ export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProp
         minWidth: 0,
         overflow: 'hidden',
         paddingX: 1,
-        paddingY: '3px',
         borderRadius: 1,
         marginLeft: -1,
         color: 'black',

--- a/packages/components/src/Username/DisplayName.tsx
+++ b/packages/components/src/Username/DisplayName.tsx
@@ -30,7 +30,7 @@ export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProp
         paddingY: '3px',
       }}
     >
-      <Flex sx={{ flexDirection: 'column', gap: 1 }}>
+      <Flex sx={{ flexDirection: 'column' }}>
         <Flex>
           <Text
             sx={{
@@ -49,12 +49,21 @@ export const DisplayName = ({ user, sx, target, isLink = true }: DisplayNameProp
               return <UserBadge key={badge.id} badge={badge} />;
             })}
         </Flex>
-        <Flex sx={{ gap: 1, alignItems: 'center' }}>
-          {countryCode && <FlagIcon countryCode={countryCode} width="13.33px" height="10px" />}
-          <Text sx={{ color: 'grey', fontSize: 1, fontFamily: 'body', lineHeight: '100%' }}>
-            {country}
-          </Text>
-        </Flex>
+        {countryCode && (
+          <Flex sx={{ alignItems: 'center', gap: 1, pt: 1 }}>
+            <FlagIcon countryCode={countryCode} />
+            <Text
+              sx={{
+                color: 'grey',
+                fontSize: 1,
+                fontFamily: 'body',
+                lineHeight: '100%',
+              }}
+            >
+              {country}
+            </Text>
+          </Flex>
+        )}
       </Flex>
     </Flex>
   );

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -10,6 +10,7 @@ export { ButtonIcon } from './ButtonIcon/ButtonIcon';
 export { ButtonShowReplies } from './ButtonShowReplies/ButtonShowReplies';
 export { CardButton } from './CardButton/CardButton';
 export { CardListItem } from './CardListItem/CardListItem';
+export type { CardVariant } from './CardProfile/CardProfile';
 export { CardProfile } from './CardProfile/CardProfile';
 export { Category } from './Category/Category';
 export { CategoryHorizonalList } from './CategoryHorizonalList/CategoryHorizonalList';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -10,7 +10,6 @@ export { ButtonIcon } from './ButtonIcon/ButtonIcon';
 export { ButtonShowReplies } from './ButtonShowReplies/ButtonShowReplies';
 export { CardButton } from './CardButton/CardButton';
 export { CardListItem } from './CardListItem/CardListItem';
-export type { CardVariant } from './CardProfile/CardProfile';
 export { CardProfile } from './CardProfile/CardProfile';
 export { Category } from './Category/Category';
 export { CategoryHorizonalList } from './CategoryHorizonalList/CategoryHorizonalList';

--- a/src/pages/Maps/Content/MapView/MapView.tsx
+++ b/src/pages/Maps/Content/MapView/MapView.tsx
@@ -67,10 +67,6 @@ export const MapView = () => {
     [fitBounds],
   );
 
-  const handlePinClose = useCallback(() => {
-    selectPin?.(null);
-  }, [selectPin]);
-
   if (!mapState) {
     return null;
   }
@@ -136,9 +132,7 @@ export const MapView = () => {
             clusterGroupRef={clusterGroupRef}
           />
         )}
-        {mapState.selectedPin && (
-          <Popup activePin={mapState.selectedPin} mapRef={mapRef} onClose={handlePinClose} />
-        )}
+        {mapState.selectedPin && <Popup activePin={mapState.selectedPin} mapRef={mapRef} />}
       </Map>
     </Box>
   );

--- a/src/pages/Maps/Content/MapView/Popup.client.tsx
+++ b/src/pages/Maps/Content/MapView/Popup.client.tsx
@@ -10,13 +10,12 @@ import './popup.css';
 interface IProps {
   activePin: MapPin;
   mapRef: React.RefObject<LeafletMap | null>;
-  onClose?: () => void;
   customPosition?: ILatLng;
 }
 
 export const Popup = (props: IProps) => {
   const leafletRef = useRef<LeafletPopupType>(null);
-  const { mapRef, onClose, customPosition } = props;
+  const { mapRef, customPosition } = props;
 
   useEffect(() => {
     openPopup();
@@ -41,12 +40,12 @@ export const Popup = (props: IProps) => {
       offset={new Point(2, -10)}
       closeOnClick={false}
       closeOnEscapeKey={false}
-      closeButton={false}
+      closeButton={true}
       minWidth={250}
       maxWidth={300}
       autoPan={false}
     >
-      {onClose && <PinProfile item={props.activePin} onClose={onClose} />}
+      <PinProfile item={props.activePin} />
     </LeafletPopup>
   );
 };

--- a/src/pages/Maps/Content/MapView/Popup.client.tsx
+++ b/src/pages/Maps/Content/MapView/Popup.client.tsx
@@ -42,7 +42,7 @@ export const Popup = (props: IProps) => {
       closeOnEscapeKey={false}
       closeButton={false}
       minWidth={250}
-      maxWidth={300}
+      maxWidth={325}
       autoPan={false}
     >
       <PinProfile item={props.activePin} />

--- a/src/pages/Maps/Content/MapView/Popup.client.tsx
+++ b/src/pages/Maps/Content/MapView/Popup.client.tsx
@@ -40,7 +40,7 @@ export const Popup = (props: IProps) => {
       offset={new Point(2, -10)}
       closeOnClick={false}
       closeOnEscapeKey={false}
-      closeButton={true}
+      closeButton={false}
       minWidth={250}
       maxWidth={300}
       autoPan={false}


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [ ] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [x] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Three connected issues covering the Map view layout and both the map-pin popup cards and the list cards. Putting them together since they share components (`CardProfile`, `DisplayName`, `ProfileTagsList`).

### #4667 — Optimise the map view

The 50/50 Map/List split combined with breakpoint-driven columns (1, 2, 2, 3) was producing cramped cards around 850px and 1120px viewport widths. Replaced the `columnCount` layout in `MapCardList.tsx` with a CSS Grid using `repeat(auto-fill, minmax(240px, 1fr))`, and clamped each card to `minWidth: 230px` / `maxWidth: 400px` in `CardListItem.tsx`. Column count now adapts to available width instead of fixed breakpoints, and cards never get too narrow to read or absurdly wide on ultra-wide screens.

### #4668 — Improve the MAP PIN cards

Followed the Figma step-by-step for the pin popup:

- **Member pin card** (`CardDetailsMemberProfile.tsx`) — switched to a vertical layout: avatar + name/country block at the top, then tags, then a 2-line clamped `about` blurb. Fixed the card to `width: 325px` in `PinProfile.tsx` so the popup has a predictable footprint.
- **Space pin card** (`CardDetailsSpaceProfile.tsx`) — kept the full-bleed cover image, but dropped the old floating badge pattern and replaced it with an 80px avatar that overlaps the cover (`marginTop: -40px`, white border). The member badge now sits as a small overlay on the avatar corner. Same 2-line about clamp as the member card.
- Removed the custom close `ButtonIcon` from `PinProfile.tsx` and flipped `closeButton={true}` on the Leaflet popup in `Popup.client.tsx` — same affordance, less custom code.

### #4669 — Improve the LIST cards

List cards share `CardProfile` with pin cards but need a tighter layout. Added a `variant?: 'pin' | 'list'` prop threaded through `CardListItem.tsx` → `CardProfile.tsx` → `CardDetailsMemberProfile.tsx`. In `list` mode the tags render next to the avatar/name block and the `about` blurb is hidden, matching the Figma.

### Shared component touch-ups

- **`DisplayName.tsx`** — added a secondary row under the name showing the country flag + country label. Affects every `DisplayName` call site, not just the map — the Figma treats this as the new default.
- **`FlagIcon.tsx`** — added optional `width` / `height` props (defaults unchanged) so the smaller in-card flag can be requested.
- **`ProfileTagsList.tsx`** — reduced tag chip `paddingY` from 5px to 2px to match the Figma chip density. Also applies on the profile page; left as a global change since the Figma treats this as the new default.

### Open question for design

The Figma spec shows 13.33 × 10px for the flag. This is a 4:3 ratio, while country flags are typically 3:2 — @dalibormrska can you confirm this is intentional, or should it be 15 × 10?

### Screenshots

| iPhone 13 | iPad | Macbook | Desktop |
|---|---|---|---|
| <img width="250" alt="iPhone 13" src="https://github.com/user-attachments/assets/b018218e-77e6-49c6-8c7d-d5d682d49b53" /> | <img width="250" alt="iPad" src="https://github.com/user-attachments/assets/802f8896-f657-4ee0-bfa8-91692756ed14" /> | <img width="250" alt="Macbook" src="https://github.com/user-attachments/assets/3b135480-4576-4355-aacb-98f2b27a97ac" /> | <img width="250" alt="Desktop" src="https://github.com/user-attachments/assets/5986ca0e-6911-42a7-bdeb-067b0baca744" /> |




## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4667
Closes #4668
Closes #4669

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform \`development\` channel](https://discord.com/channels/586676777334865928/938781727017558018).