### PR TITLE
feat: delete questions and news

### DIFF
--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -230,7 +230,7 @@ describe('[Delete a news item]', () => {
     const expectedSlug = title.replace(/\s/g, '-');
 
     cy.visit('/news');
-    const user = users.admin;
+    const user = getTenantUser(users.admin);
     cy.signIn(user.email, user.password);
 
     cy.step('Create a news item to delete');

--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -241,6 +241,8 @@ describe('[Delete a news item]', () => {
     cy.addToMarkdownField('This news will be deleted.');
     cy.get('[data-cy=submit]').click();
     cy.wait(2000);
+    cy.get('[data-cy=toast]').contains('News published');
+    cy.get('[data-cy=toast-action-link]').click();
     cy.url().should('include', '/news/');
 
     cy.step('Navigate to edit page');

--- a/packages/cypress/src/integration/news/write.spec.ts
+++ b/packages/cypress/src/integration/news/write.spec.ts
@@ -223,3 +223,38 @@ describe('[News.Write]', () => {
   // Should check an admin can edit other's content
   // })
 });
+
+describe('[Delete a news item]', () => {
+  it('[By Author]', () => {
+    const title = `${generateAlphaNumeric(8).toLowerCase()} Deletable news`;
+    const expectedSlug = title.replace(/\s/g, '-');
+
+    cy.visit('/news');
+    const user = users.admin;
+    cy.signIn(user.email, user.password);
+
+    cy.step('Create a news item to delete');
+    cy.visit('/news/create');
+    cy.get('[data-cy=field-title]', { timeout: 20000 });
+    cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
+    cy.get('[data-cy=heroImage-upload]').find(':file').selectFile('src/fixtures/images/howto-step-pic1.jpg', { force: true });
+    cy.addToMarkdownField('This news will be deleted.');
+    cy.get('[data-cy=submit]').click();
+    cy.wait(2000);
+    cy.url().should('include', '/news/');
+
+    cy.step('Navigate to edit page');
+    cy.get('[data-cy=edit]').click();
+    cy.wait(2000);
+
+    cy.step('Click delete button');
+    cy.get('[data-cy=delete]').click();
+
+    cy.step('Confirm deletion');
+    cy.get('[data-cy="Confirm.modal: Confirm"]').click();
+
+    cy.step('Redirected to news listing');
+    cy.url().should('include', '/news');
+    cy.contains(title).should('not.exist');
+  });
+});

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -203,6 +203,9 @@ describe('[Question]', () => {
       cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
       cy.get('[data-cy=field-description]').type(description, { delay: 5 });
       cy.get('[data-cy=submit]').click();
+      cy.get('a[data-cy=toast-action-link]').should('contain', 'View question');
+      cy.wait(1000);
+      cy.get('a[data-cy=toast-action-link]').should('contain', 'View question').click();
       cy.url().should('include', '/questions/');
 
       cy.step('Navigate to edit page');

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -185,4 +185,38 @@ describe('[Question]', () => {
       cy.contains(adminEdit);
     });
   });
+
+  describe('[Delete a question]', () => {
+    it('[By Author]', () => {
+      const title = generateAlphaNumeric(8).toLowerCase() + ' Deletable question?';
+      const expectedSlug = title.replace(/\s/g, '-').replace(/\?/g, '');
+      const description = 'This question will be deleted shortly after creation.';
+
+      cy.visit('/questions');
+      const user = generateNewUserDetails();
+      cy.signUpNewUser(user);
+      cy.completeUserProfile(user.username);
+
+      cy.step('Create a question to delete');
+      cy.visit('/questions/create');
+      cy.get('[data-cy=field-title]', { timeout: 20000 });
+      cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
+      cy.get('[data-cy=field-description]').type(description, { delay: 5 });
+      cy.get('[data-cy=submit]').click();
+      cy.url().should('include', '/questions/');
+
+      cy.step('Navigate to edit page');
+      cy.get('[data-cy=edit]').click();
+
+      cy.step('Click delete button');
+      cy.get('[data-cy=delete]').click();
+
+      cy.step('Confirm deletion');
+      cy.get('[data-cy="Confirm.modal: Confirm"]').click();
+
+      cy.step('Redirected to questions listing');
+      cy.url().should('include', '/questions');
+      cy.contains(title).should('not.exist');
+    });
+  });
 });

--- a/packages/cypress/src/integration/questions/write.spec.ts
+++ b/packages/cypress/src/integration/questions/write.spec.ts
@@ -202,6 +202,7 @@ describe('[Question]', () => {
       cy.get('[data-cy=field-title]', { timeout: 20000 });
       cy.get('[data-cy=field-title]').clear().type(title).blur({ force: true });
       cy.get('[data-cy=field-description]').type(description, { delay: 5 });
+      cy.selectCard('Moulds', '[data-cy=category-select]');
       cy.get('[data-cy=submit]').click();
       cy.get('a[data-cy=toast-action-link]').should('contain', 'View question');
       cy.wait(1000);

--- a/src/pages/News/Content/Common/NewsForm.tsx
+++ b/src/pages/News/Content/Common/NewsForm.tsx
@@ -1,3 +1,4 @@
+import { Button, ConfirmModal } from 'oa-components';
 import type { NewsFormData } from 'oa-shared';
 import { useCallback, useMemo, useState } from 'react';
 import { Form } from 'react-final-form';
@@ -31,6 +32,23 @@ interface IProps {
 export const NewsForm = (props: IProps) => {
   const toast = useToast();
   const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const id = props?.id || null;
+  const isEdit = props.formAction === 'edit';
+
+  const handleDelete = async () => {
+    if (!id) {
+      return;
+    }
+    setShowDeleteModal(false);
+    try {
+      await newsService.deleteNews(id);
+      window.location.assign('/news');
+    } catch (e) {
+      console.error(e.message || 'Error deleting news');
+    }
+  };
 
   const initialValues = useMemo<NewsFormData>(
     () =>
@@ -108,98 +126,124 @@ export const NewsForm = (props: IProps) => {
   }, []);
 
   return (
-    <Form
-      key={props.id || 'new'}
-      data-testid={props['data-testid']}
-      onSubmit={(values) => onSubmit(values, false)}
-      initialValues={initialValues}
-      validate={validateForm}
-      render={({
-        dirty,
-        errors,
-        form,
-        hasValidationErrors,
-        submitFailed,
-        submitting,
-        submitSucceeded,
-        handleSubmit,
-        values,
-      }) => {
-        const removeImage = () => {
-          form.change('heroImage', null);
-        };
+    <>
+      <Form
+        key={props.id || 'new'}
+        data-testid={props['data-testid']}
+        onSubmit={(values) => onSubmit(values, false)}
+        initialValues={initialValues}
+        validate={validateForm}
+        render={({
+          dirty,
+          errors,
+          form,
+          hasValidationErrors,
+          submitFailed,
+          submitting,
+          submitSucceeded,
+          handleSubmit,
+          values,
+        }) => {
+          const removeImage = () => {
+            form.change('heroImage', null);
+          };
 
-        const errorsClientSide = [errorSet(errors, LABELS.fields)];
+          const errorsClientSide = [errorSet(errors, LABELS.fields)];
 
-        const handleSubmitDraft = async (e: React.MouseEvent) => {
-          e.preventDefault();
-          setIsSubmittingDraft(true);
-          try {
-            await onSubmit(values, true);
-            form.reset(values);
-          } finally {
-            setIsSubmittingDraft(false);
-          }
-        };
-
-        const unsavedChangesDialog = (
-          <UnsavedChangesDialog hasChanges={dirty && !submitSucceeded} />
-        );
-        const validate = composeValidators(required, minValue(NEWS_MIN_TITLE_LENGTH));
-
-        return (
-          <FormWrapper
-            buttonLabel={LABELS.buttons.publish}
-            errorsClientSide={errorsClientSide}
-            guidelines={<NewsPostingGuidelines />}
-            handleSubmit={handleSubmit}
-            handleSubmitDraft={props.formData?.isDraft === false ? undefined : handleSubmitDraft}
-            hasValidationErrors={hasValidationErrors}
-            heading={LABELS.headings[props.formAction]}
-            sidebar={
-              <NewsPreviewEmailButton
-                submitting={submitting}
-                formValues={values}
-                isSubmittingDraft={isSubmittingDraft}
-                id={props.id || undefined}
-              />
+          const handleSubmitDraft = async (e: React.MouseEvent) => {
+            e.preventDefault();
+            setIsSubmittingDraft(true);
+            try {
+              await onSubmit(values, true);
+              form.reset(values);
+            } finally {
+              setIsSubmittingDraft(false);
             }
-            hideSubmittingMessage={true}
-            submitFailed={submitFailed}
-            submitting={submitting}
-            unsavedChangesDialog={unsavedChangesDialog}
-          >
-            <TitleField
-              placeholder={LABELS.fields.title.placeholder}
-              validate={validate}
-              title={LABELS.fields.title.title}
-            />
-            <NewsImageField
-              image={values.heroImage}
-              removeImage={removeImage}
-              contentId={props.id || null}
-            />
-            <CategoryField type="news" />
-            <TagsField title={LABELS.fields.tags.title} />
+          };
 
-            <BadgeVisibilityField
-              description={LABELS.fields.profileBadge.description as string}
-              placeholder={LABELS.fields.profileBadge.placeholder as string}
-              title={LABELS.fields.profileBadge.title}
-              showPublicBadge={true}
-            />
-            <ContentReachField
-              placeholder={LABELS.fields.contentReach.placeholder as string}
-              title={LABELS.fields.contentReach.title}
-              shouldDisableContentReach={
-                !!(props.id && props.formData?.contentReach && props.formData?.isDraft === false)
-              }
-            />
+          const unsavedChangesDialog = (
+            <UnsavedChangesDialog hasChanges={dirty && !submitSucceeded} />
+          );
+          const validate = composeValidators(required, minValue(NEWS_MIN_TITLE_LENGTH));
 
-            <NewsBodyField imageUpload={imageUpload} />
-          </FormWrapper>
-        );
-      }}
-    />
+          const sidebar = isEdit ? (
+            <Button
+              data-cy="delete"
+              onClick={(evt) => {
+                setShowDeleteModal(true);
+                evt.preventDefault();
+              }}
+              variant="destructive"
+              type="submit"
+              disabled={submitting}
+              sx={{ alignSelf: 'stretch', justifyContent: 'center' }}
+            >
+              {LABELS.buttons.deletion.text}
+            </Button>
+          ) : (
+            <NewsPreviewEmailButton
+              submitting={submitting}
+              formValues={values}
+              isSubmittingDraft={isSubmittingDraft}
+              id={props.id || undefined}
+            />
+          );
+
+          return (
+            <FormWrapper
+              buttonLabel={LABELS.buttons.publish}
+              errorsClientSide={errorsClientSide}
+              guidelines={<NewsPostingGuidelines />}
+              handleSubmit={handleSubmit}
+              handleSubmitDraft={props.formData?.isDraft === false ? undefined : handleSubmitDraft}
+              hasValidationErrors={hasValidationErrors}
+              heading={LABELS.headings[props.formAction]}
+              sidebar={sidebar}
+              hideSubmittingMessage={true}
+              submitFailed={submitFailed}
+              submitting={submitting}
+              unsavedChangesDialog={unsavedChangesDialog}
+            >
+              <TitleField
+                placeholder={LABELS.fields.title.placeholder}
+                validate={validate}
+                title={LABELS.fields.title.title}
+              />
+              <NewsImageField
+                image={values.heroImage}
+                removeImage={removeImage}
+                contentId={props.id || null}
+              />
+              <CategoryField type="news" />
+              <TagsField title={LABELS.fields.tags.title} />
+
+              <BadgeVisibilityField
+                description={LABELS.fields.profileBadge.description as string}
+                placeholder={LABELS.fields.profileBadge.placeholder as string}
+                title={LABELS.fields.profileBadge.title}
+                showPublicBadge={true}
+              />
+              <ContentReachField
+                placeholder={LABELS.fields.contentReach.placeholder as string}
+                title={LABELS.fields.contentReach.title}
+                shouldDisableContentReach={
+                  !!(props.id && props.formData?.contentReach && props.formData?.isDraft === false)
+                }
+              />
+
+              <NewsBodyField imageUpload={imageUpload} />
+            </FormWrapper>
+          );
+        }}
+      />
+      <ConfirmModal
+        isOpen={showDeleteModal}
+        message={LABELS.buttons.deletion.message}
+        confirmButtonText={LABELS.buttons.deletion.confirm}
+        handleCancel={() => setShowDeleteModal(false)}
+        handleConfirm={handleDelete}
+        confirmVariant="destructive"
+      />
+    </>
   );
 };

--- a/src/pages/News/labels.ts
+++ b/src/pages/News/labels.ts
@@ -1,6 +1,11 @@
 import type { ILabels } from 'src/common/Form/types';
 
 export const buttons = {
+  deletion: {
+    text: 'Delete this news',
+    confirm: 'Delete',
+    message: 'Are you sure you want to delete this news?',
+  },
   publish: 'Publish',
   update: 'Update',
 };

--- a/src/pages/Question/Content/Common/QuestionForm.tsx
+++ b/src/pages/Question/Content/Common/QuestionForm.tsx
@@ -1,4 +1,5 @@
 import { FormApi } from 'node_modules/final-form/dist';
+import { Button, ConfirmModal } from 'oa-components';
 import type { QuestionFormData } from 'oa-shared';
 import { useMemo, useState } from 'react';
 import { Form } from 'react-final-form';
@@ -27,7 +28,22 @@ interface IProps {
 export const QuestionForm = (props: IProps) => {
   const toast = useToast();
   const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const id = props?.id || null;
+  const isEdit = props.formAction === 'edit';
+
+  const handleDelete = async () => {
+    if (!id) {
+      return;
+    }
+    setShowDeleteModal(false);
+    try {
+      await questionService.deleteQuestion(id);
+      window.location.assign('/questions');
+    } catch (e) {
+      console.error(e.message || 'Error deleting question');
+    }
+  };
 
   const initialValues = useMemo<QuestionFormData>(
     () =>
@@ -81,66 +97,93 @@ export const QuestionForm = (props: IProps) => {
   };
 
   return (
-    <Form<QuestionFormData>
-      data-testid={props['data-testid']}
-      onSubmit={async (values, form) => await onSubmit(form, values, false)}
-      initialValues={initialValues}
-      render={({
-        errors,
-        handleSubmit,
-        hasValidationErrors,
-        submitFailed,
-        submitting,
-        form,
-        values,
-      }) => {
-        const errorsClientSide = [errorSet(errors, LABELS.fields)];
+    <>
+      <Form<QuestionFormData>
+        data-testid={props['data-testid']}
+        onSubmit={async (values, form) => await onSubmit(form, values, false)}
+        initialValues={initialValues}
+        render={({
+          errors,
+          handleSubmit,
+          hasValidationErrors,
+          submitFailed,
+          submitting,
+          form,
+          values,
+        }) => {
+          const errorsClientSide = [errorSet(errors, LABELS.fields)];
 
-        const handleSubmitDraft = async () => {
-          setIsSubmittingDraft(true);
-          try {
-            await onSubmit(form, values, true);
-            form.reset(values);
-          } finally {
-            setIsSubmittingDraft(false);
-          }
-        };
+          const handleSubmitDraft = async () => {
+            setIsSubmittingDraft(true);
+            try {
+              await onSubmit(form, values, true);
+              form.reset(values);
+            } finally {
+              setIsSubmittingDraft(false);
+            }
+          };
 
-        const validate = composeValidators(
-          required,
-          minValue(QUESTION_MIN_TITLE_LENGTH),
-          endsWithQuestionMark(),
-        );
+          const validate = composeValidators(
+            required,
+            minValue(QUESTION_MIN_TITLE_LENGTH),
+            endsWithQuestionMark(),
+          );
 
-        return (
-          <FormWrapper
-            buttonLabel={LABELS.buttons[props.formAction]}
-            errorsClientSide={errorsClientSide}
-            guidelines={<QuestionPostingGuidelines />}
-            handleSubmit={handleSubmit}
-            handleSubmitDraft={handleSubmitDraft}
-            hasValidationErrors={hasValidationErrors}
-            heading={LABELS.headings[props.formAction]}
-            submitFailed={submitFailed}
-            submitting={submitting || isSubmittingDraft}
-            hideSubmittingMessage={true}
-          >
-            <TitleField
-              placeholder={LABELS.fields.title.placeholder}
-              validate={validate}
-              title={LABELS.fields.title.title}
-            />
-            <QuestionDescriptionField />
-            <QuestionImagesField
-              contentType="questions"
-              contentId={id}
-              maxImages={QUESTION_MAX_IMAGES}
-            />
-            <CategoryField type="questions" required />
-            <TagsField title={LABELS.fields.tags.title} />
-          </FormWrapper>
-        );
-      }}
-    />
+          const sidebar = isEdit ? (
+            <Button
+              data-cy="delete"
+              onClick={(evt) => {
+                setShowDeleteModal(true);
+                evt.preventDefault();
+              }}
+              variant="destructive"
+              type="submit"
+              disabled={submitting || isSubmittingDraft}
+              sx={{ alignSelf: 'stretch', justifyContent: 'center' }}
+            >
+              {LABELS.buttons.deletion.text}
+            </Button>
+          ) : null;
+
+          return (
+            <FormWrapper
+              buttonLabel={LABELS.buttons[props.formAction]}
+              errorsClientSide={errorsClientSide}
+              guidelines={<QuestionPostingGuidelines />}
+              handleSubmit={handleSubmit}
+              handleSubmitDraft={handleSubmitDraft}
+              hasValidationErrors={hasValidationErrors}
+              heading={LABELS.headings[props.formAction]}
+              sidebar={sidebar}
+              submitFailed={submitFailed}
+              submitting={submitting || isSubmittingDraft}
+              hideSubmittingMessage={true}
+            >
+              <TitleField
+                placeholder={LABELS.fields.title.placeholder}
+                validate={validate}
+                title={LABELS.fields.title.title}
+              />
+              <QuestionDescriptionField />
+              <QuestionImagesField
+                contentType="questions"
+                contentId={id}
+                maxImages={QUESTION_MAX_IMAGES}
+              />
+              <CategoryField type="questions" required />
+              <TagsField title={LABELS.fields.tags.title} />
+            </FormWrapper>
+          );
+        }}
+      />
+      <ConfirmModal
+        isOpen={showDeleteModal}
+        message={LABELS.buttons.deletion.message}
+        confirmButtonText={LABELS.buttons.deletion.confirm}
+        handleCancel={() => setShowDeleteModal(false)}
+        handleConfirm={handleDelete}
+        confirmVariant="destructive"
+      />
+    </>
   );
 };

--- a/src/pages/Question/labels.ts
+++ b/src/pages/Question/labels.ts
@@ -2,6 +2,11 @@ import type { ILabels } from 'src/common/Form/types';
 
 export const buttons = {
   create: 'Publish',
+  deletion: {
+    text: 'Delete this question',
+    confirm: 'Delete',
+    message: 'Are you sure you want to delete this question?',
+  },
   draft: { create: 'Save as draft', update: 'Save to draft' },
   edit: 'Update',
 };

--- a/src/routes/api.news.$id.ts
+++ b/src/routes/api.news.$id.ts
@@ -19,10 +19,15 @@ import {
 import { convertToSlug } from 'src/utils/slug';
 
 export const action = async ({ request, params }: LoaderFunctionArgs) => {
+  const id = Number(params.id);
+
+  if (request.method === 'DELETE') {
+    return await deleteNews(request, id);
+  }
+
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
-    const id = Number(params.id);
     const formData = await request.formData();
     const data = {
       body: formData.get('body') as string,
@@ -126,6 +131,58 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
     return Response.json({ error: 'Error updating news', status: 500 }, { status: 500 });
   }
 };
+
+async function deleteNews(request: Request, id: number) {
+  const { client, headers } = createSupabaseServerClient(request);
+
+  try {
+    const claims = await client.auth.getClaims();
+
+    if (!claims.data?.claims) {
+      throw unauthorizedError();
+    }
+
+    const profileService = new ProfileServiceServer(client);
+    const profile = await profileService.getByAuthId(claims.data.claims.sub);
+
+    if (!profile) {
+      throw validationError('User not found');
+    }
+
+    const news = await new NewsServiceServer(client).getById(id);
+
+    if (!news) {
+      throw notFoundError('News');
+    }
+
+    const isCreator = news.created_by === profile.id;
+
+    if (
+      !isCreator &&
+      !profile.roles?.includes(UserRole.ADMIN) &&
+      !profile.roles?.includes(UserRole.EDITOR)
+    ) {
+      throw forbiddenError();
+    }
+
+    await client
+      .from('news')
+      .update({
+        modified_at: new Date(),
+        deleted: true,
+      })
+      .eq('id', id);
+
+    return Response.json({}, { status: 200, headers });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    console.error('Delete news error:', error);
+    return Response.json({}, { status: 500, headers });
+  }
+}
 
 async function validateRequest(
   params: Params<string>,

--- a/src/routes/api.questions.$id.ts
+++ b/src/routes/api.questions.$id.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { HTTPException } from 'hono/http-exception';
 import type { DBMedia, DBQuestion, QuestionDTO } from 'oa-shared';
-import { Question } from 'oa-shared';
+import { Question, UserRole } from 'oa-shared';
 import type { LoaderFunctionArgs, Params } from 'react-router';
 import { IMAGE_SIZES } from 'src/config/imageTransforms';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
@@ -13,17 +13,23 @@ import {
   conflictError,
   forbiddenError,
   methodNotAllowedError,
+  notFoundError,
+  unauthorizedError,
   validationError,
 } from 'src/utils/httpException';
 import { convertToSlug } from 'src/utils/slug';
 import { ContentServiceServer } from '../services/contentService.server';
 
 export const action = async ({ request, params }: LoaderFunctionArgs) => {
+  const id = Number(params.id);
+
+  if (request.method === 'DELETE') {
+    return await deleteQuestion(request, id);
+  }
+
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
-    const id = Number(params.id);
-
     const formData = await request.formData();
 
     const data = {
@@ -42,7 +48,7 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
     const claims = await client.auth.getClaims();
 
     if (!claims.data?.claims) {
-      return Response.json({}, { headers, status: 401 });
+      throw unauthorizedError();
     }
 
     const currentQuestion = await new QuestionServiceServer(client).getById(id);
@@ -95,6 +101,59 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
     return Response.json({ error: 'Error updating question' }, { headers, status: 500 });
   }
 };
+
+async function deleteQuestion(request: Request, id: number) {
+  const { client, headers } = createSupabaseServerClient(request);
+
+  try {
+    const claims = await client.auth.getClaims();
+
+    if (!claims.data?.claims) {
+      throw unauthorizedError();
+    }
+
+    const profileService = new ProfileServiceServer(client);
+    const profile = await profileService.getByAuthId(claims.data.claims.sub);
+
+    if (!profile) {
+      throw validationError('User not found');
+    }
+
+    const question = await new QuestionServiceServer(client).getById(id);
+
+    if (!question) {
+      throw notFoundError('Question');
+    }
+
+    const isCreator = question.created_by === profile.id;
+
+    if (
+      !isCreator &&
+      !profile.roles?.includes(UserRole.ADMIN) &&
+      !profile.roles?.includes(UserRole.EDITOR) &&
+      !profile.roles?.includes(UserRole.MODERATOR)
+    ) {
+      throw forbiddenError();
+    }
+
+    await client
+      .from('questions')
+      .update({
+        modified_at: new Date(),
+        deleted: true,
+      })
+      .eq('id', id);
+
+    return Response.json({}, { status: 200, headers });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    console.error('Delete question error:', error);
+    return Response.json({}, { status: 500, headers });
+  }
+}
 
 async function validateRequest(
   params: Params<string>,

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -37,6 +37,19 @@ const upsert = async (id: number | null, form: NewsFormData) => {
   return news;
 };
 
+const deleteNews = async (id: number) => {
+  const response = await fetch(`/api/news/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (response.status !== 200 && response.status !== 201) {
+    const errorData = await response.json().catch(() => ({ error: 'Error deleting news' }));
+    const errorMessage = errorData.error || 'Error deleting news';
+    throw new Error(errorMessage, { cause: response.status });
+  }
+};
+
 export const newsService = {
+  deleteNews,
   upsert,
 };

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -34,6 +34,19 @@ const upsert = async (id: number | null, question: QuestionFormData) => {
   return Question.fromDB(new DBQuestion(newQuestion.question), []);
 };
 
+const deleteQuestion = async (id: number) => {
+  const response = await fetch(`/api/questions/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (response.status !== 200 && response.status !== 201) {
+    const errorData = await response.json().catch(() => ({ error: 'Error deleting question' }));
+    const errorMessage = errorData.error || 'Error deleting question';
+    throw new Error(errorMessage, { cause: response.status });
+  }
+};
+
 export const questionService = {
+  deleteQuestion,
   upsert,
 };

--- a/supabase/migrations/20260613120000_filter_deleted_news.sql
+++ b/supabase/migrations/20260613120000_filter_deleted_news.sql
@@ -1,0 +1,96 @@
+set check_function_bodies = off;
+
+-- Filter out deleted items in get_news_feed function
+CREATE OR REPLACE FUNCTION public.get_news_feed(
+  p_user_profile_id bigint DEFAULT NULL,  -- NULL = unauthenticated
+  p_is_admin boolean DEFAULT false,
+  p_search text DEFAULT NULL,
+  p_sort text DEFAULT 'Newest',
+  p_skip integer DEFAULT 0,
+  p_limit integer DEFAULT 20
+)
+RETURNS TABLE (
+  id bigint,
+  created_at timestamptz,
+  created_by bigint,
+  modified_at timestamptz,
+  published_at timestamptz,
+  is_draft boolean,
+  comment_count bigint,
+  body text,
+  slug text,
+  summary text,
+  tags bigint[],
+  title text,
+  total_views bigint,
+  hero_image json,
+  content_reach "public"."content_reach",
+  profile_badges json,
+  total_count bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    n.id,
+    n.created_at,
+    n.created_by,
+    n.modified_at,
+    n.published_at,
+    n.is_draft,
+    n.comment_count,
+    n.body,
+    n.slug,
+    n.summary,
+    n.tags,
+    n.title,
+    n.total_views,
+    n.hero_image,
+    n.content_reach,
+    (
+      SELECT COALESCE(
+        json_agg(json_build_object('profile_badges', row_to_json(pb))),
+        '[]'::json
+      )
+      FROM news_badges_relations nbr
+      JOIN profile_badges pb ON pb.id = nbr.profile_badge_id
+      WHERE nbr.news_id = n.id
+    ) AS profile_badges,
+    COUNT(*) OVER () AS total_count
+  FROM news n
+  WHERE
+    n.is_draft = false
+    AND (n.deleted IS NULL OR n.deleted = FALSE)
+    AND (
+      p_is_admin
+      OR NOT EXISTS (
+        -- news has ANY badge restriction
+        SELECT 1 FROM news_badges_relations nbr
+        WHERE nbr.news_id = n.id
+      )
+      OR (
+        -- news has badge restrictions AND user has at least one matching badge
+        p_user_profile_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM news_badges_relations nbr
+          JOIN profile_badges_relations pbr
+            ON pbr.profile_badge_id = nbr.profile_badge_id
+          WHERE nbr.news_id = n.id
+            AND pbr.profile_id = p_user_profile_id
+        )
+      )
+    )
+    AND (
+      p_search IS NULL
+      OR to_tsvector('english', n.title || ' ' || n.body) @@ plainto_tsquery('english', p_search)
+    )
+  ORDER BY
+    CASE WHEN p_sort = 'Newest'       THEN n.published_at   END DESC NULLS LAST,
+    CASE WHEN p_sort = 'Comments'     THEN n.comment_count  END DESC NULLS LAST,
+    CASE WHEN p_sort = 'LeastComments' THEN n.comment_count END ASC  NULLS LAST,
+    n.published_at DESC  -- stable tiebreaker
+  LIMIT p_limit
+  OFFSET p_skip;
+$$;

--- a/supabase/schemas/news.sql
+++ b/supabase/schemas/news.sql
@@ -132,6 +132,7 @@ AS $$
   FROM news n
   WHERE
     n.is_draft = false
+    AND (n.deleted IS NULL OR n.deleted = FALSE)
     AND (
       p_is_admin
       OR NOT EXISTS (


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] ✨ Feature — adds new functionality

## What is the new behavior?

Allows admins and creators to delete news and questions.
For questions: Moderators, Editors and Admins can delete.
For news: Editors and Admins can delete.

## Does this PR introduce a DB Schema Change or Migration?

- [x] Yes

## Git Issues

Closes #4265 
