### PR TITLE
fix: decouple seed script from build

### DIFF
--- a/seed.ts
+++ b/seed.ts
@@ -27,7 +27,16 @@ import libraryJson from './.snaplet/library.json';
 import questionsJson from './.snaplet/questions.json';
 import { profilesSeed } from './seed/profilesSeed';
 import { usersSeed } from './seed/usersSeed';
-import { convertToSlug } from './src/utils/slug';
+
+// Copied from the helper to decouple the seed script from any app builing processes
+export const convertToSlug = (text: string) => {
+  const specialCharactersPattern = /[^a-zA-Z0-9_-]/gi;
+  const stripSpecialCharacters = (text: string) => {
+    return text ? text.split(' ').join('-').replace(specialCharactersPattern, '') : '';
+  };
+
+  return stripSpecialCharacters(text).toLowerCase();
+};
 
 const tenant_id = `precious-plastic`;
 


### PR DESCRIPTION
I was getting the below error when running `bun run db:seed` (specifically the `npx tsx seed.ts > seed.sql` part of it):

```
/Users/benfurber/projects/community-platform/src/utils/helpers.ts:2
import { UserRole } from 'oa-shared';
         ^

SyntaxError: The requested module 'oa-shared' does not provide an export named 'UserRole'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)

Node.js v22.18.0
```

I spent some time trying to work out an ordering problem or build problem within the flow but in the end decided just to decouple the app helpers from the seed script. 