### PR TITLE
fix: hide membership prices for archived Stripe products

### DIFF
--- a/src/services/stripeService.server.test.ts
+++ b/src/services/stripeService.server.test.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPricesList = vi.fn();
+
+vi.mock('stripe', () => ({
+  default: class {
+    prices = { list: mockPricesList };
+  },
+}));
+
+vi.mock('src/services/secretsService.server', () => ({
+  getSecret: vi.fn().mockResolvedValue('sk_test_123'),
+}));
+
+vi.mock('src/repository/supabaseAdmin.server', () => ({
+  createSupabaseAdminServerClient: vi.fn(),
+}));
+
+import { StripeServiceServer } from './stripeService.server';
+
+type StripePrice = {
+  id: string;
+  unit_amount: number | null;
+  currency: string;
+  recurring: { interval: string } | null;
+  product: { id: string; active?: boolean; deleted?: boolean } | string;
+  currency_options?: Record<string, { unit_amount: number | null }>;
+};
+
+const price = (overrides: Partial<StripePrice> & { id: string }): StripePrice => ({
+  unit_amount: 500,
+  currency: 'eur',
+  recurring: { interval: 'month' },
+  product: { id: 'prod_default', active: true },
+  ...overrides,
+});
+
+const makeClient = (tierRows: unknown[]): SupabaseClient =>
+  ({
+    from: () => ({
+      select: () => Promise.resolve({ data: tierRows }),
+    }),
+  }) as unknown as SupabaseClient;
+
+const activeTierRows = [
+  {
+    stripe_product_id: 'prod_active',
+    profile_badges: { premium_tier: 1, display_name: 'Starter' },
+  },
+  {
+    stripe_product_id: 'prod_archived',
+    profile_badges: { premium_tier: 2, display_name: 'Legacy' },
+  },
+];
+
+describe('StripeServiceServer.getPrices', () => {
+  beforeEach(() => {
+    mockPricesList.mockReset();
+  });
+
+  it('excludes prices whose parent product is archived (active: false)', async () => {
+    mockPricesList.mockImplementation(({ product }: { product: string }) => {
+      if (product === 'prod_active') {
+        return Promise.resolve({
+          data: [price({ id: 'price_active', product: { id: 'prod_active', active: true } })],
+        });
+      }
+      // Stripe leaves prices active even after the product is archived.
+      return Promise.resolve({
+        data: [price({ id: 'price_archived', product: { id: 'prod_archived', active: false } })],
+      });
+    });
+
+    const service = new StripeServiceServer(makeClient(activeTierRows));
+    const result = await service.getPrices();
+
+    const ids = result.map((p) => p.id);
+    expect(ids).toContain('price_active');
+    expect(ids).not.toContain('price_archived');
+  });
+
+  it('excludes prices whose parent product has been deleted', async () => {
+    mockPricesList.mockResolvedValue({
+      data: [price({ id: 'price_deleted', product: { id: 'prod_archived', deleted: true } })],
+    });
+
+    const service = new StripeServiceServer(
+      makeClient([activeTierRows[1]]),
+    );
+    const result = await service.getPrices();
+
+    expect(result.map((p) => p.id)).not.toContain('price_deleted');
+  });
+
+  it('keeps prices for active products', async () => {
+    mockPricesList.mockResolvedValue({
+      data: [price({ id: 'price_active', product: { id: 'prod_active', active: true } })],
+    });
+
+    const service = new StripeServiceServer(makeClient([activeTierRows[0]]));
+    const result = await service.getPrices();
+
+    expect(result.map((p) => p.id)).toEqual(['price_active']);
+  });
+});

--- a/src/services/stripeService.server.ts
+++ b/src/services/stripeService.server.ts
@@ -373,13 +373,20 @@ export class StripeServiceServer {
           product: productId,
           active: true,
           limit: 100,
-          expand: ['data.currency_options'],
+          expand: ['data.currency_options', 'data.product'],
         }),
       ),
     );
 
     return allPrices
       .flatMap((result) => result.data)
+      .filter((p) => {
+        const prod = p.product as { active?: boolean; deleted?: boolean } | string;
+        if (typeof prod === 'object' && prod !== null) {
+          return prod.deleted !== true && prod.active !== false;
+        }
+        return true;
+      })
       .filter((p) => p.recurring && p.unit_amount !== null)
       .flatMap((p) => {
         const productId =


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [ ] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Archiving a product in the Stripe dashboard now removes its tiers from the Membership pricing page.

Stripe keeps a product's prices `active: true` even after the product itself is archived, so `getPrices()` was leaking prices for archived products (e.g. the €0.50 test tier — confirmed against live data: `price_active=true` on a `product_active=false` product). We now expand `data.product` on `prices.list` and drop any price whose parent product is archived or deleted. Conservative: prices whose product can't be resolved are kept, so no legitimate tier is hidden.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform \`development\` channel](https://discord.com/channels/586676777334865928/938781727017558018).