### PR TITLE
feat(a11y): render site footer as landmark

### DIFF
--- a/packages/components/src/SiteFooter/SiteFooter.test.tsx
+++ b/packages/components/src/SiteFooter/SiteFooter.test.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom/vitest';
+
+import { describe, expect, it } from 'vitest';
+
+import { render } from '../test/utils';
+import { SiteFooter } from './SiteFooter';
+
+describe('SiteFooter', () => {
+  it('renders as the page contentinfo landmark', () => {
+    const { getByRole } = render(<SiteFooter siteName="Precious Plastic" />);
+
+    expect(getByRole('contentinfo')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/SiteFooter/SiteFooter.tsx
+++ b/packages/components/src/SiteFooter/SiteFooter.tsx
@@ -57,6 +57,7 @@ const OneArmyIcon = styled(Icon)`
 export const SiteFooter = ({ siteName }: SiteFooterProps) => {
   return (
     <FooterContainer
+      as="footer"
       bg="#27272c"
       sx={{ alignItems: 'center' }}
       style={{


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [ ] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

The shared site footer now renders as a semantic `footer` element, exposing the expected `contentinfo` landmark to assistive technologies without changing its visual appearance.

This completes the page-landmark work in #4826 when combined with the shared landmarks merged in #4819:

- Global header: the shared header renders as `header`.
- Navigation: desktop and mobile navigation render as labelled `nav` landmarks.
- News index and page: both are rendered through the shared News route layout and its single `main`.
- Projects index and page: both are rendered through the shared Library route layout and its single `main`.
- Research index and page: both are rendered through the shared Research route layout and its single `main`.
- Questions index and page: both are rendered through the shared Questions route layout and its single `main`.
- Map and Support: both route components render through the shared `Main` component.
- Global footer: completed by this PR.

Adding page-specific `main` elements below those route layouts would create invalid nested main landmarks, so no duplicate page-level wrappers are added.

A focused component test protects the new footer landmark. The component build, Biome check, and full component suite pass with 42 test files and 148 tests.

No screenshot is included because this is a semantic HTML-only change with no visual difference.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4826

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).