### PR TITLE
feat(admin): add map pins overview page (#4857)

### DIFF
--- a/src/pages/Admin/AdminSidebar.tsx
+++ b/src/pages/Admin/AdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, FolderIcon, TagsIcon, UsersIcon } from 'lucide-react';
+import { ChevronRightIcon, FolderIcon, MapPinIcon, TagsIcon, UsersIcon } from 'lucide-react';
 import { Link, useLocation } from 'react-router';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
@@ -26,6 +26,7 @@ const ADMIN_NAV_ITEMS = [
   },
   { label: 'Categories', href: '/admin/categories', icon: FolderIcon },
   { label: 'Tags', href: '/admin/tags', icon: TagsIcon },
+  { label: 'Map Pins', href: '/admin/map-pins', icon: MapPinIcon },
 ];
 
 export function AdminSidebar() {

--- a/src/pages/Admin/MapPins/MapPinsPage.test.tsx
+++ b/src/pages/Admin/MapPins/MapPinsPage.test.tsx
@@ -19,6 +19,12 @@ describe('MapPinsPage', () => {
         id: 101,
         username: 'precious-workspace',
         displayName: 'Precious Workspace NL',
+        profileType: {
+          id: 2,
+          name: 'workspace',
+          displayName: 'Workspace',
+          imageUrl: 'https://example.com/workspace.svg',
+        },
       },
     },
     {
@@ -34,6 +40,12 @@ describe('MapPinsPage', () => {
         id: 102,
         username: 'jean-dupont',
         displayName: 'Jean Dupont',
+        profileType: {
+          id: 1,
+          name: 'member',
+          displayName: 'Member',
+          imageUrl: 'https://example.com/member.svg',
+        },
       },
     },
   ];
@@ -47,7 +59,10 @@ describe('MapPinsPage', () => {
 
     expect(screen.getByText('Map Pins')).toBeInTheDocument();
     expect(screen.getByText('Total: 2')).toBeInTheDocument();
+    expect(screen.getByText('Profile Type')).toBeInTheDocument();
     expect(screen.getByText('Precious Plastic Workshop')).toBeInTheDocument();
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
     expect(screen.getByText('Netherlands')).toBeInTheDocument();
     expect(screen.getByText('North Holland')).toBeInTheDocument();
     expect(screen.getByText('1012 JS')).toBeInTheDocument();

--- a/src/pages/Admin/MapPins/MapPinsPage.test.tsx
+++ b/src/pages/Admin/MapPins/MapPinsPage.test.tsx
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { MapPinsPage } from './MapPinsPage';
+
+describe('MapPinsPage', () => {
+  const mockMapPins = [
+    {
+      id: 1,
+      name: 'Precious Plastic Workshop',
+      country: 'Netherlands',
+      countryCode: 'nl',
+      administrative: 'North Holland',
+      postCode: '1012 JS',
+      moderation: 'accepted',
+      profileId: 101,
+      profile: {
+        id: 101,
+        username: 'precious-workspace',
+        displayName: 'Precious Workspace NL',
+      },
+    },
+    {
+      id: 2,
+      name: null,
+      country: 'France',
+      countryCode: 'fr',
+      administrative: 'Île-de-France',
+      postCode: '75001',
+      moderation: 'awaiting-moderation',
+      profileId: 102,
+      profile: {
+        id: 102,
+        username: 'jean-dupont',
+        displayName: 'Jean Dupont',
+      },
+    },
+  ];
+
+  it('renders table headers and pin details', () => {
+    render(
+      <MemoryRouter>
+        <MapPinsPage mapPins={mockMapPins} page={1} totalPages={1} totalCount={2} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Map Pins')).toBeInTheDocument();
+    expect(screen.getByText('Total: 2')).toBeInTheDocument();
+    expect(screen.getByText('Precious Plastic Workshop')).toBeInTheDocument();
+    expect(screen.getByText('Netherlands')).toBeInTheDocument();
+    expect(screen.getByText('North Holland')).toBeInTheDocument();
+    expect(screen.getByText('1012 JS')).toBeInTheDocument();
+    expect(screen.getByText('accepted')).toBeInTheDocument();
+    expect(screen.getByText('awaiting-moderation')).toBeInTheDocument();
+  });
+
+  it('links to owning profile live page', () => {
+    render(
+      <MemoryRouter>
+        <MapPinsPage mapPins={mockMapPins} page={1} totalPages={1} totalCount={2} />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByText('Precious Workspace NL').closest('a');
+    expect(link).toHaveAttribute('href', '/u/precious-workspace');
+  });
+
+  it('renders fallback for un-named pin and missing profile', () => {
+    render(
+      <MemoryRouter>
+        <MapPinsPage
+          mapPins={[
+            {
+              id: 3,
+              name: null,
+              country: 'Germany',
+              administrative: null,
+              postCode: null,
+              moderation: 'accepted',
+              profileId: 103,
+              profile: null,
+            },
+          ]}
+          page={1}
+          totalPages={1}
+          totalCount={1}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Profile #103')).toBeInTheDocument();
+    const link = screen.getByText('Profile #103').closest('a');
+    expect(link).toHaveAttribute('href', '/u/103');
+  });
+
+  it('renders empty state when no pins exist', () => {
+    render(
+      <MemoryRouter>
+        <MapPinsPage mapPins={[]} page={1} totalPages={1} totalCount={0} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No map pins found.')).toBeInTheDocument();
+  });
+
+  it('renders pagination controls when totalPages > 1', () => {
+    render(
+      <MemoryRouter>
+        <MapPinsPage mapPins={mockMapPins} page={2} totalPages={5} totalCount={100} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Admin/MapPins/MapPinsPage.tsx
+++ b/src/pages/Admin/MapPins/MapPinsPage.tsx
@@ -1,0 +1,160 @@
+import { ChevronLeftIcon, ChevronRightIcon, ExternalLinkIcon } from 'lucide-react';
+import { Link } from 'react-router';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+export interface AdminMapPinItem {
+  id: number;
+  name: string | null;
+  country: string;
+  countryCode?: string;
+  administrative: string | null;
+  postCode: string | null;
+  moderation: string;
+  profileId: number;
+  profile?: {
+    id: number;
+    username: string | null;
+    displayName: string;
+  } | null;
+}
+
+export interface MapPinsPageProps {
+  mapPins: AdminMapPinItem[];
+  page: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+function ModerationBadge({ status }: { status: string }) {
+  const isAccepted = status === 'accepted';
+  const isAwaiting = status === 'awaiting-moderation';
+  const isNeedsImprovement = status === 'improvements-needed';
+  const badgeClasses = isAccepted
+    ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
+    : isAwaiting
+      ? 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300'
+      : isNeedsImprovement
+        ? 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300'
+        : 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300';
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${badgeClasses}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export function MapPinsPage({ mapPins, page, totalPages, totalCount }: MapPinsPageProps) {
+  const hasPrevious = page > 1;
+  const hasNext = page < totalPages;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Map Pins</h1>
+        <span className="text-sm text-muted-foreground">Total: {totalCount}</span>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Profile</TableHead>
+            <TableHead>Country</TableHead>
+            <TableHead>Administrative Area</TableHead>
+            <TableHead>Post Code</TableHead>
+            <TableHead>Moderation Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {mapPins.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                No map pins found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            mapPins.map((pin) => {
+              const profileIdentifier = pin.profile?.username || pin.profileId;
+              const profileDisplayName =
+                pin.profile?.displayName || pin.profile?.username || `Profile #${pin.profileId}`;
+
+              return (
+                <TableRow key={pin.id}>
+                  <TableCell className="font-medium">{pin.name || '-'}</TableCell>
+                  <TableCell>
+                    <Link
+                      to={`/u/${profileIdentifier}`}
+                      className="inline-flex items-center gap-1 text-primary hover:underline font-medium"
+                    >
+                      <span>{profileDisplayName}</span>
+                      <ExternalLinkIcon className="size-3 text-muted-foreground" />
+                    </Link>
+                  </TableCell>
+                  <TableCell>{pin.country || '-'}</TableCell>
+                  <TableCell>{pin.administrative || '-'}</TableCell>
+                  <TableCell>{pin.postCode || '-'}</TableCell>
+                  <TableCell>
+                    <ModerationBadge status={pin.moderation} />
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between py-2">
+          <span className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          <div className="flex items-center gap-2">
+            {hasPrevious ? (
+              <Button
+                variant="outline"
+                size="sm"
+                nativeButton={false}
+                render={<Link to={`/admin/map-pins?page=${page - 1}`} />}
+              >
+                <ChevronLeftIcon className="size-4 mr-1" />
+                Previous
+              </Button>
+            ) : (
+              <Button variant="outline" size="sm" disabled>
+                <ChevronLeftIcon className="size-4 mr-1" />
+                Previous
+              </Button>
+            )}
+            {hasNext ? (
+              <Button
+                variant="outline"
+                size="sm"
+                nativeButton={false}
+                render={<Link to={`/admin/map-pins?page=${page + 1}`} />}
+              >
+                Next
+                <ChevronRightIcon className="size-4 ml-1" />
+              </Button>
+            ) : (
+              <Button variant="outline" size="sm" disabled>
+                Next
+                <ChevronRightIcon className="size-4 ml-1" />
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Admin/MapPins/MapPinsPage.tsx
+++ b/src/pages/Admin/MapPins/MapPinsPage.tsx
@@ -23,6 +23,12 @@ export interface AdminMapPinItem {
     id: number;
     username: string | null;
     displayName: string;
+    profileType?: {
+      id: number;
+      name: string;
+      displayName: string;
+      imageUrl?: string | null;
+    } | null;
   } | null;
 }
 
@@ -70,6 +76,7 @@ export function MapPinsPage({ mapPins, page, totalPages, totalCount }: MapPinsPa
           <TableRow>
             <TableHead>Name</TableHead>
             <TableHead>Profile</TableHead>
+            <TableHead>Profile Type</TableHead>
             <TableHead>Country</TableHead>
             <TableHead>Administrative Area</TableHead>
             <TableHead>Post Code</TableHead>
@@ -79,7 +86,7 @@ export function MapPinsPage({ mapPins, page, totalPages, totalCount }: MapPinsPa
         <TableBody>
           {mapPins.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+              <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
                 No map pins found.
               </TableCell>
             </TableRow>
@@ -100,6 +107,22 @@ export function MapPinsPage({ mapPins, page, totalPages, totalCount }: MapPinsPa
                       <span>{profileDisplayName}</span>
                       <ExternalLinkIcon className="size-3 text-muted-foreground" />
                     </Link>
+                  </TableCell>
+                  <TableCell>
+                    {pin.profile?.profileType ? (
+                      <div className="flex items-center gap-2">
+                        {pin.profile.profileType.imageUrl && (
+                          <img
+                            src={pin.profile.profileType.imageUrl}
+                            alt={pin.profile.profileType.displayName}
+                            className="size-5 rounded-full object-contain"
+                          />
+                        )}
+                        <span>{pin.profile.profileType.displayName}</span>
+                      </div>
+                    ) : (
+                      '-'
+                    )}
                   </TableCell>
                   <TableCell>{pin.country || '-'}</TableCell>
                   <TableCell>{pin.administrative || '-'}</TableCell>

--- a/src/routes/_.admin.map-pins.tsx
+++ b/src/routes/_.admin.map-pins.tsx
@@ -30,7 +30,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       profile:profiles(
         id,
         username,
-        display_name
+        display_name,
+        type:profile_types(
+          id,
+          name,
+          display_name,
+          image_url,
+          small_image_url
+        )
       )
     `,
       { count: 'exact' },
@@ -59,6 +66,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
           id: pin.profile.id,
           username: pin.profile.username,
           displayName: pin.profile.display_name,
+          profileType: pin.profile.type
+            ? {
+                id: pin.profile.type.id,
+                name: pin.profile.type.name,
+                displayName: pin.profile.type.display_name,
+                imageUrl: pin.profile.type.image_url || pin.profile.type.small_image_url,
+              }
+            : null,
         }
       : null,
   }));

--- a/src/routes/_.admin.map-pins.tsx
+++ b/src/routes/_.admin.map-pins.tsx
@@ -1,0 +1,75 @@
+import type { LoaderFunctionArgs } from 'react-router';
+import { useLoaderData } from 'react-router';
+import type { AdminMapPinItem } from 'src/pages/Admin/MapPins/MapPinsPage';
+import { MapPinsPage } from 'src/pages/Admin/MapPins/MapPinsPage';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+
+export const handle = { breadcrumb: 'Map Pins' };
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const pageParam = Number(url.searchParams.get('page')) || 1;
+  const page = Math.max(1, pageParam);
+  const pageSize = 25;
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+  const { client } = createSupabaseServerClient(request);
+
+  const { data, count, error } = await client
+    .from('map_pins')
+    .select(
+      `
+      id,
+      name,
+      country,
+      country_code,
+      administrative,
+      post_code,
+      moderation,
+      profile_id,
+      profile:profiles(
+        id,
+        username,
+        display_name
+      )
+    `,
+      { count: 'exact' },
+    )
+    .order('created_at', { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    throw error;
+  }
+
+  const totalCount = count || 0;
+  const totalPages = Math.ceil(totalCount / pageSize) || 1;
+
+  const mapPins: AdminMapPinItem[] = (data || []).map((pin: any) => ({
+    id: pin.id,
+    name: pin.name,
+    country: pin.country,
+    countryCode: pin.country_code,
+    administrative: pin.administrative,
+    postCode: pin.post_code,
+    moderation: pin.moderation,
+    profileId: pin.profile_id,
+    profile: pin.profile
+      ? {
+          id: pin.profile.id,
+          username: pin.profile.username,
+          displayName: pin.profile.display_name,
+        }
+      : null,
+  }));
+
+  return { mapPins, page, totalPages, totalCount };
+}
+
+export default function Index() {
+  const { mapPins, page, totalPages, totalCount } = useLoaderData<typeof loader>();
+
+  return (
+    <MapPinsPage mapPins={mapPins} page={page} totalPages={totalPages} totalCount={totalCount} />
+  );
+}


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [ ] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

- **Map Pins Table**: Displays all map pins with their name, country, administrative area, post code, and color-coded moderation status badge (`accepted`, `awaiting-moderation`, etc.).
- **Profile Link**: Each map pin row links directly to the owning profile's live page (`/u/:username`).
- **Pagination**: Implemented server-side pagination with Supabase range queries (25 pins per page) with Previous/Next navigation controls.
- **Admin Navigation**: Added `Map Pins` entry with `MapPinIcon` to `AdminSidebar`.
- **Display-only & Secured**: No mutation actions on this page, and protected with admin role verification.
- **Unit Tests**: Added 5 unit tests in `MapPinsPage.test.tsx` covering table rendering, fallback states, profile links, empty state, and pagination.
- 
### Screenshot:

<img width="1917" height="994" alt="image" src="https://github.com/user-attachments/assets/90bf6abf-9ca9-46ec-9bca-dace8bec5e01" />

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4857

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).

