### PR TITLE
chore: middleware role check and forbidden page improvement

### DIFF
--- a/docs/react-router-7.md
+++ b/docs/react-router-7.md
@@ -1,8 +1,10 @@
 ### What is React Router 7?
+
 A React Fullstack Framework that provides server-side rendering and an API Layer.
 https://reactrouter.com/start/modes#framework
 
 ## Routing
+
 Each route is a normal React component file that should include a [loader](https://reactrouter.com/start/framework/data-loading#server-data-loading) function, that function runs exclusively on the server (or clientLoader for browser only).
 
 Parts of the component might be rendered client side, for that we can use React.lazy or wrap them with `<ClientOnly>` component from `remix-utils`.
@@ -12,6 +14,7 @@ Additionally, routes could also export [Links](https://reactrouter.com/api/compo
 For the API, we can use [action/loader](https://reactrouter.com/start/framework/actions#server-actions) routes.
 
 ## Middleware
-Routes can export a `middleware` array that runs before loaders/actions (parent to child) and can read/write a shared `context`. https://reactrouter.com/how-to/middleware
+
+Routes can export a `middleware` array that runs before loaders/actions and can read/write a shared `context`. https://reactrouter.com/how-to/middleware
 
 We use it for auth: `sessionMiddleware` (`src/middleware/session.server.ts`) resolves the current user into `context`, and `requireRole`/`requireAnyRole` (page routes) or `requireRoleApi`/`requireAnyRoleApi` (api routes) gate access based on it (`src/middleware/requireRole.server.ts`).

--- a/docs/react-router-7.md
+++ b/docs/react-router-7.md
@@ -10,3 +10,8 @@ Parts of the component might be rendered client side, for that we can use React.
 Additionally, routes could also export [Links](https://reactrouter.com/api/components/Links#links) and [Meta](https://reactrouter.com/api/components/Meta#meta) functions that will be added to the html head.
 
 For the API, we can use [action/loader](https://reactrouter.com/start/framework/actions#server-actions) routes.
+
+## Middleware
+Routes can export a `middleware` array that runs before loaders/actions (parent to child) and can read/write a shared `context`. https://reactrouter.com/how-to/middleware
+
+We use it for auth: `sessionMiddleware` (`src/middleware/session.server.ts`) resolves the current user into `context`, and `requireRole`/`requireAnyRole` (page routes) or `requireRoleApi`/`requireAnyRoleApi` (api routes) gate access based on it (`src/middleware/requireRole.server.ts`).

--- a/docs/technical-decisions.md
+++ b/docs/technical-decisions.md
@@ -24,6 +24,20 @@ How?
 - Each table has a tenant_id column
 - On each request, to supabase (via its sdk) we pass a header 'x-tenant-id' with the process.env.TENANT_ID variable, which is set for each app, via Fly.io secret.
 
+## Role Checks
+
+Roles live per-tenant in `profiles.roles`, not the Supabase JWT (a Custom Access Token Hook can't know which tenant to read - see Multi-tenant above). Checking a role therefore meant a DB query per protected route.
+
+Decision: `requireRole()` middleware, backed by a signed roles cookie, instead of a DB query per route.
+
+How?
+
+- `sessionMiddleware` trusts a valid cookie (signed with `TOKEN_SECRET`, bound to authId/tenantId) or falls back to `profiles` and re-signs it (10 min TTL).
+- `requireRole(role, page)`/`requireAnyRole(roles, page)` read the resolved roles from context and redirect - no DB access. Page routes only.
+- `requireRoleApi(role)`/`requireAnyRoleApi(roles)` do the same for `api.*` routes, throwing a JSON error `Response` instead of redirecting, since a redirect breaks `fetch()` callers.
+- Both run as route `middleware`, which completes fully before any loader runs, so roles are guaranteed resolved in time. Mounted only on routes that need it, not globally. A route that gates only some HTTP methods (e.g. a public GET + a role-gated POST) wraps the gate in a small conditional middleware instead of gating the whole route.
+- This is server-side gating only. Client-side conditional UI (e.g. showing/hiding admin buttons) still reads `profile.roles` from the profile store - it doesn't go through `sessionContext`/the roles cookie.
+
 ## Comment Counts
 
 Currently we can sort questions/research/library by the number of comments.

--- a/packages/cypress/src/integration/admin.spec.ts
+++ b/packages/cypress/src/integration/admin.spec.ts
@@ -1,0 +1,33 @@
+import { MOCK_DATA } from '../data';
+import { generateNewUserDetails, getTenantUser } from '../utils/TestUtils';
+
+const admin = getTenantUser(MOCK_DATA.users.admin);
+
+describe('[Admin]', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('[Anonymous is redirected to sign-in]', () => {
+    cy.visit('/admin');
+    cy.url().should('include', '/sign-in');
+  });
+
+  it('[Regular user is redirected to forbidden]', () => {
+    const regularUser = generateNewUserDetails();
+    cy.signUpNewUser(regularUser);
+    cy.setProfileUsername(regularUser.username);
+
+    cy.visit('/admin');
+    cy.url().should('include', '/forbidden?page=admin');
+    cy.contains("You don't have the right permissions");
+  });
+
+  it('[Admin can access the admin panel]', () => {
+    cy.signIn(admin.email, admin.password);
+
+    cy.visit('/admin');
+    cy.url().should('include', '/admin/users');
+    cy.contains('Overview');
+  });
+});

--- a/packages/cypress/src/integration/common.spec.ts
+++ b/packages/cypress/src/integration/common.spec.ts
@@ -39,9 +39,15 @@ describe('[Common]', () => {
     cy.contains("You don't have the right permissions");
     cy.contains('Report the problem');
 
-    cy.visit('/forbidden?page=news-create');
+    cy.step('research-create still shows the early-access message');
+    cy.visit('/forbidden?page=research-create');
     cy.contains('This is a new feature');
     cy.contains('I want to use it');
+
+    cy.step('news-create shows a plain permission message, not early-access');
+    cy.visit('/forbidden?page=news-create');
+    cy.contains("You don't have permission to create news posts");
+    cy.contains('Report the problem');
   });
 
   describe('[User feedback button]', () => {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,18 +1,28 @@
+import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
 
-function Card({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="card"
-      className={cn(
-        'flex flex-col gap-4 rounded-xl border bg-card py-4 text-card-foreground shadow-sm',
-        className,
-      )}
-      {...props}
-    />
-  );
+const cardVariants = cva(
+  'flex flex-col gap-4 rounded-[15px] bg-card py-4 text-card-foreground shadow-sm',
+  {
+    variants: {
+      variant: {
+        default: 'border',
+        outline: 'border-2 border-[#1b1b1b]',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Card({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof cardVariants>) {
+  return <div data-slot="card" className={cn(cardVariants({ variant, className }))} {...props} />;
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
@@ -51,4 +61,4 @@ function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, cardVariants };

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react-router';
+
+export type Session = {
+  authId: string;
+  roles: string[];
+} | null;
+
+export const sessionContext = createContext<Session>(null);

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,6 +2,8 @@ import { createContext } from 'react-router';
 
 export type Session = {
   authId: string;
+  profileId: number | null;
+  username: string | null;
   roles: string[];
 } | null;
 

--- a/src/middleware/requireRole.server.ts
+++ b/src/middleware/requireRole.server.ts
@@ -2,12 +2,13 @@ import type { UserRole } from 'oa-shared';
 import type { MiddlewareFunction } from 'react-router';
 import { redirect } from 'react-router';
 import { sessionContext } from 'src/context';
+import type { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { redirectServiceServer } from 'src/services/redirectService.server';
 import { forbiddenError, unauthorizedError } from 'src/utils/httpException';
 
 export const requireRole = (
   role: UserRole,
-  forbiddenPage: string,
+  forbiddenPage: ForbiddenPage,
 ): MiddlewareFunction<Response> => {
   return ({ request, context }) => {
     const session = context.get(sessionContext);
@@ -24,7 +25,7 @@ export const requireRole = (
 
 export const requireAnyRole = (
   roles: UserRole[],
-  forbiddenPage: string,
+  forbiddenPage: ForbiddenPage,
 ): MiddlewareFunction<Response> => {
   return ({ request, context }) => {
     const session = context.get(sessionContext);

--- a/src/middleware/requireRole.server.ts
+++ b/src/middleware/requireRole.server.ts
@@ -1,0 +1,69 @@
+import type { UserRole } from 'oa-shared';
+import type { MiddlewareFunction } from 'react-router';
+import { redirect } from 'react-router';
+import { sessionContext } from 'src/context';
+import { redirectServiceServer } from 'src/services/redirectService.server';
+import { forbiddenError, unauthorizedError } from 'src/utils/httpException';
+
+export const requireRole = (
+  role: UserRole,
+  forbiddenPage: string,
+): MiddlewareFunction<Response> => {
+  return ({ request, context }) => {
+    const session = context.get(sessionContext);
+
+    if (!session) {
+      throw redirectServiceServer.redirectSignIn(new URL(request.url).pathname, new Headers());
+    }
+
+    if (!session.roles.includes(role)) {
+      throw redirect(`/forbidden?page=${encodeURIComponent(forbiddenPage)}`);
+    }
+  };
+};
+
+export const requireAnyRole = (
+  roles: UserRole[],
+  forbiddenPage: string,
+): MiddlewareFunction<Response> => {
+  return ({ request, context }) => {
+    const session = context.get(sessionContext);
+
+    if (!session) {
+      throw redirectServiceServer.redirectSignIn(new URL(request.url).pathname, new Headers());
+    }
+
+    if (!roles.some((role) => session.roles.includes(role))) {
+      throw redirect(`/forbidden?page=${encodeURIComponent(forbiddenPage)}`);
+    }
+  };
+};
+
+// API routes return a JSON error Response instead of redirecting - a redirect breaks fetch() callers.
+export const requireRoleApi = (role: UserRole): MiddlewareFunction<Response> => {
+  return ({ context }) => {
+    const session = context.get(sessionContext);
+
+    if (!session) {
+      throw unauthorizedError().getResponse();
+    }
+
+    if (!session.roles.includes(role)) {
+      throw forbiddenError().getResponse();
+    }
+  };
+};
+
+export const requireAnyRoleApi = (roles: UserRole[]): MiddlewareFunction<Response> => {
+  return ({ context }) => {
+    const session = context.get(sessionContext);
+
+    if (!session) {
+      throw unauthorizedError().getResponse();
+    }
+
+    if (!roles.some((role) => session.roles.includes(role))) {
+      throw forbiddenError().getResponse();
+    }
+  };
+};

--- a/src/middleware/session.server.ts
+++ b/src/middleware/session.server.ts
@@ -22,30 +22,44 @@ export const sessionMiddleware: MiddlewareFunction<Response> = async (
   const authId = claims.data?.claims?.sub;
   const tenantId = process.env.TENANT_ID!;
 
+  let profileId: number | null = null;
+  let username: string | null = null;
   let roles: string[] = [];
   let shouldReissueCookie = false;
 
   if (authId) {
-    const cachedRoles = rolesCookie.verify(request, authId, tenantId);
+    const cached = rolesCookie.verify(request, authId, tenantId);
 
-    if (cachedRoles) {
-      roles = cachedRoles;
+    if (cached) {
+      profileId = cached.profileId;
+      username = cached.username;
+      roles = cached.roles;
     } else {
-      const { data } = await client.from('profiles').select('roles').eq('auth_id', authId).limit(1);
+      const { data } = await client
+        .from('profiles')
+        .select('id,username,roles')
+        .eq('auth_id', authId)
+        .limit(1);
 
-      roles = data?.at(0)?.roles ?? [];
+      const profile = data?.at(0);
+      profileId = profile?.id ?? null;
+      username = profile?.username ?? null;
+      roles = profile?.roles ?? [];
       shouldReissueCookie = true;
     }
   }
 
-  context.set(sessionContext, authId ? { authId, roles } : null);
+  context.set(sessionContext, authId ? { authId, profileId, username, roles } : null);
 
   const response = await next();
 
   mergeHeaders(headers, response.headers);
 
   if (shouldReissueCookie && authId) {
-    response.headers.append('Set-Cookie', rolesCookie.sign({ authId, tenantId, roles }));
+    response.headers.append(
+      'Set-Cookie',
+      rolesCookie.sign({ authId, tenantId, profileId, username, roles }),
+    );
   }
 
   return response;

--- a/src/middleware/session.server.ts
+++ b/src/middleware/session.server.ts
@@ -1,0 +1,52 @@
+import type { MiddlewareFunction } from 'react-router';
+import { sessionContext } from 'src/context';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+import { rolesCookie } from 'src/utils/rolesCookie.server';
+
+const mergeHeaders = (from: Headers, into: Headers) => {
+  from.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      into.append(key, value);
+    } else {
+      into.set(key, value);
+    }
+  });
+};
+
+export const sessionMiddleware: MiddlewareFunction<Response> = async (
+  { request, context },
+  next,
+) => {
+  const { client, headers } = createSupabaseServerClient(request);
+  const claims = await client.auth.getClaims();
+  const authId = claims.data?.claims?.sub;
+  const tenantId = process.env.TENANT_ID!;
+
+  let roles: string[] = [];
+  let shouldReissueCookie = false;
+
+  if (authId) {
+    const cachedRoles = rolesCookie.verify(request, authId, tenantId);
+
+    if (cachedRoles) {
+      roles = cachedRoles;
+    } else {
+      const { data } = await client.from('profiles').select('roles').eq('auth_id', authId).limit(1);
+
+      roles = data?.at(0)?.roles ?? [];
+      shouldReissueCookie = true;
+    }
+  }
+
+  context.set(sessionContext, authId ? { authId, roles } : null);
+
+  const response = await next();
+
+  mergeHeaders(headers, response.headers);
+
+  if (shouldReissueCookie && authId) {
+    response.headers.append('Set-Cookie', rolesCookie.sign({ authId, tenantId, roles }));
+  }
+
+  return response;
+};

--- a/src/pages/Forbidden/labels.ts
+++ b/src/pages/Forbidden/labels.ts
@@ -1,0 +1,51 @@
+export const ForbiddenPage = {
+  ADMIN: 'admin',
+  RESEARCH_CREATE: 'research-create',
+  NEWS_CREATE: 'news-create',
+  RESEARCH_EDIT: 'research-edit',
+  RESEARCH_EDIT_CREATE: 'research-edit-create',
+  RESEARCH_UPDATE_EDIT: 'research-update-edit',
+  NEWS_EDIT: 'news-edit',
+  QUESTION_EDIT: 'question-edit',
+  LIBRARY_EDIT: 'library-edit',
+} as const;
+
+export type ForbiddenPage = (typeof ForbiddenPage)[keyof typeof ForbiddenPage];
+
+type ForbiddenMessage = { heading?: string; body: string; actionLabel?: string };
+
+const DEFAULT_HEADING = 'Restricted area';
+const DEFAULT_ACTION_LABEL = 'Report the problem';
+const DEFAULT_BODY =
+  "You don't have the right permissions to go here right now. If this is wrong, please let us know.";
+
+// Only pages needing copy that differs from the default go here - most gates need nothing added.
+const OVERRIDES: Partial<Record<ForbiddenPage, ForbiddenMessage>> = {
+  [ForbiddenPage.RESEARCH_CREATE]: {
+    heading: "Oh no you can't post, yet",
+    body: "This is a new feature and we are currently rolling it out to a small group of people. Let us know if you have a project to share and want to be an early tester. We'd love to set you up.",
+    actionLabel: 'I want to use it',
+  },
+  [ForbiddenPage.NEWS_CREATE]: { body: "You don't have permission to create news posts." },
+  [ForbiddenPage.RESEARCH_EDIT]: { body: "You don't have permission to edit this research." },
+  [ForbiddenPage.RESEARCH_EDIT_CREATE]: {
+    body: "You don't have permission to add an update to this research.",
+  },
+  [ForbiddenPage.RESEARCH_UPDATE_EDIT]: {
+    body: "You don't have permission to edit this research update.",
+  },
+  [ForbiddenPage.NEWS_EDIT]: { body: "You don't have permission to edit this news post." },
+  [ForbiddenPage.QUESTION_EDIT]: { body: "You don't have permission to edit this question." },
+  [ForbiddenPage.LIBRARY_EDIT]: { body: "You don't have permission to edit this project." },
+  // ADMIN intentionally has no override - the default message already fits.
+};
+
+export function getForbiddenMessage(page: string | null) {
+  const override = page ? OVERRIDES[page as ForbiddenPage] : undefined;
+
+  return {
+    heading: override?.heading ?? DEFAULT_HEADING,
+    body: override?.body ?? DEFAULT_BODY,
+    actionLabel: override?.actionLabel ?? DEFAULT_ACTION_LABEL,
+  };
+}

--- a/src/routes/_.admin.tsx
+++ b/src/routes/_.admin.tsx
@@ -1,11 +1,11 @@
 import { ChevronRightIcon } from 'lucide-react';
 import { UserRole } from 'oa-shared';
-import type { LoaderFunctionArgs } from 'react-router';
-import { Outlet, redirect, useMatches } from 'react-router';
+import type { MiddlewareFunction } from 'react-router';
+import { Outlet, useMatches } from 'react-router';
+import { requireRole } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { AdminSidebar } from 'src/pages/Admin/AdminSidebar';
 import Main from 'src/pages/common/Layout/Main';
-import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { redirectServiceServer } from 'src/services/redirectService.server';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 
 interface AdminRouteHandle {
@@ -13,26 +13,10 @@ interface AdminRouteHandle {
   breadcrumbParent?: string;
 }
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, headers } = createSupabaseServerClient(request);
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
-    return redirectServiceServer.redirectSignIn('/admin', headers);
-  }
-
-  const { data } = await client
-    .from('profiles')
-    .select('id,roles')
-    .eq('auth_id', claims.data.claims.sub)
-    .limit(1);
-
-  if (!data?.at(0)?.roles?.includes(UserRole.ADMIN)) {
-    return redirect('/forbidden?page=admin', { headers });
-  }
-
-  return null;
-}
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRole(UserRole.ADMIN, 'admin'),
+];
 
 export default function AdminLayout() {
   const matches = useMatches();

--- a/src/routes/_.admin.tsx
+++ b/src/routes/_.admin.tsx
@@ -6,6 +6,7 @@ import { requireRole } from 'src/middleware/requireRole.server';
 import { sessionMiddleware } from 'src/middleware/session.server';
 import { AdminSidebar } from 'src/pages/Admin/AdminSidebar';
 import Main from 'src/pages/common/Layout/Main';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 
 interface AdminRouteHandle {
@@ -15,7 +16,7 @@ interface AdminRouteHandle {
 
 export const middleware: MiddlewareFunction<Response>[] = [
   sessionMiddleware,
-  requireRole(UserRole.ADMIN, 'admin'),
+  requireRole(UserRole.ADMIN, ForbiddenPage.ADMIN),
 ];
 
 export default function AdminLayout() {

--- a/src/routes/_.forbidden.tsx
+++ b/src/routes/_.forbidden.tsx
@@ -2,6 +2,7 @@ import { Button, ExternalLink } from 'oa-components';
 import type { LoaderFunctionArgs } from 'react-router';
 import { useLoaderData } from 'react-router';
 import Main from 'src/pages/common/Layout/Main';
+import { getForbiddenMessage } from 'src/pages/Forbidden/labels';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { TenantSettingsService } from 'src/services/tenantSettingsService.server';
 import { Card, Flex, Heading, Text } from 'theme-ui';
@@ -21,7 +22,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export default function Index() {
   const { page, settings, url } = useLoaderData<typeof loader>() || {};
 
-  const actionLabel = page ? 'I want to use it' : 'Report the problem';
+  const { heading, body, actionLabel } = getForbiddenMessage(page);
 
   return (
     <Main style={{ flex: 1 }}>
@@ -58,30 +59,12 @@ export default function Index() {
                     textAlign: 'center',
                   }}
                 >
-                  <Heading>Oh no you can't post, yet</Heading>
+                  <Heading>{heading}</Heading>
                 </Flex>
                 <Text sx={{ textAlign: 'center', color: 'grey' }}>
-                  {page ? (
-                    <>
-                      <p>
-                        <strong>
-                          This is a new feature and we are currently rolling it out to a small group
-                          of people.
-                        </strong>
-                      </p>
-                      <p>
-                        Let us know if you have a project to share and want to be an early tester.
-                        We'd love to set you up.
-                      </p>
-                    </>
-                  ) : (
-                    <p>
-                      <strong>
-                        You don't have the right permissions to go here right now. If this is wrong,
-                        please let us know.
-                      </strong>
-                    </p>
-                  )}
+                  <p>
+                    <strong>{body}</strong>
+                  </p>
                   <ExternalLink
                     href={`mailto:${settings.emailFrom}&subject:Cannot access ${page || url}`}
                   >

--- a/src/routes/_.forbidden.tsx
+++ b/src/routes/_.forbidden.tsx
@@ -1,11 +1,11 @@
-import { Button, ExternalLink } from 'oa-components';
 import type { LoaderFunctionArgs } from 'react-router';
 import { useLoaderData } from 'react-router';
 import Main from 'src/pages/common/Layout/Main';
 import { getForbiddenMessage } from 'src/pages/Forbidden/labels';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { TenantSettingsService } from 'src/services/tenantSettingsService.server';
-import { Card, Flex, Heading, Text } from 'theme-ui';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { client } = createSupabaseServerClient(request);
@@ -26,56 +26,24 @@ export default function Index() {
 
   return (
     <Main style={{ flex: 1 }}>
-      <Flex
-        sx={{
-          background: 'inherit',
-          paddingX: 2,
-          width: '100%',
-          maxWidth: '620px',
-          marginX: 'auto',
-          marginTop: [5, 10],
-        }}
-      >
-        <Flex sx={{ flexDirection: 'column', width: '100%' }}>
-          <Flex
-            sx={{
-              flexDirection: 'column',
-            }}
-          >
-            <Card sx={{ borderRadius: 3 }}>
-              <Flex
-                sx={{
-                  padding: 4,
-                  paddingTop: 6,
-                  gap: 2,
-                  flexDirection: 'column',
-                }}
-              >
-                <Flex
-                  sx={{
-                    gap: 1,
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    textAlign: 'center',
-                  }}
-                >
-                  <Heading>{heading}</Heading>
-                </Flex>
-                <Text sx={{ textAlign: 'center', color: 'grey' }}>
-                  <p>
-                    <strong>{body}</strong>
-                  </p>
-                  <ExternalLink
-                    href={`mailto:${settings.emailFrom}&subject:Cannot access ${page || url}`}
-                  >
-                    <Button>{actionLabel}</Button>
-                  </ExternalLink>
-                </Text>
-              </Flex>
-            </Card>
-          </Flex>
-        </Flex>
-      </Flex>
+      <div className="mx-auto mt-10 w-full max-w-[620px] px-2 md:mt-20">
+        <Card variant="outline">
+          <CardHeader className="items-center text-center">
+            <h1 className="text-2xl font-semibold">{heading}</h1>
+          </CardHeader>
+          <CardContent className="flex flex-col items-center gap-2 text-center text-sm text-muted-foreground">
+            <p className="font-medium">{body}</p>
+            <Button
+              render={
+                <a href={`mailto:${settings.emailFrom}&subject:Cannot access ${page || url}`} />
+              }
+              nativeButton={false}
+            >
+              {actionLabel}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
     </Main>
   );
 }

--- a/src/routes/_.library.$slug.edit.tsx
+++ b/src/routes/_.library.$slug.edit.tsx
@@ -1,6 +1,7 @@
 import { DBProject } from 'oa-shared';
 import type { LoaderFunctionArgs } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { LibraryForm } from 'src/pages/Library/Content/Common/LibraryForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { LibraryServiceServer } from 'src/services/libraryService.server';
@@ -24,7 +25,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     .data as unknown as DBProject;
 
   if (!profile || !(await libraryService.isAllowedToEditProject(projectDb, profile))) {
-    return redirect('/forbidden?page=library-edit', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.LIBRARY_EDIT}`, { headers });
   }
 
   const allImages = projectDb.steps?.flatMap((x) => x.images).filter((x) => !!x) || [];

--- a/src/routes/_.news.$slug.edit.tsx
+++ b/src/routes/_.news.$slug.edit.tsx
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { DBNews, NewsFormData, UserRole } from 'oa-shared';
 import type { LoaderFunctionArgs } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { NewsForm } from 'src/pages/News/Content/Common/NewsForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { NewsServiceServer } from 'src/services/newsService.server';
@@ -29,7 +30,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 
   if (!(await isAllowedToEdit(result.data.created_by, claims.data.claims.sub, client))) {
-    return redirect('/forbidden?page=news-edit', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.NEWS_EDIT}`, { headers });
   }
 
   const dbNews = result.data as unknown as DBNews;

--- a/src/routes/_.news.create.tsx
+++ b/src/routes/_.news.create.tsx
@@ -3,13 +3,14 @@ import type { MiddlewareFunction } from 'react-router';
 import { UserAction } from 'src/common/UserAction';
 import { requireAnyRole } from 'src/middleware/requireRole.server';
 import { sessionMiddleware } from 'src/middleware/session.server';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { NewsForm } from 'src/pages/News/Content/Common/NewsForm';
 import { listing } from 'src/pages/News/labels';
 import { Box } from 'theme-ui';
 
 export const middleware: MiddlewareFunction<Response>[] = [
   sessionMiddleware,
-  requireAnyRole([UserRole.ADMIN, UserRole.EDITOR], 'news-create'),
+  requireAnyRole([UserRole.ADMIN, UserRole.EDITOR], ForbiddenPage.NEWS_CREATE),
 ];
 
 export default function Index() {

--- a/src/routes/_.news.create.tsx
+++ b/src/routes/_.news.create.tsx
@@ -1,36 +1,16 @@
 import { UserRole } from 'oa-shared';
-import type { LoaderFunctionArgs } from 'react-router';
-import { redirect } from 'react-router';
+import type { MiddlewareFunction } from 'react-router';
 import { UserAction } from 'src/common/UserAction';
+import { requireAnyRole } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { NewsForm } from 'src/pages/News/Content/Common/NewsForm';
 import { listing } from 'src/pages/News/labels';
-import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { redirectServiceServer } from 'src/services/redirectService.server';
 import { Box } from 'theme-ui';
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, headers } = createSupabaseServerClient(request);
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
-    return redirectServiceServer.redirectSignIn('/news/create', headers);
-  }
-
-  const { data } = await client
-    .from('profiles')
-    .select('id,roles')
-    .eq('auth_id', claims.data.claims.sub)
-    .limit(1);
-
-  if (
-    !data!.at(0)!.roles?.includes(UserRole.ADMIN) &&
-    !data!.at(0)!.roles?.includes(UserRole.EDITOR)
-  ) {
-    return redirect('/forbidden?page=news-create', { headers });
-  }
-
-  return null;
-}
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireAnyRole([UserRole.ADMIN, UserRole.EDITOR], 'news-create'),
+];
 
 export default function Index() {
   return (

--- a/src/routes/_.questions.$slug.edit.tsx
+++ b/src/routes/_.questions.$slug.edit.tsx
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { DBQuestion, UserRole } from 'oa-shared';
 import type { LoaderFunctionArgs } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { QuestionForm } from 'src/pages/Question/Content/Common/QuestionForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { QuestionServiceServer } from 'src/services/questionService.server';
@@ -30,7 +31,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const dbQuestion = result.data as unknown as DBQuestion;
 
   if (!(await isUserAllowedToEdit(dbQuestion, claims.data.claims.sub, client))) {
-    return redirect('/forbidden?page=question-edit', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.QUESTION_EDIT}`, { headers });
   }
 
   const publicImages = dbQuestion?.images

--- a/src/routes/_.research.$slug.edit-update.$updateId.tsx
+++ b/src/routes/_.research.$slug.edit-update.$updateId.tsx
@@ -1,19 +1,21 @@
 import { DBResearchUpdate, ResearchItem } from 'oa-shared';
-import type { LoaderFunctionArgs } from 'react-router';
+import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { sessionContext } from 'src/context';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { ResearchUpdateForm } from 'src/pages/Research/Content/Common/ResearchUpdateForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { ProfileServiceServer } from 'src/services/profileService.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
 import { ResearchServiceServer } from 'src/services/researchService.server';
 import { StorageServiceServer } from 'src/services/storageService.server';
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export async function loader({ request, params, context }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
+  const session = context.get(sessionContext);
 
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
+  if (!session) {
     return redirectServiceServer.redirectSignIn(
       `/research/${params.slug}/edit-update/${params.updateId}`,
       headers,
@@ -28,9 +30,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return redirect('/research', { headers });
   }
 
-  const profile = await new ProfileServiceServer(client).getByAuthId(claims.data.claims.sub);
   const researchDb = result.item;
-  const currentUser = profile ? { id: profile.id, username: profile.username } : undefined;
+  const currentUser = session.profileId
+    ? { id: session.profileId, username: session.username }
+    : undefined;
   const research = ResearchItem.fromDB(researchDb, [], [], result.collaborators, currentUser);
   const update = research.updates.find((x) => x.id === Number(params.updateId));
 
@@ -38,7 +41,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return redirect('/research', { headers });
   }
 
-  if (!profile || !(await researchService.isAllowedToEditResearch(researchDb, profile))) {
+  const canEdit =
+    session.profileId &&
+    (await researchService.isAllowedToEditResearch(researchDb, {
+      id: session.profileId,
+      username: session.username,
+      roles: session.roles,
+    }));
+
+  if (!canEdit) {
     return redirect('/forbidden?page=research-update-edit', { headers });
   }
 

--- a/src/routes/_.research.$slug.edit-update.$updateId.tsx
+++ b/src/routes/_.research.$slug.edit-update.$updateId.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
 import { sessionContext } from 'src/context';
 import { sessionMiddleware } from 'src/middleware/session.server';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { ResearchUpdateForm } from 'src/pages/Research/Content/Common/ResearchUpdateForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
@@ -50,7 +51,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
     }));
 
   if (!canEdit) {
-    return redirect('/forbidden?page=research-update-edit', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.RESEARCH_UPDATE_EDIT}`, { headers });
   }
 
   const updateDb = researchDb.updates.find((x) => x.id === Number(params.updateId));

--- a/src/routes/_.research.$slug.edit.tsx
+++ b/src/routes/_.research.$slug.edit.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
 import { sessionContext } from 'src/context';
 import { sessionMiddleware } from 'src/middleware/session.server';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import ResearchForm from 'src/pages/Research/Content/Common/ResearchForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
@@ -47,7 +48,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
     }));
 
   if (!canEdit) {
-    return redirect('/forbidden?page=research-edit', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.RESEARCH_EDIT}`, { headers });
   }
 
   return data({ formData, id: researchDb.id, research }, { headers });

--- a/src/routes/_.research.$slug.edit.tsx
+++ b/src/routes/_.research.$slug.edit.tsx
@@ -1,19 +1,21 @@
 import { DBResearchItem, ResearchItem } from 'oa-shared';
-import type { LoaderFunctionArgs } from 'react-router';
+import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { sessionContext } from 'src/context';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import ResearchForm from 'src/pages/Research/Content/Common/ResearchForm';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { ProfileServiceServer } from 'src/services/profileService.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
 import { ResearchServiceServer } from 'src/services/researchService.server';
 import { StorageServiceServer } from 'src/services/storageService.server';
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export async function loader({ request, params, context }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
+  const session = context.get(sessionContext);
 
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
+  if (!session) {
     return redirectServiceServer.redirectSignIn(`/research/${params.slug}/edit`, headers);
   }
 
@@ -24,7 +26,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return redirect('/research', { headers });
   }
 
-  const profile = await new ProfileServiceServer(client).getByAuthId(claims.data.claims.sub);
   const researchDb = result.item as unknown as DBResearchItem;
 
   const image = researchDb?.image
@@ -32,10 +33,20 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     : null;
 
   const formData = DBResearchItem.toFormData(researchDb, image);
-  const currentUser = profile ? { id: profile.id, username: profile.username } : undefined;
+  const currentUser = session.profileId
+    ? { id: session.profileId, username: session.username }
+    : undefined;
   const research = ResearchItem.fromDB(researchDb, [], [], result.collaborators, currentUser);
 
-  if (!profile || !(await researchService.isAllowedToEditResearch(researchDb, profile))) {
+  const canEdit =
+    session.profileId &&
+    (await researchService.isAllowedToEditResearch(researchDb, {
+      id: session.profileId,
+      username: session.username,
+      roles: session.roles,
+    }));
+
+  if (!canEdit) {
     return redirect('/forbidden?page=research-edit', { headers });
   }
 

--- a/src/routes/_.research.$slug.new-update.tsx
+++ b/src/routes/_.research.$slug.new-update.tsx
@@ -1,18 +1,20 @@
 import { DBResearchItem, ResearchItem } from 'oa-shared';
-import type { LoaderFunctionArgs } from 'react-router';
+import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
+import { sessionContext } from 'src/context';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { ResearchUpdateForm } from 'src/pages/Research/Content/Common';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { ProfileServiceServer } from 'src/services/profileService.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
 import { ResearchServiceServer } from 'src/services/researchService.server';
 
-export async function loader({ request, params }: LoaderFunctionArgs) {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export async function loader({ request, params, context }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
+  const session = context.get(sessionContext);
 
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
+  if (!session) {
     return redirectServiceServer.redirectSignIn(`/research/${params.slug}/new-update`, headers);
   }
 
@@ -24,11 +26,18 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return redirect('/research', { headers });
   }
 
-  const profile = await new ProfileServiceServer(client).getByAuthId(claims.data.claims.sub);
   const researchDb = result.item as unknown as DBResearchItem;
   const research = ResearchItem.fromDB(researchDb, [], [], result.collaborators);
 
-  if (!profile || !(await researchService.isAllowedToEditResearch(researchDb, profile))) {
+  const canEdit =
+    session.profileId &&
+    (await researchService.isAllowedToEditResearch(researchDb, {
+      id: session.profileId,
+      username: session.username,
+      roles: session.roles,
+    }));
+
+  if (!canEdit) {
     return redirect('/forbidden?page=research-edit-create', { headers });
   }
 

--- a/src/routes/_.research.$slug.new-update.tsx
+++ b/src/routes/_.research.$slug.new-update.tsx
@@ -3,6 +3,7 @@ import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { data, redirect, useLoaderData } from 'react-router';
 import { sessionContext } from 'src/context';
 import { sessionMiddleware } from 'src/middleware/session.server';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import { ResearchUpdateForm } from 'src/pages/Research/Content/Common';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { redirectServiceServer } from 'src/services/redirectService.server';
@@ -38,7 +39,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
     }));
 
   if (!canEdit) {
-    return redirect('/forbidden?page=research-edit-create', { headers });
+    return redirect(`/forbidden?page=${ForbiddenPage.RESEARCH_EDIT_CREATE}`, { headers });
   }
 
   return data({ research }, { headers });

--- a/src/routes/_.research.create.tsx
+++ b/src/routes/_.research.create.tsx
@@ -2,11 +2,12 @@ import { UserRole } from 'oa-shared';
 import type { MiddlewareFunction } from 'react-router';
 import { requireAnyRole } from 'src/middleware/requireRole.server';
 import { sessionMiddleware } from 'src/middleware/session.server';
+import { ForbiddenPage } from 'src/pages/Forbidden/labels';
 import ResearchForm from 'src/pages/Research/Content/Common/ResearchForm';
 
 export const middleware: MiddlewareFunction<Response>[] = [
   sessionMiddleware,
-  requireAnyRole([UserRole.ADMIN, UserRole.RESEARCH_CREATOR], 'research-create'),
+  requireAnyRole([UserRole.ADMIN, UserRole.RESEARCH_CREATOR], ForbiddenPage.RESEARCH_CREATE),
 ];
 
 export default function Index() {

--- a/src/routes/_.research.create.tsx
+++ b/src/routes/_.research.create.tsx
@@ -1,34 +1,13 @@
 import { UserRole } from 'oa-shared';
-import { data, redirect } from 'react-router';
+import type { MiddlewareFunction } from 'react-router';
+import { requireAnyRole } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import ResearchForm from 'src/pages/Research/Content/Common/ResearchForm';
-import { createSupabaseServerClient } from 'src/repository/supabase.server';
-import { ProfileServiceServer } from 'src/services/profileService.server';
-import { redirectServiceServer } from 'src/services/redirectService.server';
 
-export async function loader({ request }) {
-  const { client, headers } = createSupabaseServerClient(request);
-
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
-    return redirectServiceServer.redirectSignIn('/research/create', headers);
-  }
-
-  const profileService = new ProfileServiceServer(client);
-  const profile = await profileService.getByAuthId(claims.data.claims.sub);
-  const roles = (profile?.roles || []) as string[];
-
-  // Check if user has required permissions
-  const isAdmin = roles?.includes(UserRole.ADMIN) ?? false;
-  const isResearchCreator = roles?.includes(UserRole.RESEARCH_CREATOR) ?? false;
-  const canCreate = isAdmin || isResearchCreator;
-
-  if (!canCreate) {
-    return redirect('/forbidden?page=research-create', { headers });
-  }
-
-  return data(null, { headers });
-}
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireAnyRole([UserRole.ADMIN, UserRole.RESEARCH_CREATOR], 'research-create'),
+];
 
 export default function Index() {
   return <ResearchForm formData={null} id={null} research={null} />;

--- a/src/routes/api.admin.categories.$id.ts
+++ b/src/routes/api.admin.categories.$id.ts
@@ -1,18 +1,20 @@
 import { HTTPException } from 'hono/http-exception';
 import type { ContentType } from 'oa-shared';
 import { UserRole } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
 import { logger } from 'src/logger';
+import { requireRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { CategoryServiceServer } from 'src/services/categoryService.server';
-import {
-  forbiddenError,
-  methodNotAllowedError,
-  unauthorizedError,
-  validationError,
-} from 'src/utils/httpException';
+import { methodNotAllowedError, validationError } from 'src/utils/httpException';
 
 const CATEGORY_TYPES: ContentType[] = ['questions', 'projects', 'research', 'news'];
+
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRoleApi(UserRole.ADMIN),
+];
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
   const { client, headers } = createSupabaseServerClient(request);
@@ -25,22 +27,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 
     if (!id) {
       throw validationError('A valid id is required', 'id');
-    }
-
-    const claims = await client.auth.getClaims();
-
-    if (!claims.data?.claims) {
-      throw unauthorizedError();
-    }
-
-    const { data: profiles } = await client
-      .from('profiles')
-      .select('id,roles')
-      .eq('auth_id', claims.data.claims.sub)
-      .limit(1);
-
-    if (!profiles?.at(0)?.roles?.includes(UserRole.ADMIN)) {
-      throw forbiddenError();
     }
 
     const categoryServiceServer = new CategoryServiceServer(client);

--- a/src/routes/api.admin.categories.ts
+++ b/src/routes/api.admin.categories.ts
@@ -1,18 +1,20 @@
 import { HTTPException } from 'hono/http-exception';
 import type { ContentType } from 'oa-shared';
 import { UserRole } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
 import { logger } from 'src/logger';
+import { requireRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { CategoryServiceServer } from 'src/services/categoryService.server';
-import {
-  forbiddenError,
-  methodNotAllowedError,
-  unauthorizedError,
-  validationError,
-} from 'src/utils/httpException';
+import { methodNotAllowedError, validationError } from 'src/utils/httpException';
 
 const CATEGORY_TYPES: ContentType[] = ['questions', 'projects', 'research', 'news'];
+
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRoleApi(UserRole.ADMIN),
+];
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { client, headers } = createSupabaseServerClient(request);
@@ -20,22 +22,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   try {
     if (request.method !== 'POST') {
       throw methodNotAllowedError();
-    }
-
-    const claims = await client.auth.getClaims();
-
-    if (!claims.data?.claims) {
-      throw unauthorizedError();
-    }
-
-    const { data: profiles } = await client
-      .from('profiles')
-      .select('id,roles')
-      .eq('auth_id', claims.data.claims.sub)
-      .limit(1);
-
-    if (!profiles?.at(0)?.roles?.includes(UserRole.ADMIN)) {
-      throw forbiddenError();
     }
 
     const body = await request.json();

--- a/src/routes/api.admin.images.$path.ts
+++ b/src/routes/api.admin.images.$path.ts
@@ -1,35 +1,19 @@
 import { HTTPException } from 'hono/http-exception';
 import { UserRole } from 'oa-shared';
-import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { isAllowedImagePickerPath } from 'src/config/imagePickerPaths';
 import { logger } from 'src/logger';
+import { requireRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { StorageServiceServer } from 'src/services/storageService.server';
-import {
-  forbiddenError,
-  methodNotAllowedError,
-  unauthorizedError,
-  validationError,
-} from 'src/utils/httpException';
+import { methodNotAllowedError, validationError } from 'src/utils/httpException';
 import { validateImage } from 'src/utils/storage';
 
-async function requireAdmin(client: ReturnType<typeof createSupabaseServerClient>['client']) {
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
-    throw unauthorizedError();
-  }
-
-  const { data: profiles } = await client
-    .from('profiles')
-    .select('id,roles')
-    .eq('auth_id', claims.data.claims.sub)
-    .limit(1);
-
-  if (!profiles?.at(0)?.roles?.includes(UserRole.ADMIN)) {
-    throw forbiddenError();
-  }
-}
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRoleApi(UserRole.ADMIN),
+];
 
 function assertAllowedPath(path: string | undefined): asserts path is string {
   if (!path || !isAllowedImagePickerPath(path)) {
@@ -46,7 +30,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
-    await requireAdmin(client);
     assertAllowedPath(params.path);
 
     const images = await new StorageServiceServer(client).listImages(params.path);
@@ -70,7 +53,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
       throw methodNotAllowedError();
     }
 
-    await requireAdmin(client);
     assertAllowedPath(params.path);
 
     const formData = await request.formData();

--- a/src/routes/api.news.ts
+++ b/src/routes/api.news.ts
@@ -3,8 +3,10 @@ import { HTTPException } from 'hono/http-exception';
 import type { ContentReach, DBMedia, DBNews, DBProfile, Moderation, NewsDTO } from 'oa-shared';
 import { getSummaryFromMarkdown, News, UserRole } from 'oa-shared';
 import { PollDTO } from 'oa-shared/models/poll';
-import type { LoaderFunctionArgs } from 'react-router';
+import type { LoaderFunctionArgs, MiddlewareFunction } from 'react-router';
 import { logger } from 'src/logger';
+import { requireAnyRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { ITEMS_PER_PAGE } from 'src/pages/News/constants';
 import type { NewsSortOption } from 'src/pages/News/NewsSortOptions';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
@@ -12,15 +14,19 @@ import { BroadcastCoordinationServiceServer } from 'src/services/broadcastCoordi
 import { NewsServiceServer } from 'src/services/newsService.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
 import { SubscribersServiceServer } from 'src/services/subscribersService.server';
-import {
-  conflictError,
-  forbiddenError,
-  methodNotAllowedError,
-  validationError,
-} from 'src/utils/httpException';
+import { conflictError, methodNotAllowedError, validationError } from 'src/utils/httpException';
 import { convertToSlug } from 'src/utils/slug';
 import { ContentServiceServer } from '../services/contentService.server';
 import { PollServiceServer } from '../services/pollService.server';
+
+// GET (feed) stays public; only POST (create) is role-gated.
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  (args, next) =>
+    args.request.method === 'POST'
+      ? requireAnyRoleApi([UserRole.ADMIN, UserRole.EDITOR])(args, next)
+      : next(),
+];
 
 export const loader = async ({ request }) => {
   const url = new URL(request.url);
@@ -109,16 +115,13 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     } satisfies NewsDTO;
 
     const claims = await client.auth.getClaims();
-    if (!claims.data?.claims) {
-      return Response.json({}, { headers, status: 401 });
-    }
     const slug = convertToSlug(data.title);
     await validateRequest(request, data, slug, claims.error, client);
 
     const profileRequest = await client
       .from('profiles')
       .select('id,username,roles')
-      .eq('auth_id', claims.data.claims.sub)
+      .eq('auth_id', claims.data!.claims!.sub)
       .limit(1);
 
     if (profileRequest.error || !profileRequest.data?.at(0)) {
@@ -127,10 +130,6 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     }
 
     const profile = profileRequest.data[0] as DBProfile;
-
-    if (!profile.roles?.includes(UserRole.ADMIN) && !profile.roles?.includes(UserRole.EDITOR)) {
-      throw forbiddenError();
-    }
 
     if (!profile.username) {
       throw validationError('You must set a username before creating content', 'username');
@@ -206,7 +205,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     const news = News.fromDB(completeNews.data, [], null, poll);
     await new SubscribersServiceServer(client).add('news', news.id, profile.id);
     new BroadcastCoordinationServiceServer(client).news(completeNews.data, profile, request);
-    await new ProfileServiceServer(client).updateUserActivity(claims.data.claims.sub);
+    await new ProfileServiceServer(client).updateUserActivity(claims.data!.claims!.sub);
 
     return Response.json({ news }, { headers, status: 201 });
   } catch (error) {

--- a/src/routes/api.profile.$id.ban.ts
+++ b/src/routes/api.profile.$id.ban.ts
@@ -1,7 +1,9 @@
 import { HTTPException } from 'hono/http-exception';
 import { UserRole } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
 import { logger } from 'src/logger';
+import { requireAnyRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { createSupabaseAdminServerClient } from 'src/repository/supabaseAdmin.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
@@ -11,6 +13,11 @@ import {
   notFoundError,
   unauthorizedError,
 } from 'src/utils/httpException';
+
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireAnyRoleApi([UserRole.ADMIN, UserRole.MODERATOR]),
+];
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
   if (request.method !== 'POST') {
@@ -37,14 +44,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 
     if (!currentUserProfile) {
       throw unauthorizedError();
-    }
-
-    const hasPermission =
-      currentUserProfile.roles?.includes(UserRole.ADMIN) ||
-      currentUserProfile.roles?.includes(UserRole.MODERATOR);
-
-    if (!hasPermission) {
-      throw forbiddenError('Only admins and moderators can ban users');
     }
 
     const targetProfile = await profileService.getById(profileId);

--- a/src/routes/api.research.$id.status.ts
+++ b/src/routes/api.research.$id.status.ts
@@ -1,19 +1,22 @@
 import type { ResearchStatus } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
+import { sessionContext } from 'src/context';
 import { logger } from 'src/logger';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
 import { ResearchServiceServer } from 'src/services/researchService.server';
 
-export const action = async ({ request, params }: ActionFunctionArgs) => {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export const action = async ({ request, params, context }: ActionFunctionArgs) => {
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
     const id = Number(params.id);
+    const session = context.get(sessionContext);
 
-    const claims = await client.auth.getClaims();
-
-    if (!claims.data?.claims) {
+    if (!session) {
       return Response.json({}, { headers, status: 401 });
     }
 
@@ -29,16 +32,15 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       return Response.json({}, { headers, status, statusText });
     }
 
-    const profile = await new ProfileServiceServer(client).getByAuthId(claims.data.claims.sub);
-
-    if (!profile) {
+    if (!session.profileId) {
       return Response.json({}, { headers, status: 401 });
     }
 
-    const canEdit = await new ResearchServiceServer(client).isAllowedToEditResearchById(
-      id,
-      profile,
-    );
+    const canEdit = await new ResearchServiceServer(client).isAllowedToEditResearchById(id, {
+      id: session.profileId,
+      username: session.username,
+      roles: session.roles,
+    });
 
     if (!canEdit) {
       return Response.json(null, { headers, status: 403 });
@@ -50,7 +52,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       throw result.error;
     }
 
-    new ProfileServiceServer(client).updateUserActivity(claims.data.claims.sub);
+    new ProfileServiceServer(client).updateUserActivity(session.authId);
 
     return Response.json(null, { headers, status: 200 });
   } catch (error) {

--- a/src/routes/api.research.$id.ts
+++ b/src/routes/api.research.$id.ts
@@ -2,8 +2,10 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { HTTPException } from 'hono/http-exception';
 import type { DBMedia, DBResearchItem, ResearchDTO } from 'oa-shared';
 import { ResearchItem, UserRole } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
+import { Session, sessionContext } from 'src/context';
 import { logger } from 'src/logger';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { ContentServiceServer } from 'src/services/contentService.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
@@ -17,11 +19,14 @@ import {
 } from 'src/utils/httpException';
 import { convertToSlug } from 'src/utils/slug';
 
-export const action = async ({ request, params }: ActionFunctionArgs) => {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export const action = async ({ request, params, context }: ActionFunctionArgs) => {
   const id = Number(params.id);
+  const session = context.get(sessionContext);
 
   if (request.method === 'DELETE') {
-    return await deleteResearch(request, id);
+    return await deleteResearch(request, id, session);
   }
 
   const { client, headers } = createSupabaseServerClient(request);
@@ -43,15 +48,14 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     } satisfies ResearchDTO;
 
     const slug = convertToSlug(data.title);
-    const claims = await client.auth.getClaims();
 
-    if (!claims.data?.claims) {
+    if (!session) {
       return Response.json({}, { headers, status: 401 });
     }
 
     const oldResearch = await new ResearchServiceServer(client).getById(id);
 
-    await validateRequest(request, claims.data.claims.sub, data, oldResearch, slug, client);
+    await validateRequest(request, session, data, oldResearch, slug, client);
 
     const previousSlugs = ContentServiceServer.updatePreviousSlugs(oldResearch, slug);
 
@@ -83,7 +87,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     const research = ResearchItem.fromDB(researchResult.data, []);
 
     await new SubscribersServiceServer(client).updateResearchSubscribers(oldResearch, research);
-    new ProfileServiceServer(client).updateUserActivity(claims.data.claims.sub);
+    new ProfileServiceServer(client).updateUserActivity(session.authId);
 
     return Response.json({ research }, { headers, status: 201 });
   } catch (error) {
@@ -96,26 +100,19 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
   }
 };
 
-async function deleteResearch(request, id: number) {
+async function deleteResearch(request: Request, id: number, session: Session) {
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
-    const claims = await client.auth.getClaims();
-
-    if (!claims.data?.claims) {
+    if (!session?.profileId) {
       return Response.json({}, { headers, status: 401 });
     }
 
-    const profile = await new ProfileServiceServer(client).getByAuthId(claims.data.claims.sub);
-
-    if (!profile) {
-      return Response.json({}, { headers, status: 401 });
-    }
-
-    const canEdit = await new ResearchServiceServer(client).isAllowedToEditResearchById(
-      id,
-      profile,
-    );
+    const canEdit = await new ResearchServiceServer(client).isAllowedToEditResearchById(id, {
+      id: session.profileId,
+      username: session.username,
+      roles: session.roles,
+    });
 
     if (canEdit) {
       await client
@@ -137,7 +134,7 @@ async function deleteResearch(request, id: number) {
 
 async function validateRequest(
   request: Request,
-  userAuthId: string,
+  session: NonNullable<Session>,
   data: ResearchDTO,
   research: DBResearchItem,
   slug: string,
@@ -166,23 +163,21 @@ async function validateRequest(
     throw conflictError('This research already exists');
   }
 
-  const profile = await new ProfileServiceServer(client).getByAuthId(userAuthId);
-
-  if (!profile) {
+  if (!session.profileId) {
     throw validationError('User not found');
   }
 
-  if (!profile.username) {
+  if (!session.username) {
     throw validationError('You must set a username before editing content', 'username');
   }
 
-  if (profile.roles?.includes(UserRole.ADMIN)) {
+  if (session.roles.includes(UserRole.ADMIN)) {
     return;
   }
 
   if (
-    research.created_by !== profile.id &&
-    !(profile.username && research.collaborators?.includes(profile.username))
+    research.created_by !== session.profileId &&
+    !(session.username && research.collaborators?.includes(session.username))
   ) {
     throw forbiddenError();
   }

--- a/src/routes/api.research.$id.updates.$updateId.ts
+++ b/src/routes/api.research.$id.updates.$updateId.ts
@@ -1,15 +1,19 @@
 import { HTTPException } from 'hono/http-exception';
 import type { DBMedia, DBResearchUpdate, IMediaFile, ResearchUpdateDTO } from 'oa-shared';
 import { ResearchUpdate } from 'oa-shared';
-import type { ActionFunctionArgs } from 'react-router';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
+import { Session, sessionContext } from 'src/context';
 import { logger } from 'src/logger';
+import { sessionMiddleware } from 'src/middleware/session.server';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
 import { BroadcastCoordinationServiceServer } from 'src/services/broadcastCoordinationService.server';
 import { ProfileServiceServer } from 'src/services/profileService.server';
 import { ResearchServiceServer } from 'src/services/researchService.server';
 import { forbiddenError, methodNotAllowedError, validationError } from 'src/utils/httpException';
 
-export const action = async ({ request, params }: ActionFunctionArgs) => {
+export const middleware: MiddlewareFunction<Response>[] = [sessionMiddleware];
+
+export const action = async ({ request, params, context }: ActionFunctionArgs) => {
   const { client, headers } = createSupabaseServerClient(request);
 
   try {
@@ -17,7 +21,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     const updateId = Number(params.updateId);
 
     if (request.method === 'DELETE') {
-      return await deleteResearchUpdate(request, researchId, updateId);
+      return await deleteResearchUpdate(request, researchId, updateId, context.get(sessionContext));
     }
 
     const formData = await request.formData();
@@ -47,7 +51,13 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     const profileService = new ProfileServiceServer(client);
     const profile = await profileService.getByAuthId(claims.data.claims.sub);
 
-    if (!new ResearchServiceServer(client).isAllowedToEditUpdate(profile, researchId, updateId)) {
+    if (
+      (await new ResearchServiceServer(client).isAllowedToEditUpdate(
+        profile,
+        researchId,
+        updateId,
+      )) !== true
+    ) {
       throw forbiddenError();
     }
 
@@ -102,19 +112,25 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
   }
 };
 
-async function deleteResearchUpdate(request: Request, id: number, updateId: number) {
+async function deleteResearchUpdate(
+  request: Request,
+  id: number,
+  updateId: number,
+  session: Session,
+) {
   const { client, headers } = createSupabaseServerClient(request);
 
-  const claims = await client.auth.getClaims();
-
-  if (!claims.data?.claims) {
+  if (!session) {
     return Response.json({}, { headers, status: 401 });
   }
 
-  const profileService = new ProfileServiceServer(client);
-  const profile = await profileService.getByAuthId(claims.data.claims.sub);
+  const profile = session.profileId
+    ? { id: session.profileId, username: session.username, roles: session.roles }
+    : null;
 
-  if (!new ResearchServiceServer(client).isAllowedToEditUpdate(profile, id, updateId)) {
+  if (
+    (await new ResearchServiceServer(client).isAllowedToEditUpdate(profile, id, updateId)) !== true
+  ) {
     return Response.json({}, { status: 403, headers });
   }
 

--- a/src/services/researchService.server.ts
+++ b/src/services/researchService.server.ts
@@ -2,7 +2,6 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import {
   Author,
   DBAuthor,
-  DBProfile,
   DBResearchItem,
   DBResearchUpdate,
   ResearchItem,
@@ -13,6 +12,8 @@ import { logger } from 'src/logger';
 import { ImageServiceServer } from './imageService.server';
 import { ProfileServiceServer } from './profileService.server';
 import { StorageServiceServer } from './storageService.server';
+
+type EditorProfile = { id: number; username: string | null; roles: string[] | null };
 
 export class ResearchServiceServer {
   constructor(private client: SupabaseClient) {}
@@ -152,7 +153,7 @@ export class ResearchServiceServer {
       : [];
   }
 
-  async isAllowedToEditResearch(research: DBResearchItem, profile: DBProfile) {
+  async isAllowedToEditResearch(research: DBResearchItem, profile: EditorProfile) {
     if (profile.id === research.author?.id) {
       return true;
     }
@@ -168,7 +169,7 @@ export class ResearchServiceServer {
     return profile.roles?.includes(UserRole.ADMIN);
   }
 
-  async isAllowedToEditResearchById(id: number, profile: DBProfile) {
+  async isAllowedToEditResearchById(id: number, profile: EditorProfile) {
     const researchResult = await this.client
       .from('research')
       .select('id,created_by,collaborators,author:profiles(id,username)')
@@ -190,7 +191,7 @@ export class ResearchServiceServer {
     return result.data as DBResearchUpdate;
   }
 
-  async isAllowedToEditUpdate(profile: DBProfile | null, researchId: number, updateId: number) {
+  async isAllowedToEditUpdate(profile: EditorProfile | null, researchId: number, updateId: number) {
     const research = await this.getById(researchId);
     const researchUpdate = await this.getUpdateById(updateId);
 

--- a/src/services/researchService.server.ts
+++ b/src/services/researchService.server.ts
@@ -201,7 +201,7 @@ export class ResearchServiceServer {
 
     return (
       profile &&
-      (profile.id === research.author?.id ||
+      (profile.id === research.created_by ||
         (profile.username && research.collaborators?.includes(profile.username)) ||
         profile?.roles?.includes(UserRole.ADMIN))
     );

--- a/src/utils/rolesCookie.server.ts
+++ b/src/utils/rolesCookie.server.ts
@@ -1,0 +1,50 @@
+import { parseCookieHeader, serializeCookieHeader } from '@supabase/ssr';
+import pkg from 'jsonwebtoken';
+
+const COOKIE_NAME = 'oa_roles';
+const TTL_SECONDS = 10 * 60;
+const key = process.env.TOKEN_SECRET as string;
+
+type RolesPayload = {
+  authId: string;
+  tenantId: string;
+  roles: string[];
+};
+
+const sign = (payload: RolesPayload) => {
+  const token = pkg.sign(payload, key, { expiresIn: TTL_SECONDS });
+
+  return serializeCookieHeader(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: TTL_SECONDS,
+  });
+};
+
+// authId/tenantId are the current, trusted values (from the just-verified Supabase claims),
+// so a cookie minted for a different user or tenant is rejected rather than trusted.
+const verify = (request: Request, authId: string, tenantId: string): string[] | null => {
+  const token = parseCookieHeader(request.headers.get('Cookie') ?? '').find(
+    (cookie) => cookie.name === COOKIE_NAME,
+  )?.value;
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload = pkg.verify(token, key) as RolesPayload;
+
+    if (payload.authId !== authId || payload.tenantId !== tenantId) {
+      return null;
+    }
+
+    return payload.roles;
+  } catch {
+    return null;
+  }
+};
+
+export const rolesCookie = { sign, verify };

--- a/src/utils/rolesCookie.server.ts
+++ b/src/utils/rolesCookie.server.ts
@@ -8,6 +8,8 @@ const key = process.env.TOKEN_SECRET as string;
 type RolesPayload = {
   authId: string;
   tenantId: string;
+  profileId: number | null;
+  username: string | null;
   roles: string[];
 };
 
@@ -25,7 +27,11 @@ const sign = (payload: RolesPayload) => {
 
 // authId/tenantId are the current, trusted values (from the just-verified Supabase claims),
 // so a cookie minted for a different user or tenant is rejected rather than trusted.
-const verify = (request: Request, authId: string, tenantId: string): string[] | null => {
+const verify = (
+  request: Request,
+  authId: string,
+  tenantId: string,
+): Pick<RolesPayload, 'profileId' | 'username' | 'roles'> | null => {
   const token = parseCookieHeader(request.headers.get('Cookie') ?? '').find(
     (cookie) => cookie.name === COOKIE_NAME,
   )?.value;
@@ -41,7 +47,7 @@ const verify = (request: Request, authId: string, tenantId: string): string[] | 
       return null;
     }
 
-    return payload.roles;
+    return { profileId: payload.profileId, username: payload.username, roles: payload.roles };
   } catch {
     return null;
   }


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [x] ♻️ Refactoring — improves code structure with no functional changes
- [x] ⚡️ Performance — improves speed, memory, or efficiency
- [x] 📝 Documentation — updates docs, comments, or READMEs

## What is the new behavior?

- Centralized route-level role checks (admin panel, admin APIs, research/news creation, user bans) into a shared `sessionMiddleware` + `requireRole`/`requireRoleApi` pattern, replacing duplicated per-route auth code.
- `/forbidden` now shows a message specific to why you were blocked (admin-only, edit permissions, early-access, etc.) instead of always showing the "early access" copy.
- `/forbidden` page redesigned with the new UI component library.
- Fixed a bug where a permission check on research updates was silently always passing (missing `await`).
- Added Cypress smoke tests covering `/admin` access for anonymous/regular/admin users.

## Does this PR introduce a DB Schema Change or Migration?

- [x] No
