### PR TITLE
fix(CardButton): make interactive cards keyboard accessible

### DIFF
--- a/packages/components/src/CardButton/CardButton.test.tsx
+++ b/packages/components/src/CardButton/CardButton.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom/vitest';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { render } from '../test/utils';
+import { CardButton } from './CardButton';
+
+describe('CardButton', () => {
+  it('renders as a real button when it is clickable', () => {
+    const { getByRole } = render(
+      <CardButton onClick={vi.fn()}>Clickable</CardButton>,
+    );
+
+    const button = getByRole('button', { name: 'Clickable' });
+
+    expect(button.tagName).toEqual('BUTTON');
+    // Buttons default to type="submit", which would submit any surrounding form.
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('is reachable and activatable with the keyboard', async () => {
+    const onClick = vi.fn();
+
+    const { getByRole } = render(
+      <CardButton onClick={onClick}>Clickable</CardButton>,
+    );
+
+    const button = getByRole('button', { name: 'Clickable' });
+
+    button.focus();
+    expect(button).toHaveFocus();
+
+    button.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes its selected state to assistive technology', () => {
+    const { getByRole, rerender } = render(
+      <CardButton isSelected={false} onClick={vi.fn()}>
+        Filter
+      </CardButton>,
+    );
+
+    expect(getByRole('button', { name: 'Filter' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+
+    rerender(
+      <CardButton isSelected onClick={vi.fn()}>
+        Filter
+      </CardButton>,
+    );
+
+    expect(getByRole('button', { name: 'Filter' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('stays a plain card when there is nothing to click', () => {
+    const { queryByRole, getByText } = render(<CardButton>Static</CardButton>);
+
+    expect(queryByRole('button')).toBeNull();
+    expect(getByText('Static')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/CardButton/CardButton.tsx
+++ b/packages/components/src/CardButton/CardButton.tsx
@@ -7,11 +7,26 @@ export interface IProps extends BoxProps {
   isSelected?: boolean;
 }
 
+// When an onClick is passed the card is genuinely interactive, so it has to be
+// rendered as a real <button>. A <div> is not focusable, gets skipped by tab
+// navigation and is not announced as a control to assistive technology.
+const buttonReset: ThemeUIStyleObject = {
+  appearance: 'none',
+  color: 'inherit',
+  font: 'inherit',
+  textAlign: 'inherit',
+  // Card already provides the border via its variant.
+  border: 0,
+};
+
 export const CardButton = (props: IProps) => {
-  const { children, extrastyles, isSelected } = props;
+  const { children, extrastyles, isSelected, ...cardProps } = props;
+  const isInteractive = !!props.onClick;
 
   return (
     <Card
+      {...(isInteractive ? { as: 'button', type: 'button', 'aria-pressed': !!isSelected } : {})}
+      {...cardProps}
       sx={{
         alignItems: 'center',
         alignContent: 'center',
@@ -44,9 +59,9 @@ export const CardButton = (props: IProps) => {
               transform: 'translateY(-2px)',
             }
           : {}),
+        ...(isInteractive ? buttonReset : {}),
         ...extrastyles,
       }}
-      {...props}
     >
       {children}
     </Card>

--- a/packages/components/src/CategoryHorizonalList/CategoryHorizonalList.tsx
+++ b/packages/components/src/CategoryHorizonalList/CategoryHorizonalList.tsx
@@ -61,7 +61,10 @@ export const CategoryHorizonalList = (props: IProps) => {
             {category.imageUrl && (
               <img
                 src={category.imageUrl}
-                alt={category.name}
+                // The name is already rendered as visible text below, so the
+                // image is decorative and repeating it would double up in
+                // screen readers.
+                alt=""
                 style={{
                   width: '40px',
                   height: '40px',


### PR DESCRIPTION
Closes #4827

## The problem

The category select icons can't be reached with the keyboard. Tab jumps straight from the "Questions" nav link to the first filter control below them, so the whole row of category icons is skipped. Screen readers get nothing either — there is no control there to announce.

The cause is in `CardButton`, not in `CategoryHorizonalList`: `CardButton` always renders a theme-ui `Card`, which is a `<div>`. A `<div>` with an `onClick` is not focusable, is not in the tab order and has no button semantics. `CategoryHorizonalList` just happens to be the most visible place this shows up — `MemberTypeVerticalList` and `MapFilterListItem` on the map are unreachable for the same reason, and this fixes those too.

## The change

`CardButton` now renders as `<button type="button">` whenever an `onClick` is passed:

- Focusability and Enter/Space activation come for free from the native element, so no `tabIndex`/`onKeyDown` plumbing is needed.
- `type="button"` is set explicitly — buttons default to `type="submit"`, which would submit a surrounding form.
- The selected state is exposed as `aria-pressed`, so the toggle semantics ("Machines, pressed") are announced rather than the visual green border being the only cue.
- A small style reset (`appearance`, `color`, `font`, `text-align`, `border`) keeps the rendering identical to before, since UA button styles would otherwise leak in.

Cards without an `onClick` (`PinProfile`, `CardListItem`) are not interactive, so they keep rendering as a plain card — wrapping non-interactive content in a button would be its own a11y problem, and `CardListItem` already has an `InternalLink`/`Box` handling the click one level up.

One related fix in `CategoryHorizonalList`: the category image had `alt={category.name}`, but the name is already rendered as visible text right below it, so a screen reader read the name twice. The image is decorative, so it now has `alt=""`.

I also moved the `{...props}` spread to before `sx` instead of after. It was previously spread after `sx`, so a caller passing `sx` would silently overwrite every computed style — `extrastyles` exists precisely so that callers don't have to.

## On the second checkbox

The issue also asks to move the component into `src/components`. I've left that out: per the discussion between @mariojsnunes and @benfurber on the issue, the boundary of the new library hasn't been settled yet, and "Category List" was flagged as too specific to belong there since it depends on the `Category` model. Doing the migration now would mean guessing at that decision. This PR fixes the bug on its own; happy to follow up with the move once the boundary is agreed.

## Validation

Added `CardButton.test.tsx` covering the four behaviours: renders as a `<button>` with `type="button"`, is focusable and click-activatable, reflects `isSelected` through `aria-pressed`, and stays a non-button when there's no `onClick`. Three of those four fail on `master` and pass with this change.

- `vitest run` in `packages/components` — 43 files, 152 tests passing (up from 148; nothing existing broke)
- `tsc --build` — clean
- `biome check` — clean
