### PR TITLE
feat: map side panel responsive columns and circular avatars (#4745)

### DIFF
--- a/packages/components/src/CardListItem/CardListItem.tsx
+++ b/packages/components/src/CardListItem/CardListItem.tsx
@@ -16,7 +16,10 @@ export const CardListItem = (props: IProps) => {
   const testProp = `CardListItem${isSelectedPin ? '-selected' : ''}`;
 
   const Card = (
-    <CardButton isSelected={isSelectedPin} extrastyles={{ minWidth: '230px', maxWidth: '400px' }}>
+    <CardButton
+      isSelected={isSelectedPin}
+      extrastyles={{ minWidth: '250px', maxWidth: '500px', mx: 'auto' }}
+    >
       <CardProfile item={item} variant="list" />
     </CardButton>
   );
@@ -26,7 +29,8 @@ export const CardListItem = (props: IProps) => {
     'data-testid': testProp,
     sx: {
       borderRadius: 2,
-      padding: 2,
+      paddingY: 2,
+      paddingX: 0,
     },
   };
 
@@ -49,7 +53,8 @@ export const CardListItem = (props: IProps) => {
       onClick={() => onPinClick(item)}
       sx={{
         borderRadius: 2,
-        padding: 2,
+        paddingY: 2,
+        paddingX: 0,
       }}
     >
       {Card}

--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -46,7 +46,7 @@ export const CardDetailsMemberProfile = ({ variant, item, isLink }: IProps) => {
           >
             <Avatar
               src={photoUrl || defaultProfileImage}
-              sx={{ width: '60px', height: '60px', objectFit: 'cover', flexShrink: 0 }}
+              sx={{ width: '60px', height: '60px', objectFit: 'cover' }}
               loading="lazy"
             />
             <MemberBadge

--- a/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsMemberProfile.tsx
@@ -36,7 +36,7 @@ export const CardDetailsMemberProfile = ({ variant, item, isLink }: IProps) => {
       }}
     >
       <Flex sx={{ gap: 2, alignItems: 'center' }}>
-        <Box sx={{ aspectRatio: 1, width: '60px', height: '60px' }}>
+        <Box sx={{ aspectRatio: 1, width: '60px', height: '60px', flexShrink: 0 }}>
           <Flex
             sx={{
               alignContent: 'flex-start',
@@ -46,7 +46,7 @@ export const CardDetailsMemberProfile = ({ variant, item, isLink }: IProps) => {
           >
             <Avatar
               src={photoUrl || defaultProfileImage}
-              sx={{ width: '60px', height: '60px', objectFit: 'cover' }}
+              sx={{ width: '60px', height: '60px', objectFit: 'cover', flexShrink: 0 }}
               loading="lazy"
             />
             <MemberBadge

--- a/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
+++ b/packages/components/src/CardProfile/CardDetailsSpaceProfile.tsx
@@ -61,7 +61,6 @@ export const CardDetailsSpaceProfile = ({ item, isLink, variant }: IProps) => {
                 width: '80px',
                 height: '80px',
                 objectFit: 'cover',
-                flexShrink: 0,
                 border: '3px solid white',
                 boxSizing: 'border-box',
               }}

--- a/packages/components/src/CommentDisplay/CommentDisplay.tsx
+++ b/packages/components/src/CommentDisplay/CommentDisplay.tsx
@@ -82,7 +82,7 @@ export const CommentDisplay = (props: IProps) => {
               }}
             >
               <Flex sx={{ alignItems: 'center', gap: 2 }}>
-                <Box sx={{ display: ['flex', 'none'], position: 'relative' }}>
+                <Box sx={{ display: ['flex', 'none'], position: 'relative', flexShrink: 0 }}>
                   <CommentAvatar
                     displayName={comment.createdBy?.displayName}
                     photo={comment.createdBy?.photo?.publicUrl}

--- a/packages/components/src/MapCardList/MapCardList.tsx
+++ b/packages/components/src/MapCardList/MapCardList.tsx
@@ -51,7 +51,10 @@ export const MapCardList = (props: IProps) => {
   const results = `${list.length} result${list.length == 1 ? '' : 's'} in view`;
 
   return (
-    <Flex data-cy={`CardList-${viewport}`} sx={{ flexDirection: 'column', gap: 2, padding: 2 }}>
+    <Flex
+      data-cy={`CardList-${viewport}`}
+      sx={{ flexDirection: 'column', gap: 2, padding: 2, containerType: 'inline-size' }}
+    >
       <Flex sx={{ justifyContent: 'space-between', paddingX: 2, paddingTop: 2, fontSize: 2 }}>
         <Text data-cy="list-results">{results}</Text>
         <Flex sx={{ alignItems: 'center', gap: 2 }}>
@@ -64,8 +67,10 @@ export const MapCardList = (props: IProps) => {
         <>
           <Box
             sx={{
-              columnWidth: '240px',
-              columnGap: 0,
+              columnCount: 1,
+              columnGap: 4,
+              '@container (min-width: 520px)': { columnCount: 2 },
+              '@container (min-width: 1020px)': { columnCount: 3 },
               '& > *': { breakInside: 'avoid' },
             }}
           >

--- a/packages/themes/src/common/index.ts
+++ b/packages/themes/src/common/index.ts
@@ -77,6 +77,12 @@ export const baseTheme = {
     bottomNav: '0 -6px 21px rgba(0, 0, 0, 0.15)',
   },
 
+  images: {
+    avatar: {
+      flexShrink: 0,
+    },
+  },
+
   forms: {
     input: {
       ...commonStyles.input,

--- a/packages/themes/src/types/index.ts
+++ b/packages/themes/src/types/index.ts
@@ -46,6 +46,12 @@ export interface PlatformTheme {
     bottomNav: string;
   };
 
+  images: {
+    avatar: {
+      flexShrink: number;
+    };
+  };
+
   zIndex: {
     behind: number;
     level: number;


### PR DESCRIPTION
## PR Checklist

- [x] Unit and/or e2e tests — no new unit test here: it's all CSS layout / responsive behaviour, which jsdom can't really assert. The existing `MapCardList` and `CardProfile` tests still pass, and I checked the behaviour in the browser (screenshots below).

## What kind of change does this PR introduce?

- [x] Feature — adds new functionality
- [x] Bugfix — fixes incorrect behavior without changing functionality

## What is the new behavior?

This takes on the map side panel from #4745, following @BenCmjn's design notes, and also fixes the avatar thing @davehakkens spotted.

I kept the existing masonry layout (cards still pack by height) and just tuned how the columns and cards behave:

- **Columns cap at 3 now, and prefer fewer.** 1 column when it's narrow, 2 from 520px wide, and only 3 from 1020px. So no more cramming up to 5 columns on big screens.
- **Cards get a bit more room to breathe** — they range 250-500px (members and orgs alike), and once a column gets wider than 500px the card just floats in the middle instead of stretching.
- **The 20px gap lives on the container now** (column-gap) instead of coming from each card's own padding.

On the avatars: in narrow cards with lots of tags they were getting squished into ovals. They now hold their 60x60 box (a small flex-shrink tweak, the same thing the org card already does), so they stay round no matter what.

I poked at it locally from 360 all the way up to 3600px wide — the column counts land where Ben specced, gaps stay at 20px, cards centre nicely on wide screens, avatars stay circular, and nothing overflows at 360px. Screenshots below.

## Screenshots

All from a local seeded map.

**No more than 3 columns (it used to go up to 5)**

<table>
<tr><td align="center"><b>Before</b></td><td align="center"><b>After</b></td></tr>
<tr>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step1-before-2560.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step1-before-2560.png" width="380"></a></td>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step1-after-2560.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step1-after-2560.png" width="380"></a></td>
</tr>
</table>

**Cards grow to 250-500px and float centered on wide screens**

<table>
<tr><td align="center"><b>Before</b></td><td align="center"><b>After</b></td></tr>
<tr>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step2-before-3600.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step2-before-3600.png" width="380"></a></td>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step2-after-3600.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-step2-after-3600.png" width="380"></a></td>
</tr>
</table>

**Avatars stay round, even on a busy card**

<table>
<tr><td align="center"><b>Before</b></td><td align="center"><b>After</b></td></tr>
<tr>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-avatar-before.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-avatar-before.png" width="380"></a></td>
<td><a href="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-avatar-after.png"><img src="https://raw.githubusercontent.com/rsgb/community-platform/4745-pr-assets/pr-assets/4745-avatar-after.png" width="380"></a></td>
</tr>
</table>

## Does this PR introduce a DB Schema Change or Migration?

- [x] No

## Git Issues

Closes #4745
