### PR TITLE
feat: add admin tag management

### DIFF
--- a/src/pages/Admin/AdminSidebar.tsx
+++ b/src/pages/Admin/AdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, FolderIcon, UsersIcon } from 'lucide-react';
+import { ChevronRightIcon, FolderIcon, TagsIcon, UsersIcon } from 'lucide-react';
 import { Link, useLocation } from 'react-router';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
@@ -25,6 +25,7 @@ const ADMIN_NAV_ITEMS = [
     ],
   },
   { label: 'Categories', href: '/admin/categories', icon: FolderIcon },
+  { label: 'Tags', href: '/admin/tags', icon: TagsIcon },
 ];
 
 export function AdminSidebar() {

--- a/src/pages/Admin/Tags/TagFormDialog.tsx
+++ b/src/pages/Admin/Tags/TagFormDialog.tsx
@@ -1,0 +1,92 @@
+import type { Tag } from 'oa-shared';
+import { type FormEvent, useEffect, useState } from 'react';
+import { useRevalidator } from 'react-router';
+import { useToast } from 'src/common/Toast/useToast';
+import { tagsService } from 'src/services/tagsService';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface IProps {
+  open: boolean;
+  tag: Tag | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+const emptyForm = { name: '' };
+
+export function TagFormDialog({ open, tag, onOpenChange }: IProps) {
+  const [form, setForm] = useState(emptyForm);
+  const [submitting, setSubmitting] = useState(false);
+  const revalidator = useRevalidator();
+  const toast = useToast();
+
+  useEffect(() => {
+    if (open) {
+      setForm(tag ? { name: tag.name } : emptyForm);
+    }
+  }, [open, tag]);
+
+  const isEditing = !!tag;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    const name = form.name.trim();
+
+    if (!name) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    const promise = (
+      isEditing ? tagsService.updateTag(tag!.id, { name }) : tagsService.createTag({ name })
+    ).finally(() => setSubmitting(false));
+
+    toast.promise(promise, {
+      loading: isEditing ? 'Saving tag...' : 'Creating tag...',
+      success: () => {
+        onOpenChange(false);
+        revalidator.revalidate();
+        return isEditing ? 'Tag saved' : 'Tag created';
+      },
+      error: (error) => error.message || 'Something went wrong',
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <DialogHeader>
+            <DialogTitle>{isEditing ? 'Edit tag' : 'New tag'}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="tag-name">Name</Label>
+            <Input
+              id="tag-name"
+              value={form.name}
+              onChange={(event) => setForm({ name: event.target.value })}
+              required
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={submitting}>
+              {isEditing ? 'Save' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/Admin/Tags/TagsPage.tsx
+++ b/src/pages/Admin/Tags/TagsPage.tsx
@@ -1,0 +1,71 @@
+import { PencilIcon, PlusIcon } from 'lucide-react';
+import type { Tag } from 'oa-shared';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { TagFormDialog } from './TagFormDialog';
+
+interface IProps {
+  tags: Tag[];
+}
+
+export function TagsPage({ tags }: IProps) {
+  const [editingTag, setEditingTag] = useState<Tag | null | undefined>(undefined);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Tags</h1>
+
+        <Button size="sm" onClick={() => setEditingTag(null)}>
+          <PlusIcon />
+          New tag
+        </Button>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead className="w-0">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {tags.map((tag) => (
+            <TableRow key={tag.id}>
+              <TableCell>{tag.name}</TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Edit ${tag.name}`}
+                  onClick={() => setEditingTag(tag)}
+                >
+                  <PencilIcon />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <TagFormDialog
+        open={editingTag !== undefined}
+        tag={editingTag ?? null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingTag(undefined);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/routes/_.admin.tags.tsx
+++ b/src/routes/_.admin.tags.tsx
@@ -1,0 +1,24 @@
+import type { DBTag } from 'oa-shared';
+import { Tag } from 'oa-shared';
+import type { LoaderFunctionArgs } from 'react-router';
+import { useLoaderData } from 'react-router';
+import { TagsPage } from 'src/pages/Admin/Tags/TagsPage';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+
+export const handle = { breadcrumb: 'Tags' };
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client } = createSupabaseServerClient(request);
+
+  const { data } = await client.from('tags').select('id,name,created_at,modified_at').order('name');
+
+  const tags = (data || []).map((tag) => Tag.fromDB(tag as DBTag));
+
+  return { tags };
+}
+
+export default function Index() {
+  const { tags } = useLoaderData<typeof loader>();
+
+  return <TagsPage tags={tags} />;
+}

--- a/src/routes/api.admin.tags.$id.ts
+++ b/src/routes/api.admin.tags.$id.ts
@@ -1,0 +1,68 @@
+import { HTTPException } from 'hono/http-exception';
+import { UserRole } from 'oa-shared';
+import type { ActionFunctionArgs } from 'react-router';
+import { logger } from 'src/logger';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+import { TagsServiceServer } from 'src/services/tagsService.server';
+import {
+  conflictError,
+  forbiddenError,
+  methodNotAllowedError,
+  unauthorizedError,
+  validationError,
+} from 'src/utils/httpException';
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  const { client, headers } = createSupabaseServerClient(request);
+  const id = Number(params.id);
+
+  try {
+    if (request.method !== 'PUT') {
+      throw methodNotAllowedError();
+    }
+
+    if (!id) {
+      throw validationError('A valid id is required', 'id');
+    }
+
+    const claims = await client.auth.getClaims();
+
+    if (!claims.data?.claims) {
+      throw unauthorizedError();
+    }
+
+    const { data: profiles } = await client
+      .from('profiles')
+      .select('id,roles')
+      .eq('auth_id', claims.data.claims.sub)
+      .limit(1);
+
+    if (!profiles?.at(0)?.roles?.includes(UserRole.ADMIN)) {
+      throw forbiddenError();
+    }
+
+    const body = await request.json();
+    const name = (body.name as string)?.trim();
+
+    if (!name) {
+      throw validationError('Name is required', 'name');
+    }
+
+    const tagService = new TagsServiceServer(client);
+
+    if (await tagService.isDuplicateName(name, id)) {
+      throw conflictError('A tag with this name already exists');
+    }
+
+    const tag = await tagService.update(id, { name });
+
+    return Response.json(tag, { headers, status: 200 });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    logger.error('Error updating tag:', error);
+    return Response.json({ error: 'Error updating tag' }, { status: 500, headers });
+  }
+};

--- a/src/routes/api.admin.tags.ts
+++ b/src/routes/api.admin.tags.ts
@@ -1,0 +1,63 @@
+import { HTTPException } from 'hono/http-exception';
+import { UserRole } from 'oa-shared';
+import type { ActionFunctionArgs } from 'react-router';
+import { logger } from 'src/logger';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+import { TagsServiceServer } from 'src/services/tagsService.server';
+import {
+  conflictError,
+  forbiddenError,
+  methodNotAllowedError,
+  unauthorizedError,
+  validationError,
+} from 'src/utils/httpException';
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { client, headers } = createSupabaseServerClient(request);
+
+  try {
+    if (request.method !== 'POST') {
+      throw methodNotAllowedError();
+    }
+
+    const claims = await client.auth.getClaims();
+
+    if (!claims.data?.claims) {
+      throw unauthorizedError();
+    }
+
+    const { data: profiles } = await client
+      .from('profiles')
+      .select('id,roles')
+      .eq('auth_id', claims.data.claims.sub)
+      .limit(1);
+
+    if (!profiles?.at(0)?.roles?.includes(UserRole.ADMIN)) {
+      throw forbiddenError();
+    }
+
+    const body = await request.json();
+    const name = (body.name as string)?.trim();
+
+    if (!name) {
+      throw validationError('Name is required', 'name');
+    }
+
+    const tagService = new TagsServiceServer(client);
+
+    if (await tagService.isDuplicateName(name)) {
+      throw conflictError('A tag with this name already exists');
+    }
+
+    const tag = await tagService.create({ name });
+
+    return Response.json(tag, { headers, status: 201 });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    logger.error('Error creating tag:', error);
+    return Response.json({ error: 'Error creating tag' }, { status: 500, headers });
+  }
+};

--- a/src/services/tagsService.server.ts
+++ b/src/services/tagsService.server.ts
@@ -1,5 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { DBTag } from 'oa-shared';
 import { Tag } from 'oa-shared';
+
+export interface TagInput {
+  name: string;
+}
 
 export class TagsServiceServer {
   constructor(private client: SupabaseClient) {}
@@ -19,5 +24,55 @@ export class TagsServiceServer {
     }
 
     return tags;
+  }
+
+  async isDuplicateName(name: string, excludeId?: number) {
+    let query = this.client.from('tags').select('id').eq('name', name);
+
+    if (excludeId) {
+      query = query.neq('id', excludeId);
+    }
+
+    const result = await query.limit(1);
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    return !!result.data?.length;
+  }
+
+  async create(data: TagInput) {
+    const result = await this.client
+      .from('tags')
+      .insert({
+        name: data.name,
+        tenant_id: process.env.TENANT_ID,
+      })
+      .select('id,name,created_at,modified_at')
+      .single();
+
+    if (result.error || !result.data) {
+      throw result.error;
+    }
+
+    return Tag.fromDB(result.data as DBTag);
+  }
+
+  async update(id: number, data: TagInput) {
+    const result = await this.client
+      .from('tags')
+      .update({
+        name: data.name,
+      })
+      .eq('id', id)
+      .select('id,name,created_at,modified_at')
+      .single();
+
+    if (result.error || !result.data) {
+      throw result.error;
+    }
+
+    return Tag.fromDB(result.data as DBTag);
   }
 }

--- a/src/services/tagsService.ts
+++ b/src/services/tagsService.ts
@@ -1,6 +1,9 @@
 import type { Tag } from 'oa-shared';
-
 import { logger } from 'src/logger';
+
+export interface TagFormData {
+  name: string;
+}
 
 const getAllTags = async () => {
   try {
@@ -12,6 +15,38 @@ const getAllTags = async () => {
   }
 };
 
+const createTag = async (form: TagFormData) => {
+  const response = await fetch('/api/admin/tags', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Error creating tag' }));
+    throw new Error(errorData.error || 'Error creating tag');
+  }
+
+  return (await response.json()) as Tag;
+};
+
+const updateTag = async (id: number, form: TagFormData) => {
+  const response = await fetch(`/api/admin/tags/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Error updating tag' }));
+    throw new Error(errorData.error || 'Error updating tag');
+  }
+
+  return (await response.json()) as Tag;
+};
+
 export const tagsService = {
   getAllTags,
+  createTag,
+  updateTag,
 };


### PR DESCRIPTION
## PR Checklist

- [ ] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [ ] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Adds a new Tags page to the admin panel so admins can manage tag definitions without using Retool.

The new admin page:
- Lists existing tags
- Allows admins to create new tags
- Allows admins to edit existing tag names
- Prevents blank tag names
- Prevents duplicate tag names and displays a clear validation error
- Restricts tag management endpoints to admin users

Deleting tags is intentionally not included, as it is out of scope for this issue.

Manually verified listing, creating, editing, blank-name validation, duplicate-name validation, and admin-only access locally.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4845 

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
