### PR TITLE
Keep email after failed sign-in attempt

### DIFF
--- a/packages/cypress/src/integration/SignIn.spec.ts
+++ b/packages/cypress/src/integration/SignIn.spec.ts
@@ -1,4 +1,5 @@
-import { generateNewUserDetails } from '../utils/TestUtils';
+import { MOCK_DATA } from '../data';
+import { generateNewUserDetails, getTenantUser } from '../utils/TestUtils';
 
 describe('[Sign in]', () => {
   it('[By Anonymous]', () => {
@@ -6,6 +7,20 @@ describe('[Sign in]', () => {
     cy.visit('/sign-in');
     cy.get('[data-cy=lost-password]').click();
     cy.get('[data-cy=email]').should('be.visible');
+  });
+
+  it('keeps the email field after a failed login attempt', () => {
+    const user = getTenantUser(MOCK_DATA.users.subscriber);
+    const { email } = user;
+
+    cy.visit('/sign-in');
+    cy.get('[data-cy=email]').type(email);
+    cy.get('[data-cy=password]').type(`${user.password}-wrong`);
+    cy.get('[data-cy=submit]').click();
+
+    cy.contains('Invalid email or password.').should('be.visible');
+    cy.get('[data-cy=email]').should('have.value', email);
+    cy.get('[data-cy=password]').should('have.value', '');
   });
 });
 

--- a/src/routes/_.sign-in.tsx
+++ b/src/routes/_.sign-in.tsx
@@ -53,6 +53,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       return data(
         {
           error: 'We need to confirm your email before logging in. Please check your inbox :)',
+          email,
         },
         { headers },
       );
@@ -62,6 +63,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return data(
       {
         error: 'Invalid email or password.',
+        email,
       },
       { headers, status: 400 },
     );
@@ -96,6 +98,7 @@ export default function Index() {
   return (
     <Main style={{ flex: 1 }}>
       <Form
+        initialValues={{ email: actionResponse?.email }}
         onSubmit={() => {}}
         render={({ submitting, invalid }) => {
           return (


### PR DESCRIPTION
## PR Checklist

- [x] Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] Bugfix — fixes incorrect behavior

## What is the current behavior?

When a sign-in attempt fails because the password is wrong, the form is re-rendered from the action response without an initial email value. This clears both the email and password fields, so the user needs to type their email again.

Fixes #4737

## What is the new behavior?

The failed sign-in action now returns the submitted email together with the error message. The sign-in form uses that email as its initial value after the failed submission, while the password field is not restored.

This keeps the email field after a wrong-password attempt, clears the password, and leaves the existing successful sign-in path unchanged.

## Does this PR introduce a breaking change?

No.

## Testing

- `git diff --check -- src/routes/_.sign-in.tsx packages/cypress/src/integration/SignIn.spec.ts`
- `biome check --verbose src/routes/_.sign-in.tsx`
- `tsc --noEmit --pretty false`
- `cypress verify`

I did not run the full Cypress E2E suite locally because the current E2E startup flow depends on the project test app and Supabase test environment variables. I added a focused Cypress regression spec for the intended behavior.