### PR TITLE
fix: reset pagination when filtering or searching

### DIFF
--- a/packages/cypress/src/integration/library/read.spec.ts
+++ b/packages/cypress/src/integration/library/read.spec.ts
@@ -55,9 +55,10 @@ describe('[Library]', () => {
 
     it('[Pagination resets after search]', () => {
       cy.visit('/library?page=2');
+      cy.url().should('include', 'sort=MostUsefulLastWeek');
 
       cy.step('Search while viewing a later page');
-      cy.get('[data-cy=library-search-box]').click().type('brick');
+      cy.get('[data-cy=library-search-box]').should('be.enabled').click().type('brick');
 
       cy.step('Verify the search resets pagination');
       cy.url().should('include', 'q=brick');
@@ -65,6 +66,7 @@ describe('[Library]', () => {
       cy.get('[data-cy=card]').should('have.length', 1);
 
       cy.visit('/library?page=2');
+      cy.url().should('include', 'sort=MostUsefulLastWeek');
 
       cy.step('Filter while viewing a later page');
       cy.get('[data-cy=CategoryHorizonalList]').within(() => {

--- a/packages/cypress/src/integration/library/read.spec.ts
+++ b/packages/cypress/src/integration/library/read.spec.ts
@@ -52,6 +52,30 @@ describe('[Library]', () => {
       cy.get('[data-cy=category]').contains('Machines');
       cy.get('[data-cy=category]').contains('Moulds').should('not.exist');
     });
+
+    it('[Pagination resets after search]', () => {
+      cy.visit('/library?page=2');
+
+      cy.step('Search while viewing a later page');
+      cy.get('[data-cy=library-search-box]').click().type('brick');
+
+      cy.step('Verify the search resets pagination');
+      cy.url().should('include', 'q=brick');
+      cy.url().should('not.include', 'page=');
+      cy.get('[data-cy=card]').should('have.length', 1);
+
+      cy.visit('/library?page=2');
+
+      cy.step('Filter while viewing a later page');
+      cy.get('[data-cy=CategoryHorizonalList]').within(() => {
+        cy.contains('Machines').click();
+      });
+
+      cy.step('Verify the category filter resets pagination');
+      cy.url().should('include', 'category=');
+      cy.url().should('not.include', 'page=');
+      cy.get('[data-cy=CategoryHorizonalList-Item-active]').should('be.visible');
+    });
   });
 
   describe('[Read a project]', () => {

--- a/packages/cypress/src/integration/questions/search.spec.ts
+++ b/packages/cypress/src/integration/questions/search.spec.ts
@@ -42,6 +42,30 @@ describe('[Questions]', () => {
       cy.url().should('not.include', 'category=');
     });
 
+    it('Resets pagination when searching', () => {
+      cy.visit('/questions?page=2');
+
+      cy.step('Search while viewing a later page');
+      cy.get('[data-cy=questions-search-box]').clear().type('deal');
+
+      cy.step('Verify the search resets pagination');
+      cy.url().should('include', 'q=deal');
+      cy.url().should('not.include', 'page=');
+      cy.get('[data-cy=question-list-item]').should('have.length', 1);
+
+      cy.visit('/questions?page=2');
+
+      cy.step('Filter while viewing a later page');
+      cy.get('[data-cy=CategoryHorizonalList]').within(() => {
+        cy.contains('Machines').click();
+      });
+
+      cy.step('Verify the category filter resets pagination');
+      cy.url().should('include', 'category=');
+      cy.url().should('not.include', 'page=');
+      cy.get('[data-cy=CategoryHorizonalList-Item-active]').should('be.visible');
+    });
+
     it('should show question list items after visit a question', () => {
       cy.get('[data-cy=question-list-item]:eq(0)').click();
       cy.get('[data-cy=question-title]').should('be.visible');

--- a/packages/cypress/src/integration/questions/search.spec.ts
+++ b/packages/cypress/src/integration/questions/search.spec.ts
@@ -44,9 +44,10 @@ describe('[Questions]', () => {
 
     it('Resets pagination when searching', () => {
       cy.visit('/questions?page=2');
+      cy.url().should('include', 'sort=Newest');
 
       cy.step('Search while viewing a later page');
-      cy.get('[data-cy=questions-search-box]').clear().type('deal');
+      cy.get('[data-cy=questions-search-box]').should('be.enabled').clear().type('deal');
 
       cy.step('Verify the search resets pagination');
       cy.url().should('include', 'q=deal');
@@ -54,6 +55,7 @@ describe('[Questions]', () => {
       cy.get('[data-cy=question-list-item]').should('have.length', 1);
 
       cy.visit('/questions?page=2');
+      cy.url().should('include', 'sort=Newest');
 
       cy.step('Filter while viewing a later page');
       cy.get('[data-cy=CategoryHorizonalList]').within(() => {

--- a/packages/cypress/src/integration/research/list.spec.ts
+++ b/packages/cypress/src/integration/research/list.spec.ts
@@ -52,6 +52,7 @@ describe('[Research - List Articles]', () => {
 
   it('[Pagination - Resets when filtering or searching]', () => {
     cy.visit(`${researchPageUrl}?page=2`);
+    cy.url().should('include', 'sort=LatestUpdated');
 
     cy.step('Select a category while viewing a later page');
     cy.get('[data-cy=CategoryHorizonalList]').within(() => {
@@ -64,9 +65,10 @@ describe('[Research - List Articles]', () => {
     cy.get('[data-cy=ResearchListItem]').should('have.length.greaterThan', 0);
 
     cy.visit(`${researchPageUrl}?page=2`);
+    cy.url().should('include', 'sort=LatestUpdated');
 
     cy.step('Search while viewing a later page');
-    cy.get('[data-cy=research-search-box]').clear().type('test');
+    cy.get('[data-cy=research-search-box]').should('be.enabled').clear().type('test');
 
     cy.step('Verify the search resets pagination');
     cy.url().should('include', 'q=test');

--- a/packages/cypress/src/integration/research/list.spec.ts
+++ b/packages/cypress/src/integration/research/list.spec.ts
@@ -49,4 +49,28 @@ describe('[Research - List Articles]', () => {
     cy.url().should('include', 'page=2');
     cy.get('[data-cy=ResearchListItem]').should('have.length.greaterThan', 0);
   });
+
+  it('[Pagination - Resets when filtering or searching]', () => {
+    cy.visit(`${researchPageUrl}?page=2`);
+
+    cy.step('Select a category while viewing a later page');
+    cy.get('[data-cy=CategoryHorizonalList]').within(() => {
+      cy.contains('Machines').click();
+    });
+
+    cy.step('Verify the category filter resets pagination');
+    cy.url().should('include', 'category=');
+    cy.url().should('not.include', 'page=');
+    cy.get('[data-cy=ResearchListItem]').should('have.length.greaterThan', 0);
+
+    cy.visit(`${researchPageUrl}?page=2`);
+
+    cy.step('Search while viewing a later page');
+    cy.get('[data-cy=research-search-box]').clear().type('test');
+
+    cy.step('Verify the search resets pagination');
+    cy.url().should('include', 'q=test');
+    cy.url().should('not.include', 'page=');
+    cy.get('[data-cy=ResearchListItem]').should('have.length.greaterThan', 0);
+  });
 });

--- a/src/pages/Library/Content/List/LibraryListHeader.tsx
+++ b/src/pages/Library/Content/List/LibraryListHeader.tsx
@@ -81,6 +81,7 @@ export const LibraryListHeader = (props: IProps) => {
   const updateFilter = useCallback(
     (key: LibrarySearchParams, value: string) => {
       const params = new URLSearchParams(searchParams.toString());
+      params.delete('page');
       if (value) {
         params.set(key, value);
       } else {
@@ -100,6 +101,7 @@ export const LibraryListHeader = (props: IProps) => {
 
   const searchValue = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete('page');
     params.set(LibrarySearchParams.q, value);
 
     if (value.length > 0 && sort !== 'MostRelevant') {

--- a/src/pages/Question/QuestionListHeader.tsx
+++ b/src/pages/Question/QuestionListHeader.tsx
@@ -82,6 +82,7 @@ export const QuestionListHeader = (props: IProps) => {
   const updateFilter = useCallback(
     (key: QuestionSearchParams, value: string) => {
       const params = new URLSearchParams(searchParams.toString());
+      params.delete('page');
       if (value) {
         params.set(key, value);
       } else {
@@ -101,6 +102,7 @@ export const QuestionListHeader = (props: IProps) => {
 
   const searchValue = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete('page');
     params.set('q', value);
 
     if (value.length > 0 && sort !== 'MostRelevant') {

--- a/src/pages/Research/Content/ResearchListHeader.tsx
+++ b/src/pages/Research/Content/ResearchListHeader.tsx
@@ -64,6 +64,7 @@ export const ResearchFilterHeader = (props: IProps) => {
 
   const handleApplySort = () => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete(ResearchSearchParams.page);
     if (pendingSort) {
       params.set(ResearchSearchParams.sort, pendingSort);
     } else {
@@ -80,6 +81,7 @@ export const ResearchFilterHeader = (props: IProps) => {
 
   const handleResetSort = () => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete(ResearchSearchParams.page);
     params.set(ResearchSearchParams.sort, DEFAULT_SORT);
     params.delete(ResearchSearchParams.status);
     setSearchParams(params);
@@ -131,6 +133,7 @@ export const ResearchFilterHeader = (props: IProps) => {
   const updateFilter = useCallback(
     (key: ResearchSearchParams, value: string) => {
       const params = new URLSearchParams(searchParams.toString());
+      params.delete(ResearchSearchParams.page);
       if (value) {
         params.set(key, value);
       } else {
@@ -150,6 +153,7 @@ export const ResearchFilterHeader = (props: IProps) => {
 
   const searchValue = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
+    params.delete(ResearchSearchParams.page);
     params.set(ResearchSearchParams.q, value);
 
     if (value.length > 0 && sort !== 'MostRelevant') {


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [ ] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Changing a search, category filter, or research sort while viewing a later result page now removes the `page` query parameter and returns the list to page one. Existing page URLs still load at their requested page.

Cypress coverage protects search and category filtering across Research, Questions, and Library.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4821

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).