### PR TITLE
fix: profile banner link

### DIFF
--- a/src/routes/_.settings.$.tsx
+++ b/src/routes/_.settings.$.tsx
@@ -6,6 +6,14 @@ import { SettingsPage } from 'src/pages/UserSettings/SettingsPage.client';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
 
+const incompletePathname = (pathname) => {
+  const incompletePathnameList = ['/settings', '/settings/', '/settings.data'];
+  if (incompletePathnameList.includes(pathname)) {
+    return true;
+  }
+  return false;
+};
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
   const claims = await client.auth.getClaims();
@@ -15,7 +23,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 
   const url = new URL(request.url);
-  if (url.pathname === '/settings' || url.pathname === '/settings/') {
+  if (incompletePathname(url.pathname)) {
     return redirect('/settings/profile', { headers });
   }
 


### PR DESCRIPTION
For some reason, clicking the complete profile banner link looked like it was going to '/settings' but was the pathname was actually '/settings.data', this meant users weren't being automatically linked to the default setting tab as expected.  '/settings.data' has been added to the paths that redirect to the correct tabs.

There's a better way to do this by moving the logic to `SettingsPage`, if a pathname isn't on the valid list of tabs it should default to 'profile'. But I think this is low value bug so I've gone with the quickest solution.