### PR TITLE
feat: better news summary

### DIFF
--- a/shared/utils/getSummaryFromMarkdown.test.ts
+++ b/shared/utils/getSummaryFromMarkdown.test.ts
@@ -6,12 +6,47 @@ describe('getSummaryFromMarkdown', () => {
   it('removes markdown elements', () => {
     const simpleHeading = `**A** B
 
-* C
+    * C
 
-> D
+    > D
 
-E
-`;
-    expect(getSummaryFromMarkdown(simpleHeading)).toEqual('A B D');
+    E
+    `;
+
+    expect(getSummaryFromMarkdown(simpleHeading)).toEqual('A  B C D E');
+  });
+
+  it('creates consistent length summaries', () => {
+    const shortContent = '# Short Title';
+    const summary1 = getSummaryFromMarkdown(shortContent);
+    expect(summary1).toEqual('Short Title');
+
+    const longContent =
+      "Hey Pro's, Some updates to share this month! **Bazar speed upgrade** This one has been a long time coming. Loading times on the Bazar were getting embarrassing, up to 40 seconds in some cases.";
+    const summary2 = getSummaryFromMarkdown(longContent);
+    expect(summary2?.length).toBeLessThanOrEqual(164); // 160 + "..."
+    expect(summary2).toContain("Hey Pro's");
+  });
+
+  it('handles lists properly', () => {
+    const listContent = `
+    * First item
+    * Second item
+    * Third item
+    `;
+    const summary = getSummaryFromMarkdown(listContent);
+    expect(summary).toContain('First item');
+  });
+
+  it('truncates at word boundaries', () => {
+    const longText =
+      'This is a very long paragraph that goes on and on with many words that should be truncated at a reasonable word boundary rather than cutting off in the middle of a word which would look unprofessional and confusing.';
+    const summary = getSummaryFromMarkdown(longText);
+    expect(summary?.endsWith('...')).toBe(true);
+    expect(summary?.length).toBeLessThanOrEqual(164); // 160 + "..."
+    // Verify it doesn't cut mid-word (no orphaned characters before ...)
+    const beforeEllipsis = summary?.slice(-10, -3); // Get chars before "..."
+    expect(beforeEllipsis).not.toContain(' a ');
+    expect(beforeEllipsis).not.toContain(' i ');
   });
 });

--- a/shared/utils/getSummaryFromMarkdown.ts
+++ b/shared/utils/getSummaryFromMarkdown.ts
@@ -1,23 +1,52 @@
 import { marked } from 'marked';
 
-export const getSummaryFromMarkdown = (text: string) => {
-  // Works for headings, paragraphs, etc.
-  // Doesn't work for at list items and maybe more.
+const MAX_SUMMARY_LENGTH = 160;
+const MIN_SUMMARY_LENGTH = 50;
 
+export const getSummaryFromMarkdown = (text: string) => {
   if (!text) {
     return null;
   }
-  // has to go to any as unhelpfully typed
-  const linesWithTokens = marked
-    .lexer(text)
-    .filter(({ tokens }: any) => !!tokens && tokens.length > 0);
-  const linesWithText = linesWithTokens.map((line: any) => line.tokens).flat();
 
-  const flattenedLines = linesWithText
-    .slice(0, 1)
-    .map((token) => token['text'] && token['text'].trim());
+  // Parse markdown into tokens
+  const tokens = marked.lexer(text);
+  const textParts: string[] = [];
 
-  return flattenedLines
+  // Extract text from all tokens until we have enough content
+  for (const token of tokens) {
+    let tokenText = '';
+
+    // Handle different token types
+    if ('tokens' in token && token.tokens) {
+      // Extract text from nested tokens (paragraphs, headings, etc.)
+      tokenText = token.tokens
+        .map((t: any) => t.text || '')
+        .join(' ')
+        .trim();
+    } else if ('text' in token) {
+      // Direct text tokens
+      tokenText = (token as any).text.trim();
+    } else if ('items' in token) {
+      // Handle list items
+      tokenText = (token as any).items
+        .map((item: any) => item.tokens?.map((t: any) => t.text || '').join(' ') || '')
+        .join(' ')
+        .trim();
+    }
+
+    if (tokenText) {
+      textParts.push(tokenText);
+
+      // Stop once we have enough content
+      const currentLength = textParts.join(' ').length;
+      if (currentLength >= MIN_SUMMARY_LENGTH) {
+        break;
+      }
+    }
+  }
+
+  // Join parts and clean up markdown formatting
+  let summary = textParts
     .join(' ')
     .replaceAll('*', '')
     .replaceAll('_', '')
@@ -26,5 +55,22 @@ export const getSummaryFromMarkdown = (text: string) => {
     .replaceAll('<u>', '')
     .replaceAll('</u>', '')
     .replaceAll('<code>', '')
-    .replaceAll('</code>', '');
+    .replaceAll('</code>', '')
+    .trim();
+
+  // Truncate to max length at word boundary
+  if (summary.length > MAX_SUMMARY_LENGTH) {
+    summary = summary.slice(0, MAX_SUMMARY_LENGTH);
+
+    // Find the last space to avoid cutting mid-word
+    const lastSpace = summary.lastIndexOf(' ');
+    if (lastSpace > MIN_SUMMARY_LENGTH) {
+      summary = summary.slice(0, lastSpace);
+    }
+
+    // Add ellipsis if truncated
+    summary = summary.trim() + '...';
+  }
+
+  return summary || null;
 };


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] ✨ Feature — adds new functionality

## What is the new behavior?

Currently, News summaries are just the first news block, so their length is very inconsistent, and there is no limit to it.

Now summaries are always a similar length - about one or two sentences, around 160 characters. The system reads through the beginning of the post, gathering text until it has enough for a proper summary, then cuts it at a clean word ending.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No
