### PR TITLE
fix: oversized map pin icons

### DIFF
--- a/src/pages/Maps/Content/MapView/Sprites.tsx
+++ b/src/pages/Maps/Content/MapView/Sprites.tsx
@@ -77,7 +77,11 @@ export const createMarkerIcon = (pin: MapPin, draggable?: boolean) => {
       : AwaitingModerationHighlight;
   return divIcon({
     className: `icon-marker icon-${pin.profile!.type}`,
-    html: `<img data-cy="pin-${pin.profile.username}" src="${icon}" style="${draggable ? 'cursor: grab' : ''}" />`,
+    html: `<img 
+      data-cy="pin-${pin.profile.username}" 
+      src="${icon}" 
+      style="width: 100%; height: 100%; ${draggable ? 'cursor: grab' : ''}" 
+    />`,
     iconSize: point(38, 38, true),
   });
 };


### PR DESCRIPTION
If map pin SVG are saved in a certain (unknown) way, the existing sizing rules on the app were igonored:

<img width="1290" height="644" alt="Screenshot 2026-07-07 at 10 22 04" src="https://github.com/user-attachments/assets/612d6bd6-91b7-4f9d-9fac-6d10ce7fcb9a" />

This change does a quick style rule at the image level to fix this:

<img width="1290" height="644" alt="Screenshot 2026-07-07 at 10 21 55" src="https://github.com/user-attachments/assets/90062007-dec7-40b0-ac10-96ea7a13c869" />
