### PR TITLE
update helper to use string instead of share enum

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,4 @@
 import type { DBProfile, IModeration, Profile } from 'oa-shared';
-import { UserRole } from 'oa-shared';
 import { DEFAULT_PUBLIC_CONTACT_PREFERENCE } from 'src/pages/UserSettings/constants';
 
 const specialCharactersPattern = /[^a-zA-Z0-9_-]/gi;
@@ -60,7 +59,7 @@ export const hasAdminRights = (user?: DBProfile | Partial<Profile>) => {
   }
   const roles = user.roles && Array.isArray(user.roles) ? user.roles : [];
 
-  return roles.includes(UserRole.ADMIN);
+  return roles.includes('admin');
 };
 
 export const needsModeration = (doc: IModeration, user?: Profile) => {


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [ ] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Fresh dev environments failed to seed the database because `helpers.ts` imported the `UserRole` enum from `oa-shared` at runtime, which requires a build step. Replaced `UserRole.ADMIN` with the string literal `'admin'` since the seed script only reaches this module transitively and never calls the function that uses it.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No
