### PR TITLE
chore: preview pr

### DIFF
--- a/.github/workflows/pr-preview-fly-deploy.yml
+++ b/.github/workflows/pr-preview-fly-deploy.yml
@@ -12,6 +12,9 @@ env:
   SUPABASE_PROJECT_ID: ${{ secrets.PREVIEW_PROJECT_ID }}
   FLY_APP_NAME: community-platform-pr-${{ github.event.number }}
 
+permissions:
+  contents: read
+
 jobs:
   preview_app:
     if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
@@ -31,6 +34,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Install Fly CLI
         run: |

--- a/.github/workflows/pr-preview-remove-label.yml
+++ b/.github/workflows/pr-preview-remove-label.yml
@@ -5,6 +5,9 @@ on:
     # Trigger when labels are changed or more commits added to a PR that contains labels
     types: [closed]
 
+permissions:
+  issues: write
+
 jobs:
   preview_app:
     if: contains(github.event.pull_request.labels.*.name, 'Review allow-preview ✅')
@@ -15,12 +18,6 @@ jobs:
       group: pr-${{ github.event.number }}
 
     steps:
-      - name: Get code
-        uses: actions/checkout@v4
-        with:
-          # pull the repo from the pull request source, not the default local repo
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Remove preview label
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🔧 Tools / CI — changes to build, deploy, or developer tooling

## What is the new behavior?

Allow again preview sites for contributor PRs.
It stopped working due to tightened github security on forks + env variables.
