### PR TITLE
docs: fix broken Getting Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please make sure to read the [Contributing Guide](/CONTRIBUTING.md) before makin
 
 It also covers lots of handy additional information such as setting up a local server, or finding [good first issues](https://github.com/ONEARMY/community-platform/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue%22) to work on.
 
-To startup the project locally use `bun start`, but before that, follow [Getting Started](https://github.com/ONEARMY/community-platform/blob/master/docs/supabase.md)
+To startup the project locally use `bun start`, but before that, follow [Getting Started](/docs/supabase.md)
 
 If needed you can [drop us a line here](mailto:platform@onearmy.earth?subject=contact%20from%20github) 👋
 Or join our [Discord channel](https://discord.gg/gJ7Yyk4)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please make sure to read the [Contributing Guide](/CONTRIBUTING.md) before makin
 
 It also covers lots of handy additional information such as setting up a local server, or finding [good first issues](https://github.com/ONEARMY/community-platform/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue%22) to work on.
 
-To startup the project locally use `bun start`, but before that, follow [Getting Started](/packages/documentation/docs/supabase.md)
+To startup the project locally use `bun start`, but before that, follow [Getting Started](https://github.com/ONEARMY/community-platform/blob/master/docs/supabase.md)
 
 If needed you can [drop us a line here](mailto:platform@onearmy.earth?subject=contact%20from%20github) 👋
 Or join our [Discord channel](https://discord.gg/gJ7Yyk4)


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality

## What is the new behavior?

The `Getting Started` link in `README.md` previously pointed to `/packages/documentation/docs/supabase.md`, which 404s — that path no longer exists. Updated it to point to the actual location of the Supabase setup guide at `docs/supabase.md`, using a full GitHub URL to match the convention of other in-repo links in this README.

## Git Issues

Closes #