### PR TITLE
feat: add admin banner management

### DIFF
--- a/src/pages/Admin/AdminSidebar.tsx
+++ b/src/pages/Admin/AdminSidebar.tsx
@@ -1,4 +1,11 @@
-import { ChevronRightIcon, FolderIcon, MapPinIcon, TagsIcon, UsersIcon } from 'lucide-react';
+import {
+  ChevronRightIcon,
+  FolderIcon,
+  MapPinIcon,
+  MegaphoneIcon,
+  TagsIcon,
+  UsersIcon,
+} from 'lucide-react';
 import { Link, useLocation } from 'react-router';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
@@ -27,6 +34,7 @@ const ADMIN_NAV_ITEMS = [
   { label: 'Categories', href: '/admin/categories', icon: FolderIcon },
   { label: 'Tags', href: '/admin/tags', icon: TagsIcon },
   { label: 'Map Pins', href: '/admin/map-pins', icon: MapPinIcon },
+  { label: 'Banner', href: '/admin/banners', icon: MegaphoneIcon },
 ];
 
 export function AdminSidebar() {

--- a/src/pages/Admin/Banners/BannersPage.tsx
+++ b/src/pages/Admin/Banners/BannersPage.tsx
@@ -1,0 +1,120 @@
+import { TrashIcon } from 'lucide-react';
+import type { Banner } from 'oa-shared';
+import { type FormEvent, useEffect, useState } from 'react';
+import { useRevalidator } from 'react-router';
+import { useToast } from 'src/common/Toast/useToast';
+import { bannerService } from 'src/pages/common/banner.service';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { DeleteBannerDialog } from './DeleteBannerDialog';
+
+interface IProps {
+  banner: Banner | null;
+}
+
+const toForm = (banner: Banner | null) => ({ text: banner?.text ?? '', url: banner?.url ?? '' });
+
+export function BannersPage({ banner }: IProps) {
+  const [form, setForm] = useState(toForm(banner));
+  const [textError, setTextError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const revalidator = useRevalidator();
+  const toast = useToast();
+
+  useEffect(() => {
+    setForm(toForm(banner));
+  }, [banner]);
+
+  const isEditing = !!banner;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    const text = form.text.trim();
+
+    if (!text) {
+      setTextError('Text is required');
+      return;
+    }
+
+    setTextError(null);
+
+    const data = { text, url: form.url.trim() || null };
+
+    setSubmitting(true);
+
+    const promise = (
+      isEditing ? bannerService.updateBanner(banner.id, data) : bannerService.createBanner(data)
+    ).finally(() => setSubmitting(false));
+
+    toast.promise(promise, {
+      loading: isEditing ? 'Saving banner...' : 'Creating banner...',
+      success: () => {
+        revalidator.revalidate();
+        return isEditing ? 'Banner saved' : 'Banner created';
+      },
+      error: (error) => error.message || 'Something went wrong',
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Banner</h1>
+        {isEditing && (
+          <Button variant="outline" size="sm" onClick={() => setDeleting(true)}>
+            <TrashIcon />
+            Delete banner
+          </Button>
+        )}
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Shown at the top of every page for all visitors. Leave the URL empty for a plain message.
+      </p>
+
+      <form onSubmit={handleSubmit} className="flex max-w-xl flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="banner-text">Text</Label>
+          <Textarea
+            id="banner-text"
+            value={form.text}
+            onChange={(event) => setForm((f) => ({ ...f, text: event.target.value }))}
+            aria-invalid={!!textError}
+            required
+          />
+          {textError && <p className="text-sm text-destructive">{textError}</p>}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="banner-url">URL</Label>
+          <Input
+            id="banner-url"
+            type="url"
+            placeholder="https://"
+            value={form.url}
+            onChange={(event) => setForm((f) => ({ ...f, url: event.target.value }))}
+          />
+        </div>
+
+        <div>
+          <Button type="submit" disabled={submitting}>
+            {isEditing ? 'Save' : 'Create'}
+          </Button>
+        </div>
+      </form>
+
+      <DeleteBannerDialog
+        banner={deleting ? banner : null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleting(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/src/pages/Admin/Banners/DeleteBannerDialog.tsx
+++ b/src/pages/Admin/Banners/DeleteBannerDialog.tsx
@@ -1,0 +1,66 @@
+import type { Banner } from 'oa-shared';
+import { useState } from 'react';
+import { useRevalidator } from 'react-router';
+import { useToast } from 'src/common/Toast/useToast';
+import { bannerService } from 'src/pages/common/banner.service';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface IProps {
+  banner: Banner | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteBannerDialog({ banner, onOpenChange }: IProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const revalidator = useRevalidator();
+  const toast = useToast();
+
+  const handleDelete = () => {
+    if (!banner) {
+      return;
+    }
+
+    setSubmitting(true);
+
+    const promise = bannerService.deleteBanner(banner.id).finally(() => setSubmitting(false));
+
+    toast.promise(promise, {
+      loading: 'Deleting banner...',
+      success: () => {
+        onOpenChange(false);
+        revalidator.revalidate();
+        return 'Banner deleted';
+      },
+      error: (error) => error.message || 'Something went wrong',
+    });
+  };
+
+  return (
+    <Dialog open={!!banner} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete banner</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete the banner? It will no longer be shown on the site.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={submitting}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/common/banner.service.ts
+++ b/src/pages/common/banner.service.ts
@@ -1,6 +1,11 @@
 import type { Banner } from 'oa-shared';
 import { logger } from 'src/logger';
 
+export interface BannerFormData {
+  text: string;
+  url: string | null;
+}
+
 const getBanner = async () => {
   try {
     const response = await fetch('/api/banner');
@@ -11,6 +16,50 @@ const getBanner = async () => {
   }
 };
 
+const createBanner = async (form: BannerFormData) => {
+  const response = await fetch('/api/admin/banners', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Error creating banner' }));
+    throw new Error(errorData.error || 'Error creating banner');
+  }
+
+  return (await response.json()) as Banner;
+};
+
+const updateBanner = async (id: number, form: BannerFormData) => {
+  const response = await fetch(`/api/admin/banners/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(form),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Error updating banner' }));
+    throw new Error(errorData.error || 'Error updating banner');
+  }
+
+  return (await response.json()) as Banner;
+};
+
+const deleteBanner = async (id: number) => {
+  const response = await fetch(`/api/admin/banners/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: 'Error deleting banner' }));
+    throw new Error(errorData.error || 'Error deleting banner');
+  }
+};
+
 export const bannerService = {
   getBanner,
+  createBanner,
+  updateBanner,
+  deleteBanner,
 };

--- a/src/routes/_.admin.banners.tsx
+++ b/src/routes/_.admin.banners.tsx
@@ -1,0 +1,28 @@
+import type { DBBanner } from 'oa-shared';
+import { Banner } from 'oa-shared';
+import type { LoaderFunctionArgs } from 'react-router';
+import { useLoaderData } from 'react-router';
+import { BannersPage } from 'src/pages/Admin/Banners/BannersPage';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+
+export const handle = { breadcrumb: 'Banner' };
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { client } = createSupabaseServerClient(request);
+
+  const { data } = await client
+    .from('banners')
+    .select('id,text,url,created_at,modified_at')
+    .order('id')
+    .limit(1);
+
+  const banner = data?.length ? Banner.fromDB(data[0] as DBBanner) : null;
+
+  return { banner };
+}
+
+export default function Index() {
+  const { banner } = useLoaderData<typeof loader>();
+
+  return <BannersPage banner={banner} />;
+}

--- a/src/routes/api.admin.banners.$id.ts
+++ b/src/routes/api.admin.banners.$id.ts
@@ -1,0 +1,57 @@
+import { HTTPException } from 'hono/http-exception';
+import { UserRole } from 'oa-shared';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
+import { logger } from 'src/logger';
+import { requireRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+import { BannerServiceServer } from 'src/services/bannerService.server';
+import { methodNotAllowedError, validationError } from 'src/utils/httpException';
+
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRoleApi(UserRole.ADMIN),
+];
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  const { client, headers } = createSupabaseServerClient(request);
+  const id = Number(params.id);
+
+  try {
+    if (request.method !== 'PUT' && request.method !== 'DELETE') {
+      throw methodNotAllowedError();
+    }
+
+    if (!id) {
+      throw validationError('A valid id is required', 'id');
+    }
+
+    const bannerServiceServer = new BannerServiceServer(client);
+
+    if (request.method === 'DELETE') {
+      await bannerServiceServer.delete(id);
+      return Response.json({}, { headers, status: 200 });
+    }
+
+    const body = await request.json();
+    const text = (body.text as string)?.trim();
+
+    if (!text) {
+      throw validationError('Text is required', 'text');
+    }
+
+    const banner = await bannerServiceServer.update(id, {
+      text,
+      url: (body.url as string)?.trim() || null,
+    });
+
+    return Response.json(banner, { headers, status: 200 });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    logger.error('Error updating/deleting banner:', error);
+    return Response.json({ error: 'Error updating/deleting banner' }, { status: 500, headers });
+  }
+};

--- a/src/routes/api.admin.banners.ts
+++ b/src/routes/api.admin.banners.ts
@@ -1,0 +1,45 @@
+import { HTTPException } from 'hono/http-exception';
+import { UserRole } from 'oa-shared';
+import type { ActionFunctionArgs, MiddlewareFunction } from 'react-router';
+import { logger } from 'src/logger';
+import { requireRoleApi } from 'src/middleware/requireRole.server';
+import { sessionMiddleware } from 'src/middleware/session.server';
+import { createSupabaseServerClient } from 'src/repository/supabase.server';
+import { BannerServiceServer } from 'src/services/bannerService.server';
+import { methodNotAllowedError, validationError } from 'src/utils/httpException';
+
+export const middleware: MiddlewareFunction<Response>[] = [
+  sessionMiddleware,
+  requireRoleApi(UserRole.ADMIN),
+];
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { client, headers } = createSupabaseServerClient(request);
+
+  try {
+    if (request.method !== 'POST') {
+      throw methodNotAllowedError();
+    }
+
+    const body = await request.json();
+    const text = (body.text as string)?.trim();
+
+    if (!text) {
+      throw validationError('Text is required', 'text');
+    }
+
+    const banner = await new BannerServiceServer(client).create({
+      text,
+      url: (body.url as string)?.trim() || null,
+    });
+
+    return Response.json(banner, { headers, status: 201 });
+  } catch (error) {
+    if (error instanceof HTTPException) {
+      return error.getResponse();
+    }
+
+    logger.error('Error creating banner:', error);
+    return Response.json({ error: 'Error creating banner' }, { status: 500, headers });
+  }
+};

--- a/src/routes/api.banner.ts
+++ b/src/routes/api.banner.ts
@@ -1,16 +1,14 @@
-import Keyv from 'keyv';
 import type { DBBanner } from 'oa-shared';
 import { Banner } from 'oa-shared';
 import { data, type LoaderFunctionArgs } from 'react-router';
 import { isProductionEnvironment } from 'src/config/config';
 import { createSupabaseServerClient } from 'src/repository/supabase.server';
-
-const cache = new Keyv<Banner[]>({ ttl: 600000 }); // ttl: 10 minutes
+import { bannerCache } from 'src/services/bannerService.server';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { client, headers } = createSupabaseServerClient(request);
 
-  const cachedBanner = await cache.get('banner');
+  const cachedBanner = await bannerCache.get('banner');
 
   if (cachedBanner && isProductionEnvironment()) {
     return data(cachedBanner, { headers, status: 200 });
@@ -23,7 +21,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     banner = Banner.fromDB(bannerData[0] as DBBanner);
   }
 
-  cache.set('banner', banner);
+  bannerCache.set('banner', banner);
 
   return data(banner, { headers, status: 200 });
 }

--- a/src/services/bannerService.server.test.ts
+++ b/src/services/bannerService.server.test.ts
@@ -1,0 +1,79 @@
+import { bannerCache, BannerServiceServer } from 'src/services/bannerService.server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const single = vi.fn();
+const query: any = {
+  insert: vi.fn(() => query),
+  update: vi.fn(() => query),
+  delete: vi.fn(() => query),
+  eq: vi.fn(() => query),
+  select: vi.fn(() => query),
+  single,
+};
+const mockClient: any = { from: vi.fn(() => query) };
+
+const dbBanner = {
+  id: 3,
+  created_at: '2026-01-01T00:00:00.000Z',
+  modified_at: null,
+  text: 'Hello',
+  url: 'https://example.com',
+};
+
+describe('BannerServiceServer', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await bannerCache.set('banner', { text: 'stale' } as any);
+  });
+
+  it('creates a banner and clears the cache', async () => {
+    single.mockResolvedValue({ data: dbBanner, error: null });
+
+    const banner = await new BannerServiceServer(mockClient).create({
+      text: 'Hello',
+      url: 'https://example.com',
+    });
+
+    expect(mockClient.from).toHaveBeenCalledWith('banners');
+    expect(query.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Hello', url: 'https://example.com' }),
+    );
+    expect(banner.id).toBe(3);
+    expect(banner.text).toBe('Hello');
+    expect(await bannerCache.get('banner')).toBeUndefined();
+  });
+
+  it('updates a banner by id and clears the cache', async () => {
+    single.mockResolvedValue({ data: { ...dbBanner, text: 'Updated' }, error: null });
+
+    const banner = await new BannerServiceServer(mockClient).update(3, {
+      text: 'Updated',
+      url: null,
+    });
+
+    expect(query.update).toHaveBeenCalledWith({ text: 'Updated', url: null });
+    expect(query.eq).toHaveBeenCalledWith('id', 3);
+    expect(banner.text).toBe('Updated');
+    expect(await bannerCache.get('banner')).toBeUndefined();
+  });
+
+  it('deletes a banner by id and clears the cache', async () => {
+    query.eq.mockResolvedValueOnce({ error: null });
+
+    await new BannerServiceServer(mockClient).delete(3);
+
+    expect(query.delete).toHaveBeenCalled();
+    expect(query.eq).toHaveBeenCalledWith('id', 3);
+    expect(await bannerCache.get('banner')).toBeUndefined();
+  });
+
+  it('throws and keeps the cache when the update fails', async () => {
+    const error = new Error('boom');
+    single.mockResolvedValue({ data: null, error });
+
+    await expect(
+      new BannerServiceServer(mockClient).update(3, { text: 'Updated', url: null }),
+    ).rejects.toBe(error);
+    expect(await bannerCache.get('banner')).toEqual({ text: 'stale' });
+  });
+});

--- a/src/services/bannerService.server.ts
+++ b/src/services/bannerService.server.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import Keyv from 'keyv';
+import type { DBBanner } from 'oa-shared';
+import { Banner } from 'oa-shared';
+
+export const bannerCache = new Keyv<Banner>({ ttl: 86400000 }); // ttl: 24 hours
+
+export interface BannerInput {
+  text: string;
+  url: string | null;
+}
+
+export class BannerServiceServer {
+  constructor(private client: SupabaseClient) {}
+
+  async create(data: BannerInput) {
+    const result = await this.client
+      .from('banners')
+      .insert({
+        text: data.text,
+        url: data.url,
+        tenant_id: process.env.TENANT_ID,
+      })
+      .select()
+      .single();
+
+    if (result.error || !result.data) {
+      throw result.error;
+    }
+
+    await bannerCache.delete('banner');
+
+    return Banner.fromDB(result.data as DBBanner);
+  }
+
+  async update(id: number, data: BannerInput) {
+    const result = await this.client
+      .from('banners')
+      .update({
+        text: data.text,
+        url: data.url,
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (result.error || !result.data) {
+      throw result.error;
+    }
+
+    await bannerCache.delete('banner');
+
+    return Banner.fromDB(result.data as DBBanner);
+  }
+
+  async delete(id: number) {
+    const result = await this.client.from('banners').delete().eq('id', id);
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    await bannerCache.delete('banner');
+  }
+}


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [ ] 🐛 Bugfix — fixes incorrect behavior without changing functionality
- [x] ✨ Feature — adds new functionality
- [ ] ♻️ Refactoring — improves code structure with no functional changes
- [ ] ⚡️ Performance — improves speed, memory, or efficiency
- [ ] 🧪 Tests — adds or updates tests only
- [ ] 🔧 Tools / CI — changes to build, deploy, or developer tooling
- [ ] 📝 Documentation — updates docs, comments, or READMEs
- [ ] 📦 Dependencies — upgrades, downgrades, or removes packages
- [ ] 🔖 Other:

## What is the new behavior?

Adds a Banner page to the admin panel so admins can manage the site banner without Retool.

- New "Banner" entry in the admin sidebar, at `/admin/banners`
- Since only one banner is shown on the site, the page opens the form directly (text + optional URL) instead of a list
- Create when there is no banner yet, Save when editing, and a Delete button with a confirmation dialog
- Blank text shows a validation message and nothing is saved; the same check runs server-side
- Endpoints are admin-only via `requireRoleApi`, same as categories
- Saving or deleting clears the banner cache so the change shows up right away, and the cache TTL goes from 10 minutes to 24 hours

Structure follows `src/pages/Admin/Categories` and its API routes. The banner cache moved from `api.banner.ts` into `bannerService.server.ts` so the admin routes can invalidate it.

Covered by unit tests for the server service (create/update/delete clear the cache, a failed update keeps it). Typecheck and Biome are clean. I could not run a local Supabase on this machine, so the page has not been clicked through in a browser yet — happy to adjust anything the preview turns up.

## Does this PR introduce a DB Schema Change or Migration?

- [ ] Yes
- [x] No

## Git Issues

Closes #4843

## What happens next?

Thank you for the contribution! We will review it ASAP.

If you need more immediate feedback you can reach out to us on Discord in the [Community Platform `development` channel](https://discord.com/channels/586676777334865928/938781727017558018).
