### PR TITLE
fix: update remakes section copy (#4874)

### DIFF
--- a/src/pages/Library/Content/Page/Remakes/RemakesSection.test.tsx
+++ b/src/pages/Library/Content/Page/Remakes/RemakesSection.test.tsx
@@ -89,9 +89,9 @@ describe('RemakesSection', () => {
     });
 
     await waitFor(() => {
-      expect(wrapper.getByText('Remakes')).toBeInTheDocument();
+      expect(wrapper.getByText('Remakes (⭐️New!)')).toBeInTheDocument();
       expect(wrapper.getByText('Make this and share with us!')).toBeInTheDocument();
-      expect(wrapper.getByText('Try this tutorial and share with the community.')).toBeInTheDocument();
+      expect(wrapper.getByText("We'd love to see your version and learn from it.")).toBeInTheDocument();
       expect(wrapper.getByText('Upload your remake')).toBeInTheDocument();
       expect(wrapper.container.querySelector('[data-cy=remakes-fetch-error]')).not.toBeInTheDocument();
     });

--- a/src/pages/Library/Content/Page/Remakes/RemakesSection.tsx
+++ b/src/pages/Library/Content/Page/Remakes/RemakesSection.tsx
@@ -127,7 +127,7 @@ export const RemakesSection = ({ project, onRemakeCountChange }: IProps) => {
 
   const countLabel =
     remakes.length === 0
-      ? 'Remakes'
+      ? 'Remakes (⭐️New!)'
       : `${remakes.length} ${buildStatisticsLabel({
           stat: remakes.length,
           statUnit: 'remake',
@@ -144,7 +144,13 @@ export const RemakesSection = ({ project, onRemakeCountChange }: IProps) => {
         <Text data-cy="remakes-count" sx={{ fontFamily: 'title', fontSize: 4 }}>
           {countLabel}
         </Text>
-        <Button type="button" variant="primary" data-cy="upload-remake" onClick={openAddForm}>
+        <Button
+          type="button"
+          variant="primary"
+          data-cy="upload-remake"
+          onClick={openAddForm}
+          sx={{ flexShrink: 0 }}
+        >
           Upload your remake
         </Button>
       </Flex>
@@ -177,7 +183,7 @@ export const RemakesSection = ({ project, onRemakeCountChange }: IProps) => {
           <Flex sx={{ flexDirection: 'column', alignItems: 'center', gap: 1 }}>
             <Text sx={{ fontFamily: 'title', fontSize: 4 }}>Make this and share with us!</Text>
             <Text sx={{ fontFamily: 'title', fontSize: 2, color: 'darkGrey' }}>
-              Try this tutorial and share with the community.
+              We'd love to see your version and learn from it.
             </Text>
           </Flex>
         </Flex>


### PR DESCRIPTION
## PR Checklist

- [x] - Unit and/or e2e tests for the changes that have been added (for bug fixes / features)

## What kind of change does this PR introduce?

- [x] Other: UI copy update

## What is the new behavior?

Copy edits to the remakes section on library project pages, as requested by @davehakkens in #4874.

- The heading shown while a project has no remakes reads "Remakes (New!)" with the star emoji in front of "New!". The star is a literal character in the text, matching Dave's mockup on the issue. The counted heading ("53 remakes") is unchanged, since the issue names the zero-count string and the mockup shows the empty state. Happy to add it there too if wanted.
- The empty-state subtitle reads "We'd love to see your version and learn from it." The "Make this and share with us!" line stays.
- The wider heading squeezed the header row on small phones: at 375px the upload button shrank and its label wrapped out of its box. The button now keeps its width and the heading wraps instead. Measured in the running app: at 360 and 375 the heading is two lines ("Remakes" on the first line, the star and "(New!)" on the second), the button label is one line at 188px, no overflow and no horizontal scroll. From 412 up everything is on one line. Supported floor is 360px. I kept this on the one button rather than changing the shared Button, since that would touch every surface.
- The "0 remakes" counter in the stats bar is a count, not the section heading, so it is intentionally untouched.
- Tests: the two unit assertions for the strings are updated. The layout fix is verified by measurement rather than a test, as Cypress has no viewport dimension assertions in this repo and emoji glyph widths differ between browsers.

## Screenshots

| Desktop, empty state | Mobile at 375px |
| --- | --- |
| <img width="560" alt="Desktop: remakes empty state with the new heading and subtitle" src="https://github.com/user-attachments/assets/2a04cf1a-ba82-4d8c-a0b0-0b5e090fe1f1" /> | <img width="230" alt="Mobile at 375px: heading wrapped to two lines, upload button intact" src="https://github.com/user-attachments/assets/a0d24a8f-d272-40a3-9755-46c19e189398" /> |

## Does this PR introduce a DB Schema Change or Migration?

- [x] No

## Git Issues

Closes #4874

